### PR TITLE
cli batch processing

### DIFF
--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -26,6 +26,7 @@ onnxruntime.set_default_logger_severity(3)
 warnings.filterwarnings('ignore', category = UserWarning, module = 'gradio')
 warnings.filterwarnings('ignore', category = UserWarning, module = 'torchvision')
 
+
 def get_args(mode : ArgumentsMode = 'all') -> ArgumentParser:
 	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position = 120), add_help = False)
 	if mode in ('batch-common'):
@@ -70,6 +71,7 @@ def get_args(mode : ArgumentsMode = 'all') -> ArgumentParser:
 		group_face_mask = program.add_argument_group('face mask')
 		group_face_mask.add_argument('--face-mask-blur', help = wording.get('face_mask_blur_help'), dest = 'face_mask_blur', type = float, default = 0.3, choices = facefusion.choices.face_mask_blur_range, metavar = create_metavar(facefusion.choices.face_mask_blur_range))
 		group_face_mask.add_argument('--face-mask-padding', help = wording.get('face_mask_padding_help'), dest = 'face_mask_padding', type = int, default = [ 0, 0, 0, 0 ], nargs = '+')
+	if mode in ('all', 'batch-task'):
 		# frame extraction
 		group_frame_extraction = program.add_argument_group('frame extraction')
 		group_frame_extraction.add_argument('--trim-frame-start', help = wording.get('trim_frame_start_help'), dest = 'trim_frame_start', type = int)

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -19,136 +19,179 @@ from facefusion import face_analyser, content_analyser, metadata, wording
 from facefusion.content_analyser import analyse_image, analyse_video
 from facefusion.processors.frame.core import get_frame_processors_modules, load_frame_processor_module
 from facefusion.utilities import is_image, is_video, detect_fps, compress_image, merge_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clear_temp, list_module_names, encode_execution_providers, decode_execution_providers, normalize_output_path, normalize_padding, create_metavar, update_status
+from facefusion.face_cache import clear_faces_cache
+from facefusion.typing import ArgumentsMode
 
 onnxruntime.set_default_logger_severity(3)
 warnings.filterwarnings('ignore', category = UserWarning, module = 'gradio')
 warnings.filterwarnings('ignore', category = UserWarning, module = 'torchvision')
 
