### PR TITLE
Multi files processing

### DIFF
--- a/facefusion/filesystem.py
+++ b/facefusion/filesystem.py
@@ -107,3 +107,8 @@ def list_directory(directory_path : str) -> Optional[List[str]]:
 		files = os.listdir(directory_path)
 		return sorted([ Path(file).stem for file in files if not Path(file).stem.startswith(('.', '__')) ])
 	return None
+
+def list_directory_with_path(directory_path : str) -> Optional[List[str]]:
+	if is_directory(directory_path):
+		return [f for f in glob.glob(directory_path + "/*") if not Path(f).stem.startswith(('.', '__'))]
+	return None

--- a/facefusion/globals.py
+++ b/facefusion/globals.py
@@ -5,6 +5,7 @@ from facefusion.typing import LogLevel, VideoMemoryStrategy, FaceSelectorMode, F
 # general
 source_paths : Optional[List[str]] = None
 target_path : Optional[str] = None
+target_paths : Optional[List[str]] = None
 output_path : Optional[str] = None
 # misc
 skip_download : Optional[bool] = None
@@ -44,11 +45,14 @@ keep_temp : Optional[bool] = None
 # output creation
 output_image_quality : Optional[int] = None
 output_image_resolution : Optional[str] = None
+output_images_resolutions : Optional[List[str]] = []
 output_video_encoder : Optional[OutputVideoEncoder] = None
 output_video_preset : Optional[OutputVideoPreset] = None
 output_video_quality : Optional[int] = None
 output_video_resolution : Optional[str] = None
+output_videos_resolutions : Optional[List[str]] = []
 output_video_fps : Optional[float] = None
+output_videos_fps : Optional[List[float]] = []
 skip_audio : Optional[bool] = None
 # frame processors
 frame_processors : List[str] = []

--- a/facefusion/wording.py
+++ b/facefusion/wording.py
@@ -9,6 +9,7 @@ WORDING : Dict[str, Any] =\
 	'extracting_frames_succeed': 'Extracting frames succeed',
 	'extracting_frames_failed': 'Extracting frames failed',
 	'analysing': 'Analysing',
+	'executing_for': 'Executing for {path}',
 	'processing': 'Processing',
 	'downloading': 'Downloading',
 	'temp_frames_not_found': 'Temporary frames not found',
@@ -55,7 +56,9 @@ WORDING : Dict[str, Any] =\
 		'skip_venv': 'skip the virtual environment check',
 		# general
 		'source': 'choose single or multiple source images or audios',
+		'source_directory': 'choose directory containing source images',
 		'target': 'choose single target image or video',
+		'target_directory': 'choose directory containing target images or videos',
 		'output': 'specify the output file or directory',
 		# misc
 		'skip_download': 'omit automate downloads and remote lookups',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,19 +1,33 @@
 import subprocess
 import sys
 import pytest
+from pathlib import Path
 
 from facefusion.download import conditional_download
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
+	Path('.assets/examples_multiple/output').mkdir(parents = True, exist_ok = True)
+	Path('.assets/examples_multiple/target/img').mkdir(parents = True, exist_ok = True)
+	Path('.assets/examples_multiple/target/video').mkdir(parents = True, exist_ok = True)
 	conditional_download('.assets/examples',
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples/source.mp3',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples/target-240p.mp4'
 	])
+	conditional_download('.assets/examples_multiple/source',
+	[
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples/source.jpg'
+	])
+	conditional_download('.assets/examples_multiple/target/video',
+	[
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples/target-240p.mp4'
+	])
 	subprocess.run([ 'ffmpeg', '-i', '.assets/examples/target-240p.mp4', '-vframes', '1', '.assets/examples/target-240p.jpg' ])
+	subprocess.run([ 'ffmpeg', '-i', '.assets/examples/target-240p.mp4', '-vframes', '1', '.assets/examples_multiple/target/img/target-1-240p.jpg' ])
+	subprocess.run([ 'ffmpeg', '-i', '.assets/examples/target-240p.mp4', '-vframes', '1', '.assets/examples_multiple/target/img/target-2-240p.jpg' ])
 
 
 def test_debug_face_to_image() -> None:
@@ -39,6 +53,12 @@ def test_enhance_face_to_image() -> None:
 	assert run.returncode == 0
 	assert 'image succeed' in run.stdout.decode()
 
