### PR TITLE
sort the 'temp_frame_paths' in alphabetical order (ascending order) 

### DIFF
--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -165,6 +165,8 @@ def process_video() -> None:
 	extract_frames(facefusion.globals.target_path, fps)
 	# process frame
 	temp_frame_paths = get_temp_frame_paths(facefusion.globals.target_path)
+	temp_frame_paths = sorted(temp_frame_paths) 
+    
 	if temp_frame_paths:
 		for frame_processor_module in get_frame_processors_modules(facefusion.globals.frame_processors):
 			update_status(wording.get('processing'), frame_processor_module.NAME)


### PR DESCRIPTION
In order for the  'reference-frame-number' variable to obtain the correct reference face, temp_frame_paths needs to be ensured that it is ordered.