+def get_args(mode : ArgumentsMode = 'all') -> ArgumentParser:
+	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position = 120), add_help = False)
+	if mode in ('batch-common'):
+		program.add_argument('--batch', help = wording.get('batch_help'), dest = 'batch_file_path', default = '')
+		program.add_argument('--batch-tasks-limit-before-release', help = wording.get('batch_release_resources_limit'), dest = 'batch_release_resources_limit', type = int, default = 0)
+	if mode in ('all', 'batch-task'):
+		# general
+		program.add_argument('-s', '--source', help = wording.get('source_help'), dest = 'source_path')
+		program.add_argument('-t', '--target', help = wording.get('target_help'), dest = 'target_path')
+		program.add_argument('-o', '--output', help = wording.get('output_help'), dest = 'output_path')
+	if mode not in ('batch-task'):
+		program.add_argument('-v', '--version', version = metadata.get('name') + ' ' + metadata.get('version'), action = 'version')
+		# misc
+		group_misc = program.add_argument_group('misc')
+		group_misc.add_argument('--skip-download', help = wording.get('skip_download_help'), dest = 'skip_download', action = 'store_true')
+		group_misc.add_argument('--headless', help = wording.get('headless_help'), dest = 'headless', action = 'store_true')
+	if mode not in ('batch-task'):
+		# execution
+		group_execution = program.add_argument_group('execution')
+		group_execution.add_argument('--execution-providers', help = wording.get('execution_providers_help'), dest = 'execution_providers', default = [ 'cpu' ], choices = encode_execution_providers(onnxruntime.get_available_providers()), nargs = '+')
+		group_execution.add_argument('--execution-thread-count', help = wording.get('execution_thread_count_help'), dest = 'execution_thread_count', type = int, default = 4, choices = facefusion.choices.execution_thread_count_range, metavar = create_metavar(facefusion.choices.execution_thread_count_range))
+		group_execution.add_argument('--execution-queue-count', help = wording.get('execution_queue_count_help'), dest = 'execution_queue_count', type = int, default = 1, choices = facefusion.choices.execution_queue_count_range, metavar = create_metavar(facefusion.choices.execution_queue_count_range))
+		group_execution.add_argument('--max-memory', help = wording.get('max_memory_help'), dest = 'max_memory', type = int, choices = facefusion.choices.max_memory_range, metavar = create_metavar(facefusion.choices.max_memory_range))
+	# face analyser
+	group_face_analyser = program.add_argument_group('face analyser')
+	if mode in ('all', 'batch-task'):
+		group_face_analyser.add_argument('--face-analyser-order', help = wording.get('face_analyser_order_help'), dest = 'face_analyser_order', default = 'left-right', choices = facefusion.choices.face_analyser_orders)
+		group_face_analyser.add_argument('--face-analyser-age', help = wording.get('face_analyser_age_help'), dest = 'face_analyser_age', choices = facefusion.choices.face_analyser_ages)
+		group_face_analyser.add_argument('--face-analyser-gender', help = wording.get('face_analyser_gender_help'), dest = 'face_analyser_gender', choices = facefusion.choices.face_analyser_genders)
+	if mode not in ('batch-task'):
+		group_face_analyser.add_argument('--face-detector-model', help = wording.get('face_detector_model_help'), dest = 'face_detector_model', default = 'retinaface', choices = facefusion.choices.face_detector_models)
+	if mode in ('all', 'batch-task'):
+		group_face_analyser.add_argument('--face-detector-size', help = wording.get('face_detector_size_help'), dest = 'face_detector_size', default = '640x640', choices = facefusion.choices.face_detector_sizes)
+		group_face_analyser.add_argument('--face-detector-score', help = wording.get('face_detector_score_help'), dest = 'face_detector_score', type = float, default = 0.5, choices = facefusion.choices.face_detector_score_range, metavar = create_metavar(facefusion.choices.face_detector_score_range))
+		# face selector
+		group_face_selector = program.add_argument_group('face selector')
+		group_face_selector.add_argument('--face-selector-mode', help = wording.get('face_selector_mode_help'), dest = 'face_selector_mode', default = 'reference', choices = facefusion.choices.face_selector_modes)
+		group_face_selector.add_argument('--reference-face-position', help = wording.get('reference_face_position_help'), dest = 'reference_face_position', type = int, default = 0)
+		group_face_selector.add_argument('--reference-face-distance', help = wording.get('reference_face_distance_help'), dest = 'reference_face_distance', type = float, default = 0.6, choices = facefusion.choices.reference_face_distance_range, metavar = create_metavar(facefusion.choices.reference_face_distance_range))
+		group_face_selector.add_argument('--reference-frame-number', help = wording.get('reference_frame_number_help'), dest = 'reference_frame_number', type = int, default = 0)
+		# face mask
+		group_face_mask = program.add_argument_group('face mask')
+		group_face_mask.add_argument('--face-mask-blur', help = wording.get('face_mask_blur_help'), dest = 'face_mask_blur', type = float, default = 0.3, choices = facefusion.choices.face_mask_blur_range, metavar = create_metavar(facefusion.choices.face_mask_blur_range))
+		group_face_mask.add_argument('--face-mask-padding', help = wording.get('face_mask_padding_help'), dest = 'face_mask_padding', type = int, default = [ 0, 0, 0, 0 ], nargs = '+')
+		# frame extraction
+		group_frame_extraction = program.add_argument_group('frame extraction')
+		group_frame_extraction.add_argument('--trim-frame-start', help = wording.get('trim_frame_start_help'), dest = 'trim_frame_start', type = int)
+		group_frame_extraction.add_argument('--trim-frame-end', help = wording.get('trim_frame_end_help'), dest = 'trim_frame_end', type = int)
+		group_frame_extraction.add_argument('--temp-frame-format', help = wording.get('temp_frame_format_help'), dest = 'temp_frame_format', default = 'jpg', choices = facefusion.choices.temp_frame_formats)
+		group_frame_extraction.add_argument('--temp-frame-quality', help = wording.get('temp_frame_quality_help'), dest = 'temp_frame_quality', type = int, default = 100, choices = facefusion.choices.temp_frame_quality_range, metavar = create_metavar(facefusion.choices.temp_frame_quality_range))
+		# store no temp in batch mode (i.e. mode == 'batch-task' or mode == 'batch-common')
+		if mode in ('all'):
+			group_frame_extraction.add_argument('--keep-temp', help = wording.get('keep_temp_help'), dest = 'keep_temp', action = 'store_true')
+	if mode in ('all', 'batch-task'):
+		# output creation
+		group_output_creation = program.add_argument_group('output creation')
+		group_output_creation.add_argument('--output-image-quality', help = wording.get('output_image_quality_help'), dest = 'output_image_quality', type = int, default = 80, choices = facefusion.choices.output_image_quality_range, metavar = create_metavar(facefusion.choices.output_image_quality_range))
+		group_output_creation.add_argument('--output-video-encoder', help = wording.get('output_video_encoder_help'), dest = 'output_video_encoder', default = 'libx264', choices = facefusion.choices.output_video_encoders)
+		group_output_creation.add_argument('--output-video-quality', help = wording.get('output_video_quality_help'), dest = 'output_video_quality', type = int, default = 80, choices = facefusion.choices.output_video_quality_range, metavar = create_metavar(facefusion.choices.output_video_quality_range))
+		group_output_creation.add_argument('--keep-fps', help = wording.get('keep_fps_help'), dest = 'keep_fps', action = 'store_true')
+		group_output_creation.add_argument('--skip-audio', help = wording.get('skip_audio_help'), dest = 'skip_audio', action = 'store_true')
+	if mode not in ('batch-task'):
+		# frame processors
+		available_frame_processors = list_module_names('facefusion/processors/frame/modules')
+		program = ArgumentParser(parents = [ program ], formatter_class = program.formatter_class, add_help = True)
+		group_frame_processors = program.add_argument_group('frame processors')
+		group_frame_processors.add_argument('--frame-processors', help = wording.get('frame_processors_help').format(choices = ', '.join(available_frame_processors)), dest = 'frame_processors', default = [ 'face_swapper' ], nargs = '+')
+		for frame_processor in available_frame_processors:
+			frame_processor_module = load_frame_processor_module(frame_processor)
+			frame_processor_module.register_args(group_frame_processors)
+	
+	return program
+
+
+def batch_cli() -> None:
+	facefusion.globals.batch_running = True
+	cli()
+
 
 def cli() -> None:
 	signal.signal(signal.SIGINT, lambda signal_number, frame: destroy())
