### PR TITLE
Update helper.py

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,44 +1,53 @@
 import os
 import tempfile
+from pathlib import Path
 
 from facefusion.filesystem import create_directory, is_directory, is_file, remove_directory
 from facefusion.typing import JobStatus
 
 
-def is_test_job_file(file_path : str, job_status : JobStatus) -> bool:
-	return is_file(get_test_job_file(file_path, job_status))
+# Get the base temporary directory once and reuse it
+TEMP_DIR = Path(tempfile.gettempdir())
+
+def is_test_job_file(file_path: str, job_status: JobStatus) -> bool:
+    return is_file(get_test_job_file(file_path, job_status))
 
 
-def get_test_job_file(file_path : str, job_status : JobStatus) -> str:
-	return os.path.join(get_test_jobs_directory(), job_status, file_path)
+def get_test_job_file(file_path: str, job_status: JobStatus) -> str:
+    return str(get_test_jobs_directory() / job_status / file_path)
 
 
-def get_test_jobs_directory() -> str:
-	return os.path.join(tempfile.gettempdir(), 'facefusion-test-jobs')
+def get_test_jobs_directory() -> Path:
+    return TEMP_DIR / 'facefusion-test-jobs'
 
 
-def get_test_example_file(file_path : str) -> str:
-	return os.path.join(get_test_examples_directory(), file_path)
+def get_test_example_file(file_path: str) -> str:
+    return str(get_test_examples_directory() / file_path)
 
 
-def get_test_examples_directory() -> str:
-	return os.path.join(tempfile.gettempdir(), 'facefusion-test-examples')
+def get_test_examples_directory() -> Path:
+    return TEMP_DIR / 'facefusion-test-examples'
 
 
-def is_test_output_file(file_path : str) -> bool:
-	return is_file(get_test_output_file(file_path))
+def is_test_output_file(file_path: str) -> bool:
+    return is_file(get_test_output_file(file_path))
 
 
-def get_test_output_file(file_path : str) -> str:
-	return os.path.join(get_test_outputs_directory(), file_path)
+def get_test_output_file(file_path: str) -> str:
+    return str(get_test_outputs_directory() / file_path)
 
 
-def get_test_outputs_directory() -> str:
-	return os.path.join(tempfile.gettempdir(), 'facefusion-test-outputs')
+def get_test_outputs_directory() -> Path:
+    return TEMP_DIR / 'facefusion-test-outputs'
 
 
 def prepare_test_output_directory() -> bool:
-	test_outputs_directory = get_test_outputs_directory()
-	remove_directory(test_outputs_directory)
-	create_directory(test_outputs_directory)
-	return is_directory(test_outputs_directory)
+    test_outputs_directory = get_test_outputs_directory()
+    try:
+        remove_directory(str(test_outputs_directory))  # Ensure it's removed
+        create_directory(str(test_outputs_directory))  # Ensure it's created
+        return is_directory(str(test_outputs_directory))
+    except Exception as e:
+        # Log the error or handle it as needed
+        print(f"Error preparing test output directory: {e}")
+        return False


### PR DESCRIPTION
Hello,
I tried making some changes,

- Replaced os.path.join with pathlib.Path for cleaner, more readable path manipulation.
- The TEMP_DIR variable is defined once and reused in the functions. This makes it easier to modify the base temporary directory if needed in the future.
- Added a try-except block to handle potential errors while removing or creating directories. You can replace the print with logging if needed.
- Path objects are converted to strings when interacting with functions like remove_directory and create_directory, assuming they work with strings. If those functions work with Path objects, you can adjust this to pass Path objects directly.

Thank You,
Rajat Mishra