### PR TITLE
cache video stream instead of reading again and again for each frame 

### DIFF
--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -70,11 +70,15 @@ def create_image_resolutions(resolution : Resolution) -> List[str]:
 	return resolutions
 
 
+@lru_cache(maxsize=128)
+def get_video_stream(video_path : str):
+	return cv2.VideoCapture(video_path)
+
 def get_video_frame(video_path : str, frame_number : int = 0) -> Optional[VisionFrame]:
 	if is_video(video_path):
 		if is_windows():
 			video_path = sanitize_path_for_windows(video_path)
-		video_capture = cv2.VideoCapture(video_path)
+		video_capture = get_video_stream(video_path)
 		if video_capture.isOpened():
 			frame_total = video_capture.get(cv2.CAP_PROP_FRAME_COUNT)
 			video_capture.set(cv2.CAP_PROP_POS_FRAMES, min(frame_total, frame_number - 1))

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -71,8 +71,9 @@ def create_image_resolutions(resolution : Resolution) -> List[str]:
 
 
 @lru_cache(maxsize=128)
-def get_video_stream(video_path : str):
+def get_video_stream(video_path : str) -> VideoCapture:
 	return cv2.VideoCapture(video_path)
+
 
 def get_video_frame(video_path : str, frame_number : int = 0) -> Optional[VisionFrame]:
 	if is_video(video_path):


### PR DESCRIPTION
solves the crash when stream is already open

performance gain

Handled review comments in #635 