-	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position = 120), add_help = False)
-	# general
-	program.add_argument('-s', '--source', help = wording.get('source_help'), dest = 'source_path')
-	program.add_argument('-t', '--target', help = wording.get('target_help'), dest = 'target_path')
-	program.add_argument('-o', '--output', help = wording.get('output_help'), dest = 'output_path')
-	program.add_argument('-v', '--version', version = metadata.get('name') + ' ' + metadata.get('version'), action = 'version')
-	# misc
-	group_misc = program.add_argument_group('misc')
-	group_misc.add_argument('--skip-download', help = wording.get('skip_download_help'), dest = 'skip_download', action = 'store_true')
-	group_misc.add_argument('--headless', help = wording.get('headless_help'), dest = 'headless', action = 'store_true')
-	# execution
-	group_execution = program.add_argument_group('execution')
-	group_execution.add_argument('--execution-providers', help = wording.get('execution_providers_help'), dest = 'execution_providers', default = [ 'cpu' ], choices = encode_execution_providers(onnxruntime.get_available_providers()), nargs = '+')
-	group_execution.add_argument('--execution-thread-count', help = wording.get('execution_thread_count_help'), dest = 'execution_thread_count', type = int, default = 4, choices = facefusion.choices.execution_thread_count_range, metavar = create_metavar(facefusion.choices.execution_thread_count_range))
-	group_execution.add_argument('--execution-queue-count', help = wording.get('execution_queue_count_help'), dest = 'execution_queue_count', type = int, default = 1, choices = facefusion.choices.execution_queue_count_range, metavar = create_metavar(facefusion.choices.execution_queue_count_range))
-	group_execution.add_argument('--max-memory', help = wording.get('max_memory_help'), dest = 'max_memory', type = int, choices = facefusion.choices.max_memory_range, metavar = create_metavar(facefusion.choices.max_memory_range))
-	# face analyser
-	group_face_analyser = program.add_argument_group('face analyser')
-	group_face_analyser.add_argument('--face-analyser-order', help = wording.get('face_analyser_order_help'), dest = 'face_analyser_order', default = 'left-right', choices = facefusion.choices.face_analyser_orders)
-	group_face_analyser.add_argument('--face-analyser-age', help = wording.get('face_analyser_age_help'), dest = 'face_analyser_age', choices = facefusion.choices.face_analyser_ages)
-	group_face_analyser.add_argument('--face-analyser-gender', help = wording.get('face_analyser_gender_help'), dest = 'face_analyser_gender', choices = facefusion.choices.face_analyser_genders)
-	group_face_analyser.add_argument('--face-detector-model', help = wording.get('face_detector_model_help'), dest = 'face_detector_model', default = 'retinaface', choices = facefusion.choices.face_detector_models)
-	group_face_analyser.add_argument('--face-detector-size', help = wording.get('face_detector_size_help'), dest = 'face_detector_size', default = '640x640', choices = facefusion.choices.face_detector_sizes)
-	group_face_analyser.add_argument('--face-detector-score', help = wording.get('face_detector_score_help'), dest = 'face_detector_score', type = float, default = 0.5, choices = facefusion.choices.face_detector_score_range, metavar = create_metavar(facefusion.choices.face_detector_score_range))
-	# face selector
-	group_face_selector = program.add_argument_group('face selector')
-	group_face_selector.add_argument('--face-selector-mode', help = wording.get('face_selector_mode_help'), dest = 'face_selector_mode', default = 'reference', choices = facefusion.choices.face_selector_modes)
-	group_face_selector.add_argument('--reference-face-position', help = wording.get('reference_face_position_help'), dest = 'reference_face_position', type = int, default = 0)
-	group_face_selector.add_argument('--reference-face-distance', help = wording.get('reference_face_distance_help'), dest = 'reference_face_distance', type = float, default = 0.6, choices = facefusion.choices.reference_face_distance_range, metavar = create_metavar(facefusion.choices.reference_face_distance_range))
-	group_face_selector.add_argument('--reference-frame-number', help = wording.get('reference_frame_number_help'), dest = 'reference_frame_number', type = int, default = 0)
-	# face mask
-	group_face_mask = program.add_argument_group('face mask')
-	group_face_mask.add_argument('--face-mask-blur', help = wording.get('face_mask_blur_help'), dest = 'face_mask_blur', type = float, default = 0.3, choices = facefusion.choices.face_mask_blur_range, metavar = create_metavar(facefusion.choices.face_mask_blur_range))
-	group_face_mask.add_argument('--face-mask-padding', help = wording.get('face_mask_padding_help'), dest = 'face_mask_padding', type = int, default = [ 0, 0, 0, 0 ], nargs = '+')
-	# frame extraction
-	group_frame_extraction = program.add_argument_group('frame extraction')
-	group_frame_extraction.add_argument('--trim-frame-start', help = wording.get('trim_frame_start_help'), dest = 'trim_frame_start', type = int)
-	group_frame_extraction.add_argument('--trim-frame-end', help = wording.get('trim_frame_end_help'), dest = 'trim_frame_end', type = int)
-	group_frame_extraction.add_argument('--temp-frame-format', help = wording.get('temp_frame_format_help'), dest = 'temp_frame_format', default = 'jpg', choices = facefusion.choices.temp_frame_formats)
-	group_frame_extraction.add_argument('--temp-frame-quality', help = wording.get('temp_frame_quality_help'), dest = 'temp_frame_quality', type = int, default = 100, choices = facefusion.choices.temp_frame_quality_range, metavar = create_metavar(facefusion.choices.temp_frame_quality_range))
-	group_frame_extraction.add_argument('--keep-temp', help = wording.get('keep_temp_help'), dest = 'keep_temp', action = 'store_true')
-	# output creation
-	group_output_creation = program.add_argument_group('output creation')
-	group_output_creation.add_argument('--output-image-quality', help = wording.get('output_image_quality_help'), dest = 'output_image_quality', type = int, default = 80, choices = facefusion.choices.output_image_quality_range, metavar = create_metavar(facefusion.choices.output_image_quality_range))
-	group_output_creation.add_argument('--output-video-encoder', help = wording.get('output_video_encoder_help'), dest = 'output_video_encoder', default = 'libx264', choices = facefusion.choices.output_video_encoders)
-	group_output_creation.add_argument('--output-video-quality', help = wording.get('output_video_quality_help'), dest = 'output_video_quality', type = int, default = 80, choices = facefusion.choices.output_video_quality_range, metavar = create_metavar(facefusion.choices.output_video_quality_range))
-	group_output_creation.add_argument('--keep-fps', help = wording.get('keep_fps_help'), dest = 'keep_fps', action = 'store_true')
-	group_output_creation.add_argument('--skip-audio', help = wording.get('skip_audio_help'), dest = 'skip_audio', action = 'store_true')
-	# frame processors
-	available_frame_processors = list_module_names('facefusion/processors/frame/modules')
-	program = ArgumentParser(parents = [ program ], formatter_class = program.formatter_class, add_help = True)
-	group_frame_processors = program.add_argument_group('frame processors')
-	group_frame_processors.add_argument('--frame-processors', help = wording.get('frame_processors_help').format(choices = ', '.join(available_frame_processors)), dest = 'frame_processors', default = [ 'face_swapper' ], nargs = '+')
-	for frame_processor in available_frame_processors:
-		frame_processor_module = load_frame_processor_module(frame_processor)
-		frame_processor_module.register_args(group_frame_processors)
-	# uis
-	group_uis = program.add_argument_group('uis')
-	group_uis.add_argument('--ui-layouts', help = wording.get('ui_layouts_help').format(choices = ', '.join(list_module_names('facefusion/uis/layouts'))), dest = 'ui_layouts', default = [ 'default' ], nargs = '+')
+	if not facefusion.globals.batch_running:
+		program = get_args('all')
+		# uis
+		group_uis = program.add_argument_group('uis')
+		group_uis.add_argument('--ui-layouts', help = wording.get('ui_layouts_help').format(choices = ', '.join(list_module_names('facefusion/uis/layouts'))), dest = 'ui_layouts', default = [ 'default' ], nargs = '+')
+	else:
+		program = get_args('batch-common')
 	run(program)
 
 
