### PR TITLE
Mac torch support

### DIFF
--- a/facefusion/installer.py
+++ b/facefusion/installer.py
@@ -13,7 +13,7 @@ TORCH : Dict[str, str] =\
 	'cpu': 'https://download.pytorch.org/whl/cpu',
 	'cuda': 'https://download.pytorch.org/whl/cu118',
 	'rocm': 'https://download.pytorch.org/whl/rocm5.6',
-	'mac': ''
+	'default': ''
 }
 ONNXRUNTIMES : Dict[str, Tuple[str, str]] =\
 {

--- a/facefusion/installer.py
+++ b/facefusion/installer.py
@@ -12,7 +12,8 @@ TORCH : Dict[str, str] =\
 {
 	'cpu': 'https://download.pytorch.org/whl/cpu',
 	'cuda': 'https://download.pytorch.org/whl/cu118',
-	'rocm': 'https://download.pytorch.org/whl/rocm5.6'
+	'rocm': 'https://download.pytorch.org/whl/rocm5.6',
+	'mac': ''
 }
 ONNXRUNTIMES : Dict[str, Tuple[str, str]] =\
 {
@@ -62,7 +63,10 @@ def run(program : ArgumentParser) -> None:
 		onnxruntime = answers['onnxruntime']
 		onnxruntime_name, onnxruntime_version = ONNXRUNTIMES[onnxruntime]
 		subprocess.call([ 'pip', 'uninstall', 'torch', '-y' ])
-		subprocess.call([ 'pip', 'install', '-r', 'requirements.txt', '--extra-index-url', torch_url ])
+		if torch_url:
+			subprocess.call([ 'pip', 'install', '-r', 'requirements.txt', '--extra-index-url', torch_url ])
+		else:
+			subprocess.call([ 'pip', 'install', '-r', 'requirements.txt' ])
 		if onnxruntime != 'cpu':
 			subprocess.call([ 'pip', 'uninstall', 'onnxruntime', onnxruntime_name, '-y' ])
 		subprocess.call([ 'pip', 'install', onnxruntime_name + '==' + onnxruntime_version ])


### PR DESCRIPTION
The latest release breaks Mac support by only allowing `cpu`, `cuda`, and `rocm` options for the torch flag.

In case of mac, there is no need for `--extra-index-url` for installing torch. It's simply:

```
pip3 install torch
```

Basically the problem with the latest release is that while it can specify `--extra-index-url` for `cpu`, `cuda`, and `rocm`, there is no way to NOT specify any `--extra-index-url`, which is what is required for the mac install.

This PR adds new torch attribute `default`, which has an empty value. When the value is empty, the `--extra-index-url` flag is not included in the command.

Example installer commands for macs using the `--torch default` support:

```
# apple silicon
python install.py --onnxruntime coreml-silicon --torch default

# intel
python install.py --onnxruntime cpu --torch default
```