### PR TITLE
Fix/remote inference pool lookups

### DIFF
--- a/facefusion.ini
+++ b/facefusion.ini
@@ -57,7 +57,7 @@ output_video_fps =
 skip_audio =
 
 [processors]
-processors = face_debugger
+processors =
 age_modifier_model =
 age_modifier_direction =
 deep_swapper_model =
@@ -99,7 +99,7 @@ ui_workflow =
 
 [execution]
 execution_device_id =
-execution_providers = cuda
+execution_providers =
 execution_thread_count =
 execution_queue_count =
 

--- a/facefusion.ini
+++ b/facefusion.ini
@@ -57,7 +57,7 @@ output_video_fps =
 skip_audio =
 
 [processors]
-processors =
+processors = face_debugger
 age_modifier_model =
 age_modifier_direction =
 deep_swapper_model =
@@ -99,7 +99,7 @@ ui_workflow =
 
 [execution]
 execution_device_id =
-execution_providers =
+execution_providers = cuda
 execution_thread_count =
 execution_queue_count =
 

--- a/facefusion/inference_manager.py
+++ b/facefusion/inference_manager.py
@@ -6,6 +6,7 @@ from onnxruntime import InferenceSession
 from facefusion import process_manager, state_manager
 from facefusion.app_context import detect_app_context
 from facefusion.execution import create_inference_execution_providers
+from facefusion.filesystem import is_file
 from facefusion.thread_helper import thread_lock
 from facefusion.typing import DownloadSet, ExecutionProvider, InferencePool, InferencePoolSet
 
@@ -14,6 +15,15 @@ INFERENCE_POOLS : InferencePoolSet =\
 	'cli': {}, #type:ignore[typeddict-item]
 	'ui': {} #type:ignore[typeddict-item]
 }
+
+
+def has_inference_model(model_context : str, model_name : str) -> bool:
+	while process_manager.is_checking():
+		sleep(0.5)
+	app_context = detect_app_context()
+	inference_context = get_inference_context(model_context)
+	inference_pool = INFERENCE_POOLS.get(app_context).get(inference_context)
+	return inference_pool and model_name in inference_pool
 
 
 def get_inference_pool(model_context : str, model_sources : DownloadSet) -> InferencePool:
@@ -39,7 +49,10 @@ def create_inference_pool(model_sources : DownloadSet, execution_device_id : str
 	inference_pool : InferencePool = {}
 
 	for model_name in model_sources.keys():
-		inference_pool[model_name] = create_inference_session(model_sources.get(model_name).get('path'), execution_device_id, execution_providers)
+		model_path = model_sources.get(model_name).get('path')
+		if is_file(model_path):
+			inference_pool[model_name] = create_inference_session(model_path, execution_device_id, execution_providers)
+
 	return inference_pool
 
 

--- a/facefusion/inference_manager.py
+++ b/facefusion/inference_manager.py
@@ -23,7 +23,10 @@ def has_inference_model(model_context : str, model_name : str) -> bool:
 	app_context = detect_app_context()
 	inference_context = get_inference_context(model_context)
 	inference_pool = INFERENCE_POOLS.get(app_context).get(inference_context)
-	return inference_pool and model_name in inference_pool
+
+	if inference_pool:
+		return model_name in inference_pool
+	return False
 
 
 def get_inference_pool(model_context : str, model_sources : DownloadSet) -> InferencePool:

--- a/facefusion/processors/modules/deep_swapper.py
+++ b/facefusion/processors/modules/deep_swapper.py
@@ -238,6 +238,10 @@ def create_static_model_set(download_scope : DownloadScope) -> ModelSet:
 	return model_set
 
 
+def has_inference_model(model_name : str) -> InferencePool:
+	return inference_manager.has_inference_model(__name__, model_name)
+
+
 def get_inference_pool() -> InferencePool:
 	model_sources = get_model_options().get('sources')
 	return inference_manager.get_inference_pool(__name__, model_sources)
@@ -357,11 +361,13 @@ def forward(crop_vision_frame : VisionFrame, deep_swapper_morph : DeepSwapperMor
 
 
 def has_morph_input() -> bool:
-	deep_swapper = get_inference_pool().get('deep_swapper')
+	if has_inference_model('deep_swapper'):
+		deep_swapper = get_inference_pool().get('deep_swapper')
 
-	for deep_swapper_input in deep_swapper.get_inputs():
-		if deep_swapper_input.name == 'morph_value:0':
-			return True
+		for deep_swapper_input in deep_swapper.get_inputs():
+			if deep_swapper_input.name == 'morph_value:0':
+				return True
+
 	return False
 
 

--- a/facefusion/processors/modules/deep_swapper.py
+++ b/facefusion/processors/modules/deep_swapper.py
@@ -238,7 +238,7 @@ def create_static_model_set(download_scope : DownloadScope) -> ModelSet:
 	return model_set
 
 
-def has_inference_model(model_name : str) -> InferencePool:
+def has_inference_model(model_name : str) -> bool:
 	return inference_manager.has_inference_model(__name__, model_name)
 
 

--- a/facefusion/processors/modules/face_enhancer.py
+++ b/facefusion/processors/modules/face_enhancer.py
@@ -221,7 +221,7 @@ def create_static_model_set(download_scope : DownloadScope) -> ModelSet:
 	}
 
 
-def has_inference_model(model_name : str) -> InferencePool:
+def has_inference_model(model_name : str) -> bool:
 	return inference_manager.has_inference_model(__name__, model_name)
 
 

--- a/facefusion/processors/modules/face_enhancer.py
+++ b/facefusion/processors/modules/face_enhancer.py
@@ -221,6 +221,10 @@ def create_static_model_set(download_scope : DownloadScope) -> ModelSet:
 	}
 
 