-def apply_args(program : ArgumentParser) -> None:
-	args = program.parse_args()
-	# general
-	facefusion.globals.source_path = args.source_path
-	facefusion.globals.target_path = args.target_path
-	facefusion.globals.output_path = normalize_output_path(facefusion.globals.source_path, facefusion.globals.target_path, args.output_path)
-	# misc
-	facefusion.globals.skip_download = args.skip_download
-	facefusion.globals.headless = args.headless
-	# execution
-	facefusion.globals.execution_providers = decode_execution_providers(args.execution_providers)
-	facefusion.globals.execution_thread_count = args.execution_thread_count
-	facefusion.globals.execution_queue_count = args.execution_queue_count
-	facefusion.globals.max_memory = args.max_memory
+def apply_args(program : ArgumentParser, mode : ArgumentsMode = 'all', raw_args = None) -> None:
+	args = program.parse_args(args=raw_args)
+	if mode in ('batch-common'):
+		facefusion.globals.batch_file_path = args.batch_file_path
+		facefusion.globals.batch_release_resources_limit = args.batch_release_resources_limit
+	if mode in ('all', 'batch-task'):
+		# general
+		facefusion.globals.source_path = args.source_path
+		facefusion.globals.target_path = args.target_path
+		facefusion.globals.output_path = normalize_output_path(facefusion.globals.source_path, facefusion.globals.target_path, args.output_path)
+	if mode not in ('batch-task'):
+		# misc
+		facefusion.globals.skip_download = args.skip_download
+		facefusion.globals.headless = args.headless if mode not in ('batch-task', 'batch-common') else True
+		# execution
+		facefusion.globals.execution_providers = decode_execution_providers(args.execution_providers)
+		facefusion.globals.execution_thread_count = args.execution_thread_count
+		facefusion.globals.execution_queue_count = args.execution_queue_count
+		facefusion.globals.max_memory = args.max_memory
 	# face analyser
