### PR TITLE
Fix/extrating merging progress bar total

### DIFF
--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -451,7 +451,7 @@ def process_video(start_time : float) -> ErrorCode:
 		return 1
 
 	logger.info(wording.get('merging_video').format(resolution = state_manager.get_item('output_video_resolution'), fps = state_manager.get_item('output_video_fps')), __name__)
-	if merge_video(state_manager.get_item('target_path'), temp_video_fps, state_manager.get_item('output_video_resolution'), state_manager.get_item('output_video_fps')):
+	if merge_video(state_manager.get_item('target_path'), temp_video_fps, state_manager.get_item('output_video_resolution'), state_manager.get_item('output_video_fps'), trim_frame_start, trim_frame_end):
 		logger.debug(wording.get('merging_video_succeed'), __name__)
 	else:
 		if is_process_stopping():

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -102,10 +102,12 @@ def count_video_frame_total(video_path : str) -> int:
 	return 0
 
 
-def predict_video_frame_total(target_path : str, fps : Fps, trim_frame_start : int, trim_frame_end : int) -> int:
-	target_video_fps = detect_video_fps(target_path)
-	extract_frame_total = count_trim_frame_total(target_path, trim_frame_start, trim_frame_end) * fps / target_video_fps
-	return math.ceil(extract_frame_total)
+def predict_video_frame_total(video_path : str, fps : Fps, trim_frame_start : int, trim_frame_end : int) -> int:
+	if is_video(video_path):
+		target_video_fps = detect_video_fps(video_path)
+		extract_frame_total = count_trim_frame_total(video_path, trim_frame_start, trim_frame_end) * fps / target_video_fps
+		return math.ceil(extract_frame_total)
+	return 0
 
 
 def detect_video_fps(video_path : str) -> Optional[float]:

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -1,3 +1,4 @@
+import math
 from functools import lru_cache
 from typing import List, Optional, Tuple
 
@@ -99,6 +100,12 @@ def count_video_frame_total(video_path : str) -> int:
 			video_capture.release()
 			return video_frame_total
 	return 0
+
+
+def predict_video_frame_total(target_path : str, fps : Fps, trim_frame_start : int, trim_frame_end : int) -> int:
+	target_video_fps = detect_video_fps(target_path)
+	extract_frame_total = count_trim_frame_total(target_path, trim_frame_start, trim_frame_end) * fps / target_video_fps
+	return math.ceil(extract_frame_total)
 
 
 def detect_video_fps(video_path : str) -> Optional[float]:

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -106,7 +106,7 @@ def predict_video_frame_total(video_path : str, fps : Fps, trim_frame_start : in
 	if is_video(video_path):
 		target_video_fps = detect_video_fps(video_path)
 		extract_frame_total = count_trim_frame_total(video_path, trim_frame_start, trim_frame_end) * fps / target_video_fps
-		return math.ceil(extract_frame_total)
+		return math.floor(extract_frame_total)
 	return 0
 
 

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -84,7 +84,7 @@ def test_predict_video_frame_total() -> None:
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 12.5, 0, 100) == 50
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 200) == 200
-	assert predict_video_frame_total('invalid', 0, 0, 0) == 0
+	assert predict_video_frame_total('invalid', 25, 0, 100) == 0
 
 
 def test_detect_video_fps() -> None:

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -3,7 +3,7 @@ import subprocess
 import pytest
 
 from facefusion.download import conditional_download
-from facefusion.vision import calc_histogram_difference, count_trim_frame_total, count_video_frame_total, create_image_resolutions, create_video_resolutions, detect_image_resolution, detect_video_duration, detect_video_fps, detect_video_resolution, match_frame_color, normalize_resolution, pack_resolution, read_image, read_video_frame, restrict_image_resolution, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, unpack_resolution, write_image
+from facefusion.vision import calc_histogram_difference, count_trim_frame_total, count_video_frame_total, create_image_resolutions, create_video_resolutions, detect_image_resolution, detect_video_duration, detect_video_fps, detect_video_resolution, match_frame_color, normalize_resolution, pack_resolution, predict_video_frame_total, read_image, read_video_frame, restrict_image_resolution, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, unpack_resolution, write_image
 from .helper import get_test_example_file, get_test_examples_directory, get_test_output_file, prepare_test_output_directory
 
 
@@ -78,6 +78,13 @@ def test_count_video_frame_total() -> None:
 	assert count_video_frame_total(get_test_example_file('target-240p-30fps.mp4')) == 324
 	assert count_video_frame_total(get_test_example_file('target-240p-60fps.mp4')) == 648
 	assert count_video_frame_total('invalid') == 0
+
+
+def test_predict_video_frame_total() -> None:
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 12.5, 0, 100) == 50
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 200) == 200
+	assert predict_video_frame_total('invalid', 0, 0, 0) == 0
 
 
 def test_detect_video_fps() -> None:


### PR DESCRIPTION
This fixes  extracting frames and merging video are showing the correct frames when fps are either decreased or encreased.

```
python facefusion.py headless-run -t .assets/examples/target-240p.mp4 -o ./test.mp4 --processors face_debugger --trim-frame-end 100 --output-video-fps 15
```

```
python facefusion.py headless-run -t .assets/examples/target-240p.mp4 -o ./test.mp4 --processors face_debugger --trim-frame-end 100 --output-video-fps 60
```