### PR TITLE
Added `*.pyc` files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .assets
 .idea
 .vscode
+*.pyc


### PR DESCRIPTION
I noticed upon first run of FaceFusion that there are a ton of `.pyc` files generated.  In order to keep these from accidentally being committed to the repo I've added a rule to the `gitignore` file for them.