-	facefusion.globals.face_analyser_order = args.face_analyser_order
-	facefusion.globals.face_analyser_age = args.face_analyser_age
-	facefusion.globals.face_analyser_gender = args.face_analyser_gender
-	facefusion.globals.face_detector_model = args.face_detector_model
-	facefusion.globals.face_detector_size = args.face_detector_size
-	facefusion.globals.face_detector_score = args.face_detector_score
-	# face selector
-	facefusion.globals.face_selector_mode = args.face_selector_mode
-	facefusion.globals.reference_face_position = args.reference_face_position
-	facefusion.globals.reference_face_distance = args.reference_face_distance
-	facefusion.globals.reference_frame_number = args.reference_frame_number
-	# face mask
-	facefusion.globals.face_mask_blur = args.face_mask_blur
-	facefusion.globals.face_mask_padding = normalize_padding(args.face_mask_padding)
-	# frame extraction
-	facefusion.globals.trim_frame_start = args.trim_frame_start
-	facefusion.globals.trim_frame_end = args.trim_frame_end
-	facefusion.globals.temp_frame_format = args.temp_frame_format
-	facefusion.globals.temp_frame_quality = args.temp_frame_quality
-	facefusion.globals.keep_temp = args.keep_temp
-	# output creation
-	facefusion.globals.output_image_quality = args.output_image_quality
-	facefusion.globals.output_video_encoder = args.output_video_encoder
-	facefusion.globals.output_video_quality = args.output_video_quality
-	facefusion.globals.keep_fps = args.keep_fps
-	facefusion.globals.skip_audio = args.skip_audio
-	# frame processors
-	available_frame_processors = list_module_names('facefusion/processors/frame/modules')
-	facefusion.globals.frame_processors = args.frame_processors
-	for frame_processor in available_frame_processors:
-		frame_processor_module = load_frame_processor_module(frame_processor)
-		frame_processor_module.apply_args(program)
-	# uis
-	facefusion.globals.ui_layouts = args.ui_layouts
+	if mode in ('all', 'batch-task'):
+		facefusion.globals.face_analyser_order = args.face_analyser_order
+		facefusion.globals.face_analyser_age = args.face_analyser_age
+		facefusion.globals.face_analyser_gender = args.face_analyser_gender
+	if mode not in ('batch-task'):
+		facefusion.globals.face_detector_model = args.face_detector_model
+	if mode in ('all', 'batch-task'):
+		facefusion.globals.face_detector_size = args.face_detector_size
+		facefusion.globals.face_detector_score = args.face_detector_score
+		# face selector
+		facefusion.globals.face_selector_mode = args.face_selector_mode
+		facefusion.globals.reference_face_position = args.reference_face_position
+		facefusion.globals.reference_face_distance = args.reference_face_distance
+		facefusion.globals.reference_frame_number = args.reference_frame_number
+		# face mask
+		facefusion.globals.face_mask_blur = args.face_mask_blur
+		facefusion.globals.face_mask_padding = normalize_padding(args.face_mask_padding)
+		# frame extraction
+		facefusion.globals.trim_frame_start = args.trim_frame_start
+		facefusion.globals.trim_frame_end = args.trim_frame_end
+		facefusion.globals.temp_frame_format = args.temp_frame_format
+		facefusion.globals.temp_frame_quality = args.temp_frame_quality
+	# store no temp in batch mode (i.e. mode == 'batch-task' or mode == 'batch-common')
+	facefusion.globals.keep_temp = args.keep_temp if mode not in ('batch-task', 'batch-common') else False
+	if mode in ('all', 'batch-task'):
+		# output creation
+		facefusion.globals.output_image_quality = args.output_image_quality
+		facefusion.globals.output_video_encoder = args.output_video_encoder
+		facefusion.globals.output_video_quality = args.output_video_quality
+		facefusion.globals.keep_fps = args.keep_fps
+		facefusion.globals.skip_audio = args.skip_audio
+	if mode not in ('batch-task'):
+		# frame processors
+		available_frame_processors = list_module_names('facefusion/processors/frame/modules')
+		facefusion.globals.frame_processors = args.frame_processors
+		for frame_processor in available_frame_processors:
+			frame_processor_module = load_frame_processor_module(frame_processor)
+			frame_processor_module.apply_args(program)
+	if mode in ('all'):
+		# uis
+		facefusion.globals.ui_layouts = args.ui_layouts
 
 
 def run(program : ArgumentParser) -> None:
