### PR TITLE
feat: Implement custom INI file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ options:
   -t TARGET_PATH, --target TARGET_PATH                                                                                                                  choose single target image or video
   -o OUTPUT_PATH, --output OUTPUT_PATH                                                                                                                  specify the output file or directory
   -v, --version                                                                                                                                         show program's version number and exit
+  -i INI_PATH, --ini INI_PATH                                                                                                                           specify ini file for launch configuration
 
 misc:
   --force-download                                                                                                                                      force automate downloads and exit

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Run the command:
 python run.py [options]
 
 options:
+  -c CONFIG_PATH, --config_path CONFIG_PATH                                                                                                             specify config file for launch configuration
   -h, --help                                                                                                                                            show this help message and exit
   -s SOURCE_PATHS, --source SOURCE_PATHS                                                                                                                choose single or multiple source images or audios
   -t TARGET_PATH, --target TARGET_PATH                                                                                                                  choose single target image or video
   -o OUTPUT_PATH, --output OUTPUT_PATH                                                                                                                  specify the output file or directory
   -v, --version                                                                                                                                         show program's version number and exit
-  -i INI_PATH, --ini INI_PATH                                                                                                                           specify ini file for launch configuration
 
 misc:
   --force-download                                                                                                                                      force automate downloads and exit

--- a/facefusion/config.py
+++ b/facefusion/config.py
@@ -1,24 +1,34 @@
 from configparser import ConfigParser
 from typing import Any, Optional, List
-
+import os.path 
 from facefusion.filesystem import resolve_relative_path
+import facefusion.globals
 
 CONFIG = None
 
 
-def get_config() -> ConfigParser:
-	global CONFIG
-
-	if CONFIG is None:
-		config_path = resolve_relative_path('../facefusion.ini')
-		CONFIG = ConfigParser()
-		CONFIG.read(config_path, encoding = 'utf-8')
-	return CONFIG
-
+def get_config(config_file_path: str = None) -> ConfigParser:
+    global CONFIG
+	
+    if CONFIG is None:  # Only read from file if CONFIG is not initialized
+        if config_file_path is not None:
+            resolved_path = config_file_path
+        else:
+            config_file_path = facefusion.globals.ini_path  
+            if config_file_path is not None:
+                if os.path.isabs(config_file_path):  
+                    resolved_path = config_file_path
+                else:
+                    resolved_path = resolve_relative_path(config_file_path)
+            else:
+                resolved_path = resolve_relative_path('../facefusion.ini')# Default path
+        CONFIG = ConfigParser()
+        CONFIG.read(resolved_path, encoding='utf-8')
+    return CONFIG  # Always return the CONFIG object
 
 def clear_config() -> None:
 	global CONFIG
-
+	
 	CONFIG = None
 
 

--- a/facefusion/config.py
+++ b/facefusion/config.py
@@ -5,9 +5,10 @@ import facefusion.globals
 
 CONFIG = None
 
+
 def get_config() -> ConfigParser:
 	global CONFIG
-
+	
 	if CONFIG is None:
 		CONFIG = ConfigParser()
 		CONFIG.read(facefusion.globals.config_path, encoding = 'utf-8')

--- a/facefusion/config.py
+++ b/facefusion/config.py
@@ -1,34 +1,21 @@
 from configparser import ConfigParser
 from typing import Any, Optional, List
-import os.path 
-from facefusion.filesystem import resolve_relative_path
+
 import facefusion.globals
 
 CONFIG = None
 
+def get_config() -> ConfigParser:
+	global CONFIG
 
-def get_config(config_file_path: str = None) -> ConfigParser:
-    global CONFIG
-	
-    if CONFIG is None:  # Only read from file if CONFIG is not initialized
-        if config_file_path is not None:
-            resolved_path = config_file_path
-        else:
-            config_file_path = facefusion.globals.ini_path  
-            if config_file_path is not None:
-                if os.path.isabs(config_file_path):  
-                    resolved_path = config_file_path
-                else:
-                    resolved_path = resolve_relative_path(config_file_path)
-            else:
-                resolved_path = resolve_relative_path('../facefusion.ini')# Default path
-        CONFIG = ConfigParser()
-        CONFIG.read(resolved_path, encoding='utf-8')
-    return CONFIG  # Always return the CONFIG object
+	if CONFIG is None:
+		CONFIG = ConfigParser()
+		CONFIG.read(facefusion.globals.config_path, encoding = 'utf-8')
+	return CONFIG
+
 
 def clear_config() -> None:
 	global CONFIG
-	
 	CONFIG = None
 
 

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -33,21 +33,16 @@ warnings.filterwarnings('ignore', category = UserWarning, module = 'gradio')
 
 
 def cli() -> None:
-	config.clear_config()
 	signal.signal(signal.SIGINT, lambda signal_number, frame: destroy())
-	program = ArgumentParser(formatter_class=lambda prog: HelpFormatter(prog, max_help_position=160), add_help=False)
-    
-    # ini
-	program.add_argument('-i', '--ini', help=wording.get('help.ini'), dest='ini_path')
+	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position=160), add_help = False)
+    # general
+	program.add_argument('-c', '--config_path', help = wording.get('help.config_path'), dest = 'config_path', default = 'facefusion.ini')
 	args = program.parse_args()
