### PR TITLE
Solve error of slider using img

### DIFF
--- a/facefusion/uis/components/preview.py
+++ b/facefusion/uis/components/preview.py
@@ -185,7 +185,7 @@ def update_preview_frame_slider() -> gradio.Slider:
 	if is_video(facefusion.globals.target_path):
 		video_frame_total = count_video_frame_total(facefusion.globals.target_path)
 		return gradio.Slider(maximum = video_frame_total, visible = True)
-	return gradio.Slider(value = None, maximum = None, visible = False)
+	return gradio.Slider(visible = False)
 
 
 def process_preview_frame(reference_faces : FaceSet, source_face : Face, source_audio_frame : AudioFrame, target_vision_frame : VisionFrame) -> VisionFrame:

--- a/facefusion/uis/components/trim_frame.py
+++ b/facefusion/uis/components/trim_frame.py
@@ -61,7 +61,7 @@ def remote_update() -> Tuple[gradio.Slider, gradio.Slider]:
 		facefusion.globals.trim_frame_start = None
 		facefusion.globals.trim_frame_end = None
 		return gradio.Slider(value = 0, maximum = video_frame_total, visible = True), gradio.Slider(value = video_frame_total, maximum = video_frame_total, visible = True)
-	return gradio.Slider(value = None, maximum = None, visible = False), gradio.Slider(value = None, maximum = None, visible = False)
+	return gradio.Slider(visible = False), gradio.Slider(visible = False)
 
 
 def update_trim_frame_start(trim_frame_start : int) -> None:


### PR DESCRIPTION
When using img instead of video there's error about frame slider, because frame min and value are "None"
```
  File "D:\...\facefusion\uis\components\preview.py", line 188, in update_preview_frame_slider
    return gradio.Slider(value = None, maximum = None, visible = False)
  File "D:\....\modules\gradio_extensions.py", line 126, in __repaired_init__
    original(self, *args, **fixed_kwargs)
  File "D:\......\gradio\component_meta.py", line 159, in wrapper
    return fn(self, **kwargs)
  File "D:\......\gradio\components\slider.py", line 70, in __init__
    difference = maximum - minimum
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```