+def test_loop_enhance_faces_to_images() -> None:
+	commands = [ sys.executable, 'run.py', '--frame-processors', 'face_enhancer', '-td', '.assets/examples_multiple/target/img', '-o', '.assets/examples_multiple/output', '--headless' ]
+	run = subprocess.run(commands, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+
+	assert run.returncode == 0
+	assert 'image succeed' in run.stdout.decode()
 
 def test_enhance_face_to_video() -> None:
 	commands = [ sys.executable, 'run.py', '--frame-processors', 'face_enhancer', '-t', '.assets/examples/target-240p.mp4', '-o', '.assets/examples/test_enhance_face_to_video.mp4', '--trim-frame-end', '10', '--headless' ]
@@ -47,6 +67,19 @@ def test_enhance_face_to_video() -> None:
 	assert run.returncode == 0
 	assert 'video succeed' in run.stdout.decode()
 
+def test_loop_enhance_face_to_video() -> None:
+	commands = [ sys.executable, 'run.py', '--frame-processors', 'face_enhancer', '-td', '.assets/examples_multiple/target/video', '-o', '.assets/examples_multiple/output/test_enhance_face_to_video.mp4', '--headless' ]
+	run = subprocess.run(commands, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+
+	assert run.returncode == 0
+	assert 'video succeed' in run.stdout.decode()
+
+def test_loop_swap_faces_to_images() -> None:
+	commands = [ sys.executable, 'run.py', '--frame-processors', 'face_swapper', '-sd', '.assets/examples_multiple/source', '-td', '.assets/examples_multiple/target/img', '-o', '.assets/examples_multiple/output', '--headless' ]
+	run = subprocess.run(commands, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+
+	assert run.returncode == 0
+	assert 'image succeed' in run.stdout.decode()
 
 def test_swap_face_to_image() -> None:
 	commands = [ sys.executable, 'run.py', '--frame-processors', 'face_swapper', '-s', '.assets/examples/source.jpg', '-t', '.assets/examples/target-240p.jpg', '-o', '.assets/examples/test_swap_face_to_image.jpg', '--headless' ]
@@ -55,7 +88,6 @@ def test_swap_face_to_image() -> None:
 	assert run.returncode == 0
 	assert 'image succeed' in run.stdout.decode()
 
-
 def test_swap_face_to_video() -> None:
 	commands = [ sys.executable, 'run.py', '--frame-processors', 'face_swapper', '-s', '.assets/examples/source.jpg', '-t', '.assets/examples/target-240p.mp4', '-o', '.assets/examples/test_swap_face_to_video.mp4', '--trim-frame-end', '10', '--headless' ]
 	run = subprocess.run(commands, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
@@ -63,6 +95,12 @@ def test_swap_face_to_video() -> None:
 	assert run.returncode == 0
 	assert 'video succeed' in run.stdout.decode()
 
+def test_loop_swap_face_to_video() -> None:
+	commands = [ sys.executable, 'run.py', '--frame-processors', 'face_swapper', '-sd', '.assets/examples_multiple/source', '-td', '.assets/examples_multiple/target/video', '-o', '.assets/examples_multiple/output/test_swap_face_to_video.mp4', '--headless' ]
+	run = subprocess.run(commands, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+
+	assert run.returncode == 0
+	assert 'video succeed' in run.stdout.decode()
 
 def test_sync_lip_to_image() -> None:
 	commands = [ sys.executable, 'run.py', '--frame-processors', 'lip_syncer', '-s', '.assets/examples/source.mp3', '-t', '.assets/examples/target-240p.jpg', '-o', '.assets/examples/test_sync_lip_to_image.jpg', '--headless' ]
@@ -70,7 +108,6 @@ def test_sync_lip_to_image() -> None:
 
 	assert run.returncode == 0
 	assert 'image succeed' in run.stdout.decode()
-
 
 def test_sync_lip_to_video() -> None:
 	commands = [ sys.executable, 'run.py', '--frame-processors', 'lip_syncer', '-s', '.assets/examples/source.mp3', '-t', '.assets/examples/target-240p.mp4', '-o', '.assets/examples/test_sync_lip_to_video.mp4', '--trim-frame-end', '10', '--headless' ]

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,7 +1,7 @@
 import pytest
 
 from facefusion.download import conditional_download
-from facefusion.filesystem import is_file, is_directory, is_audio, has_audio, is_image, has_image, is_video, filter_audio_paths, filter_image_paths, list_directory
+from facefusion.filesystem import is_file, is_directory, is_audio, has_audio, is_image, has_image, is_video, filter_audio_paths, filter_image_paths, list_directory, list_directory_with_path
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -74,3 +74,8 @@ def test_list_directory() -> None:
 	assert list_directory('.assets/examples')
 	assert list_directory('.assets/examples/source.jpg') is None
 	assert list_directory('invalid') is None
+
+def test_list_directory_with_path() -> None:
+	assert list_directory_with_path('.assets/examples')
+	assert list_directory_with_path('.assets/examples/source.jpg') is None
+	assert list_directory_with_path('invalid') is None


### PR DESCRIPTION
+ Add --target_dir and --source_dir arguments to process for multiple files with single command

+ Process for all files in directory (--target_dir)

+ Define only a source directory with multiple source files (--source-dir) instead of one by one file with command --source

Only for headless mode for now