-	facefusion.globals.ini_path = args.ini_path
-	if is_file(args.ini_path) or args.ini_path is None:
-		if facefusion.globals.ini_path and facefusion.globals.ini_path[0]:  # Check if ini_path is not empty
-			config.get_config(args.ini_path)
-	else: 
-		logger.error(wording.get('select_valid_ini_files'), __name__.upper())
-		logger.error('Launching with default values from FaceFusion.ini', __name__.upper())
-	# general
+	facefusion.globals.config_path = args.config_path
+	if not is_file(args.config_path) and args.config_path is not None:
+		logger.error(wording.get('select_config_file'), __name__.upper())
+		logger.error('Launching with default values from facefusion.ini', __name__.upper())
+		facefusion.globals.config_path = 'facefusion.ini'
 	program.add_argument('-s', '--source', help = wording.get('help.source'), action = 'append', dest = 'source_paths', default = config.get_str_list('general.source_paths'))
 	program.add_argument('-t', '--target', help = wording.get('help.target'), dest = 'target_path', default = config.get_str_value('general.target_path'))
 	program.add_argument('-o', '--output', help = wording.get('help.output'), dest = 'output_path', default = config.get_str_value('general.output_path'))

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -24,7 +24,7 @@ from facefusion.normalizer import normalize_output_path, normalize_padding, norm
 from facefusion.memory import limit_system_memory
 from facefusion.statistics import conditional_log_statistics
 from facefusion.download import conditional_download
-from facefusion.filesystem import list_directory, get_temp_frame_paths, create_temp, move_temp, clear_temp, is_image, is_video, filter_audio_paths, resolve_relative_path
+from facefusion.filesystem import list_directory, get_temp_frame_paths, create_temp, move_temp, clear_temp, is_image, is_video, is_file, filter_audio_paths, resolve_relative_path
 from facefusion.ffmpeg import extract_frames, merge_video, copy_image, finalize_image, restore_audio, replace_audio
 from facefusion.vision import read_image, read_static_images, detect_image_resolution, restrict_video_fps, create_image_resolutions, get_video_frame, detect_video_resolution, detect_video_fps, restrict_video_resolution, restrict_image_resolution, create_video_resolutions, pack_resolution, unpack_resolution
 
@@ -33,8 +33,20 @@ warnings.filterwarnings('ignore', category = UserWarning, module = 'gradio')
 
 
 def cli() -> None:
+	config.clear_config()
 	signal.signal(signal.SIGINT, lambda signal_number, frame: destroy())
-	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position = 160), add_help = False)
+	program = ArgumentParser(formatter_class=lambda prog: HelpFormatter(prog, max_help_position=160), add_help=False)
+    
+    # ini
+	program.add_argument('-i', '--ini', help=wording.get('help.ini'), dest='ini_path')
+	args = program.parse_args()
+	facefusion.globals.ini_path = args.ini_path
+	if is_file(args.ini_path) or args.ini_path is None:
+		if facefusion.globals.ini_path and facefusion.globals.ini_path[0]:  # Check if ini_path is not empty
+			config.get_config(args.ini_path)
+	else: 
+		logger.error(wording.get('select_valid_ini_files'), __name__.upper())
+		logger.error('Launching with default values from FaceFusion.ini', __name__.upper())
 	# general
 	program.add_argument('-s', '--source', help = wording.get('help.source'), action = 'append', dest = 'source_paths', default = config.get_str_list('general.source_paths'))
 	program.add_argument('-t', '--target', help = wording.get('help.target'), dest = 'target_path', default = config.get_str_value('general.target_path'))

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -34,14 +34,14 @@ warnings.filterwarnings('ignore', category = UserWarning, module = 'gradio')
 
 def cli() -> None:
 	signal.signal(signal.SIGINT, lambda signal_number, frame: destroy())
-	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position=160), add_help = False)
+	program = ArgumentParser(formatter_class = lambda prog: HelpFormatter(prog, max_help_position = 160), add_help = False)
     # general
 	program.add_argument('-c', '--config_path', help = wording.get('help.config_path'), dest = 'config_path', default = 'facefusion.ini')
 	args = program.parse_args()
 	facefusion.globals.config_path = args.config_path
 	if not is_file(args.config_path) and args.config_path is not None:
 		logger.error(wording.get('select_config_file'), __name__.upper())
-		logger.error('Launching with default values from facefusion.ini', __name__.upper())
+		logger.error(wording.get('using_default_config'), __name__.upper())
 		facefusion.globals.config_path = 'facefusion.ini'
 	program.add_argument('-s', '--source', help = wording.get('help.source'), action = 'append', dest = 'source_paths', default = config.get_str_list('general.source_paths'))
 	program.add_argument('-t', '--target', help = wording.get('help.target'), dest = 'target_path', default = config.get_str_value('general.target_path'))