+def has_inference_model(model_name : str) -> InferencePool:
+	return inference_manager.has_inference_model(__name__, model_name)
+
+
 def get_inference_pool() -> InferencePool:
 	model_sources = get_model_options().get('sources')
 	return inference_manager.get_inference_pool(__name__, model_sources)
@@ -324,11 +328,13 @@ def forward(crop_vision_frame : VisionFrame, face_enhancer_weight : FaceEnhancer
 
 
 def has_weight_input() -> bool:
-	face_enhancer = get_inference_pool().get('face_enhancer')
+	if has_inference_model('face_enhancer'):
+		face_enhancer = get_inference_pool().get('face_enhancer')
 
-	for deep_swapper_input in face_enhancer.get_inputs():
-		if deep_swapper_input.name == 'weight':
-			return True
+		for deep_swapper_input in face_enhancer.get_inputs():
+			if deep_swapper_input.name == 'weight':
+				return True
+
 	return False
 
 

--- a/facefusion/uis/components/deep_swapper_options.py
+++ b/facefusion/uis/components/deep_swapper_options.py
@@ -31,7 +31,7 @@ def render() -> None:
 		step = calc_int_step(processors_choices.deep_swapper_morph_range),
 		minimum = processors_choices.deep_swapper_morph_range[0],
 		maximum = processors_choices.deep_swapper_morph_range[-1],
-		visible = has_deep_swapper and has_morph_input()
+		visible = has_morph_input()
 	)
 	register_ui_component('deep_swapper_model_dropdown', DEEP_SWAPPER_MODEL_DROPDOWN)
 	register_ui_component('deep_swapper_morph_slider', DEEP_SWAPPER_MORPH_SLIDER)
@@ -48,7 +48,7 @@ def listen() -> None:
 
 def remote_update(processors : List[str]) -> Tuple[gradio.Dropdown, gradio.Slider]:
 	has_deep_swapper = 'deep_swapper' in processors
-	return gradio.Dropdown(visible = has_deep_swapper), gradio.Slider(visible = has_deep_swapper and has_morph_input())
+	return gradio.Dropdown(visible = has_deep_swapper), gradio.Slider(visible = has_morph_input())
 
 
 def update_deep_swapper_model(deep_swapper_model : DeepSwapperModel) -> Tuple[gradio.Dropdown, gradio.Slider]:


### PR DESCRIPTION
While validation the offline capabilities of the latest release, I figured out that the deep swapper and face enhancer are failing under certain edge cases.

# Reproduce 

0. Checkout next branch
1. Delete the initial models `iperov/elon_musk_224.dmg`  and `gfpgan_1.4`
2. Break the domains in the choices `download_provider_set` like `https://-github.com`, `https://-huggingface.co` and `https://-hf-mirror.com`
3. Once in the UI, either load deep swapper or face enhancer
4. Unload it and enable expression restorer

This will cause in a exception that the model path is invalid.

# Why

This is caused by the methods `has_morph_input()` and `has_weight_input()` and the fact that Gradio reders even invisible UI elements. As a remote update is triggered by enabling the expression restorer, the input lookup methods are fired without the `pre_check()`, resulting in a inference pool creation with non-existing model (paths).


# Solution

1. Prevent inference session creation when model path is not a file
2. Introduce a has model lookup without the creation of the inference pool