-	apply_args(program)
+	mode = 'all' if not facefusion.globals.batch_running else 'batch-common'
+	apply_args(program, mode)
 	limit_resources()
 	if not pre_check() or not content_analyser.pre_check() or not face_analyser.pre_check():
 		return
 	for frame_processor_module in get_frame_processors_modules(facefusion.globals.frame_processors):
 		if not frame_processor_module.pre_check():
 			return
-	if facefusion.globals.headless:
+	if facefusion.globals.batch_running:
+		batch_process()
+	elif facefusion.globals.headless:
 		conditional_process()
 	else:
 		import facefusion.uis.core as ui
@@ -189,6 +232,42 @@ def pre_check() -> bool:
 	return True
 
 
+BATCH_WARM_POST_PROCESS = False
+
+
+def batch_post_process(module) -> None:
+	global BATCH_WARM_POST_PROCESS
+	module.post_process(BATCH_WARM_POST_PROCESS)
+
+
+def batch_process() -> None:
+	global BATCH_WARM_POST_PROCESS
+	if not os.path.isfile(facefusion.globals.batch_file_path):
+		update_status(wording.get('batch_file_bad_path'))
+		return
+	with open(facefusion.globals.batch_file_path, 'r') as f:
+		batch_lines = list(line.rstrip() for line in f)
+	if len(list(filter(None, batch_lines))) == 0:
+		update_status(wording.get('batch_file_empty'))
+		return
+	program = get_args('batch-task')
+	tasks_counter = facefusion.globals.batch_release_resources_limit
+	for i, args_line in enumerate(batch_lines):
+		if args_line == '':
+			continue
+		update_status(wording.get('batch_line_started').format(line_id = i))
+		apply_args(program, 'batch-task', args_line.split())
+		tasks_counter -= 1
+		if tasks_counter <= 0 or i >= len(batch_lines) - 1:
+			tasks_counter = facefusion.globals.batch_release_resources_limit
+			BATCH_WARM_POST_PROCESS = False
+		else:
+			BATCH_WARM_POST_PROCESS = True
+		conditional_process()
+		clear_faces_cache()
+	update_status(wording.get('batch_processing_ended'))
+
+
 def conditional_process() -> None:
 	conditional_set_face_reference()
 	for frame_processor_module in get_frame_processors_modules(facefusion.globals.frame_processors):
