### PR TITLE
Fix ConfigParser encoding

### DIFF
--- a/facefusion/config.py
+++ b/facefusion/config.py
@@ -12,7 +12,7 @@ def get_config() -> ConfigParser:
 	if CONFIG is None:
 		config_path = resolve_relative_path('../facefusion.ini')
 		CONFIG = ConfigParser()
-		CONFIG.read(config_path)
+		CONFIG.read(config_path, encoding='utf-8')
 	return CONFIG
 
 


### PR DESCRIPTION
facefusion.ini is UTF8 encoded but config.py doesn't specify encoding which results in corrupted entries when non english characters are used. I didn't see any side effects with this change and paths load correctly. 

Note: Sorry if I am not allowed to open pull requests or I used wrong branch. I couldn't find any information about contribution in github page, docs and discord.