--- a/facefusion/globals.py
+++ b/facefusion/globals.py
@@ -3,10 +3,10 @@ from typing import List, Optional
 from facefusion.typing import LogLevel, VideoMemoryStrategy, FaceSelectorMode, FaceAnalyserOrder, FaceAnalyserAge, FaceAnalyserGender, FaceMaskType, FaceMaskRegion, OutputVideoEncoder, OutputVideoPreset, FaceDetectorModel, FaceRecognizerModel, TempFrameFormat, Padding
 
 # general
+config_path: Optional[str] = None
 source_paths : Optional[List[str]] = None
 target_path : Optional[str] = None
 output_path : Optional[str] = None
-ini_path: Optional[str] = None
 # misc
 force_download : Optional[bool] = None
 skip_download : Optional[bool] = None

--- a/facefusion/globals.py
+++ b/facefusion/globals.py
@@ -6,6 +6,7 @@ from facefusion.typing import LogLevel, VideoMemoryStrategy, FaceSelectorMode, F
 source_paths : Optional[List[str]] = None
 target_path : Optional[str] = None
 output_path : Optional[str] = None
+ini_path: Optional[str] = None
 # misc
 force_download : Optional[bool] = None
 skip_download : Optional[bool] = None

--- a/facefusion/wording.py
+++ b/facefusion/wording.py
@@ -38,7 +38,7 @@ WORDING : Dict[str, Any] =\
 	'select_video_target': 'Select a video for target path',
 	'select_image_or_video_target': 'Select a image or video for target path',
 	'select_file_or_directory_output': 'Select a file or directory for output path',
-	'select_valid_ini_files': 'Select a valid ini file, like: example.ini',
+	'select_config_file': 'Select a config file',
 	'no_source_face_detected': 'No source face detected',
 	'frame_processor_not_loaded': 'Frame processor {frame_processor} could not be loaded',
 	'frame_processor_not_implemented': 'Frame processor {frame_processor} not implemented correctly',
@@ -56,10 +56,10 @@ WORDING : Dict[str, Any] =\
 		'install_dependency': 'select the variant of {dependency} to install',
 		'skip_conda': 'skip the conda environment check',
 		# general
+  		'config_path': 'specify the config file',
 		'source': 'choose single or multiple source images or audios',
 		'target': 'choose single target image or video',
 		'output': 'specify the output file or directory',
-		'ini': 'specify the .ini file used at launch',
 		# misc
 		'force_download': 'force automate downloads and exit',
 		'skip_download': 'omit automate downloads and remote lookups',

--- a/facefusion/wording.py
+++ b/facefusion/wording.py
@@ -38,6 +38,7 @@ WORDING : Dict[str, Any] =\
 	'select_video_target': 'Select a video for target path',
 	'select_image_or_video_target': 'Select a image or video for target path',
 	'select_file_or_directory_output': 'Select a file or directory for output path',
+	'select_valid_ini_files': 'Select a valid ini file, like: example.ini',
 	'no_source_face_detected': 'No source face detected',
 	'frame_processor_not_loaded': 'Frame processor {frame_processor} could not be loaded',
 	'frame_processor_not_implemented': 'Frame processor {frame_processor} not implemented correctly',
@@ -58,6 +59,7 @@ WORDING : Dict[str, Any] =\
 		'source': 'choose single or multiple source images or audios',
 		'target': 'choose single target image or video',
 		'output': 'specify the output file or directory',
+		'ini': 'specify the .ini file used at launch',
 		# misc
 		'force_download': 'force automate downloads and exit',
 		'skip_download': 'omit automate downloads and remote lookups',

--- a/facefusion/wording.py
+++ b/facefusion/wording.py
@@ -39,6 +39,7 @@ WORDING : Dict[str, Any] =\
 	'select_image_or_video_target': 'Select a image or video for target path',
 	'select_file_or_directory_output': 'Select a file or directory for output path',
 	'select_config_file': 'Select a config file',
+	'using_default_config': 'Launching with default config values',
 	'no_source_face_detected': 'No source face detected',
 	'frame_processor_not_loaded': 'Frame processor {frame_processor} could not be loaded',
 	'frame_processor_not_implemented': 'Frame processor {frame_processor} not implemented correctly',


### PR DESCRIPTION
This commit introduces the ability to specify a custom INI file using the `-i/--ini` argument when running the program.
**Changes:**
Argument Parsing: Added the `-i/--ini` argument to the `ArgumentParser` to accept a custom INI file path.
**Configuration Loading:**
Modified the `get_config` function to accept an optional `config_file_path` argument.
If a custom path is provided, the function loads the configuration from the specified INI file. Otherwise, it falls back to the default `FaceFusion.ini`.
**Argument Handling:**
Updated the `apply_args` function to retrieve the custom INI file path from the parsed arguments.
Implemented logic to clear the cached configuration and load the custom INI file when a valid path is provided.
**Error Handling:** 
Added checks and error handling for cases where the custom INI file is not found, is invalid, or the path is incorrect.
**Updated README**
Added the new arg to the README for clarity