@@ -218,7 +297,10 @@ def process_image() -> None:
 	for frame_processor_module in get_frame_processors_modules(facefusion.globals.frame_processors):
 		update_status(wording.get('processing'), frame_processor_module.NAME)
 		frame_processor_module.process_image(facefusion.globals.source_path, facefusion.globals.output_path, facefusion.globals.output_path)
-		frame_processor_module.post_process()
+		if not facefusion.globals.batch_running:
+			frame_processor_module.post_process()
+		else:
+			batch_post_process(frame_processor_module)
 	# compress image
 	update_status(wording.get('compressing_image'))
 	if not compress_image(facefusion.globals.output_path):
@@ -246,7 +328,10 @@ def process_video() -> None:
 		for frame_processor_module in get_frame_processors_modules(facefusion.globals.frame_processors):
 			update_status(wording.get('processing'), frame_processor_module.NAME)
 			frame_processor_module.process_video(facefusion.globals.source_path, temp_frame_paths)
-			frame_processor_module.post_process()
+			if not facefusion.globals.batch_running:
+				frame_processor_module.post_process()
+			else:
+				batch_post_process(frame_processor_module)
 	else:
 		update_status(wording.get('temp_frames_not_found'))
 		return

--- a/facefusion/globals.py
+++ b/facefusion/globals.py
@@ -46,3 +46,7 @@ skip_audio : Optional[bool] = None
 frame_processors : List[str] = []
 # uis
 ui_layouts : List[str] = []
+# batch mode
+batch_running = False
+batch_file_path = None
+batch_release_resources_limit = 0

--- a/facefusion/processors/frame/modules/face_debugger.py
+++ b/facefusion/processors/frame/modules/face_debugger.py
@@ -50,10 +50,11 @@ def pre_process(mode : ProcessMode) -> bool:
 	return True
 
 
-def post_process() -> None:
-	clear_frame_processor()
-	clear_face_analyser()
-	clear_content_analyser()
+def post_process(is_warm : bool = False) -> None:
+	if not is_warm:
+		clear_frame_processor()
+		clear_face_analyser()
+		clear_content_analyser()
 
 
 def debug_face(source_face : Face, target_face : Face, temp_frame : Frame) -> Frame:

