### PR TITLE
Set the installer is DPI-aware so the text is never blurry.

### DIFF
--- a/.install/facefusion.nsi
+++ b/.install/facefusion.nsi
@@ -4,6 +4,9 @@
 
 RequestExecutionLevel admin
 
+# Set the installer is DPI-aware so the text is never blurry. For NSIS version v3.0a0+
+ManifestDPIAware true
+
 Name 'FaceFusion 2.6.0'
 OutFile 'FaceFusion_2.6.0.exe'
 


### PR DESCRIPTION
Set the installer is DPI-aware so the text is never blurry. For NSIS version v3.0a0+