### PR TITLE
Read the source as a pattern not just a file

### DIFF
--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -255,7 +255,8 @@ def route_job_runner() -> ErrorCode:
 def process_headless(args : Args) -> ErrorCode:
 	job_id = job_helper.suggest_job_id('headless')
 	step_args = reduce_step_args(args)
-
+	source_paths = resolve_file_pattern(step_args.get('source_paths'))
+	step_args['source_paths'] = source_paths if isinstance(source_paths, str) else ' '.join(source_paths)
 	if job_manager.create_job(job_id) and job_manager.add_step(job_id, step_args) and job_manager.submit_job(job_id) and job_runner.run_job(job_id, process_step):
 		return 0
 	return 1


### PR DESCRIPTION
This pull request updates the process_headless function in the facefusion/core.py file to improve how the source_paths argument is handled. The update ensures that source_paths is correctly resolved and formatted before being used in the job creation process.
Notably, it now supports parsing paths from glob-like patterns such as files/* as well as direct string paths like files/1.jpg.

* [facefusion/core.py](diffhunk://#diff-b4eb646632f993bf0d0ad431d2961a12f36f19ce87f470173d98072f6892cca8L258-R259): Added code to resolve the source_paths pattern and format it correctly in the process_headless function.