--- a/facefusion/processors/frame/modules/face_enhancer.py
+++ b/facefusion/processors/frame/modules/face_enhancer.py
@@ -146,10 +146,11 @@ def pre_process(mode : ProcessMode) -> bool:
 	return True
 
 
-def post_process() -> None:
-	clear_frame_processor()
-	clear_face_analyser()
-	clear_content_analyser()
+def post_process(is_warm : bool = False) -> None:
+	if not is_warm:
+		clear_frame_processor()
+		clear_face_analyser()
+		clear_content_analyser()
 	read_static_image.cache_clear()
 
 

--- a/facefusion/processors/frame/modules/face_swapper.py
+++ b/facefusion/processors/frame/modules/face_swapper.py
@@ -176,11 +176,12 @@ def pre_process(mode : ProcessMode) -> bool:
 	return True
 
 
-def post_process() -> None:
-	clear_frame_processor()
-	clear_model_matrix()
-	clear_face_analyser()
-	clear_content_analyser()
+def post_process(is_warm : bool = False) -> None:
+	if not is_warm:
+		clear_frame_processor()
+		clear_model_matrix()
+		clear_face_analyser()
+		clear_content_analyser()
 	read_static_image.cache_clear()
 
 

--- a/facefusion/processors/frame/modules/frame_enhancer.py
+++ b/facefusion/processors/frame/modules/frame_enhancer.py
@@ -121,10 +121,11 @@ def pre_process(mode : ProcessMode) -> bool:
 	return True
 
 
-def post_process() -> None:
-	clear_frame_processor()
-	clear_face_analyser()
-	clear_content_analyser()
+def post_process(is_warm : bool = False) -> None:
+	if not is_warm:
+		clear_frame_processor()
+		clear_face_analyser()
+		clear_content_analyser()
 	read_static_image.cache_clear()
 
 

--- a/facefusion/typing.py
+++ b/facefusion/typing.py
@@ -39,3 +39,5 @@ OptionsWithModel = TypedDict('OptionsWithModel',
 {
 	'model' : ModelValue
 })
+
+ArgumentsMode = Literal['all', 'batch-common', 'batch-task']

--- a/facefusion/wording.py
+++ b/facefusion/wording.py
@@ -121,7 +121,13 @@ WORDING =\
 	'comma': ',',
 	'colon': ':',
 	'question_mark': '?',
-	'exclamation_mark': '!'
+	'exclamation_mark': '!',
+	'batch_help': 'select a batch file',
+	'batch_release_resources_limit': 'specifies N counter that will be used to release a frame processor resources after each N tasks',
+	'batch_file_bad_path': 'Batch file not found',
+	'batch_file_empty': 'Batch file contain no instructions',
+	'batch_line_started': 'Batch line {line_id} processing started',
+	'batch_processing_ended': 'Batch processing ended',
 }
 
 

--- a/run-batch.py
+++ b/run-batch.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from facefusion import core
+
+if __name__ == '__main__':
+    core.batch_cli()


### PR DESCRIPTION
A batch should be called with a new script `run-batch.py` like
> python run-batch.py --batch test.txt --frame-processors face_swapper face_enhancer --batch-tasks-limit-before-release 5

`--batch-tasks-limit-before-release` specifies how many tasks will be done with warm `post_process` of frame processors before full `post_process`.

A batch file consists of command line arguments for image / video processing, one task per line.
Example of a batch file content:

> -s face1.jpg -t some-target.jpg -o . --face-mask-padding 0 0 35 0
-s face1.jpg -t another-target.jpg -o . --face-mask-padding 10 10 55 10
-s face2.png -t some-target.jpg -o . --face-selector-mode one --face-analyser-order right-left --reference-face-position 0

This way all command line arguments are divided into two parts.
Part of them are arguments only for `run-batch.py`
> --version
--batch
--batch-tasks-limit-before-release
--skip-download
--headless (that is anyway set to True for the batch mode)
--face-detector-model
--execution-providers
--execution-thread-count
--execution-queue-count
--max-memory
--frame-processors (and their command line argument)

I.e. these paremeters are common for all batch tasks.
All another arguments are allowed only in the batch file to specify settings per task.

`--keep-temp` is turned off at all as nonmeaning in batch mode.

`run.py` continue to work as before with all command line arguments.