### PR TITLE
feat: Add optimized pixi environment for Apple Silicon

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,61 @@
+[workspace]
+authors = ["Kazuki Nakai <48890992+kazukinakai@users.noreply.github.com>"]
+channels = ["conda-forge"]
+name = "facefusion-dev"
+platforms = ["osx-arm64"]
+version = "0.1.0"
+
+[activation.env]
+ORT_COREML_FLAGS = "COREML_FLAG_ENABLE_ON_SUBGRAPH|COREML_FLAG_ONLY_ENABLE_DEVICE_WITH_ANE"
+ORT_COREML_EP_PRECISION = "fp16"
+COREML_PREFER_GPU = "1"
+PYTORCH_MPS_HIGH_WATERMARK_RATIO = "0.0"
+PYTORCH_ENABLE_MPS_FALLBACK = "1"
+NPY_BLAS_ORDER = "accelerate"
+NPY_LAPACK_ORDER = "accelerate"
+SCIPY_USE_ACCELERATE = "1"
+OPENCV_USE_ACCELERATE = "1"
+
+[tasks]
+run = "python facefusion.py run --open-browser"
+check-providers = "python -c 'import onnxruntime as ort; print(\"Available providers:\", ort.get_available_providers())'"
+check-versions = "python -c 'import sys, onnxruntime, torch, numpy, cv2, coremltools; print(f\"Python: {sys.version}\"); print(f\"ONNX Runtime: {onnxruntime.__version__}\"); print(f\"PyTorch: {torch.__version__}\"); print(f\"NumPy: {numpy.__version__}\"); print(f\"OpenCV: {cv2.__version__}\"); print(f\"CoreMLTools: {coremltools.__version__}\")'"
+check-accelerate = "python -c 'import numpy as np; config = np.__config__; print(\"NumPy BLAS info:\"); print(config.show())'"
+
+[dependencies]
+python = "3.12.*"
+libblas = { version = "*", build = "*accelerate" }
+libcblas = { version = "*", build = "*accelerate" }
+liblapack = { version = "*", build = "*accelerate" }
+numpy = "*"
+scipy = "*"
+psutil = ">=7.0.0,<8"
+tqdm = ">=4.67.1,<5"
+ffmpeg = "*"
+pip = "*"
+
+[pypi-dependencies]
+onnxruntime = ">=1.22.0"
+gradio = "==5.25.2"
+gradio-rangeslider = "==0.0.8"
+onnx = "==1.17.0"
+torch = ">=2.0"
+torchvision = "*"
+torchaudio = "*"
+insightface = "*"
+coremltools = ">=8.0"
+protobuf = ">=3.20.0"
+opencv-python = ">=4.10.0"
+filetype = "*"
+pydantic = "*"
+
+[feature.benchmark.dependencies]
+matplotlib = "*"
+seaborn = "*"
+
+[feature.benchmark.tasks]
+benchmark = "python -c 'import numpy as np, time; sizes=[512,1024,2048]; times=[]; [times.append((lambda s: (time.time(), np.dot(np.random.rand(s,s), np.random.rand(s,s)), time.time())[-1] - (lambda s: (time.time(), np.dot(np.random.rand(s,s), np.random.rand(s,s)), time.time()))[0])(s)) for s in sizes]; print(\"Matrix sizes:\", sizes); print(\"Times (s):\", times)'"
+
+[environments]
+default = { solve-group = "main" }
+benchmark = { features = ["benchmark"], solve-group = "main" }


### PR DESCRIPTION
Hi Henry 👋

Long time no see!

I've successfully managed to significantly reduce CoreML CPU fallbacks on Apple Silicon Macs, which resulted in substantial performance improvements for FaceFusion. I'd love to share this with you.
(Sorry I didn't have time to extend the existing installer.)

This PR adds a `pixi.toml` file.
Apple Silicon Mac users can simply run `pixi install` instead of using the existing installer to easily reproduce the optimized environment I've achieved.

---

- ONNX Runtime with CoreML EP (ANE and GPU via Metal)  
- NumPy/SciPy using Accelerate instead of OpenBLAS
- PyTorch MPS (Metal backend) fallback enabled
- OpenCV optimized for Apple Silicon

---

The environment is defined for `osx-arm64`, fully reproducible, and includes minimal diagnostic tasks (`run`, `check-providers`, etc).

---

Pixi is a new developer-focused package management tool that leverages the conda ecosystem.
For more details: https://pixi.sh/latest/

I encountered a situation where all my miniforge conda virtual environments disappeared last week. lol.
That's when I came across this article and became interested in pixi:

https://prefix.dev/blog/pixi_a_fast_conda_alternative

This makes no changes to the existing `installer.py` or main application logic.
I tried uv and other alternatives, but I personally prefer pixi.
Pixi is easy for conda users to migrate to.
It's also OS-agnostic, so it can be extended for Windows and Linux users as well.
While we could make the existing `installer.py` do what pixi is doing here, pixi provides lockfiles and other features that make it a complete superset of conda functionality.

You might already be aware of this, but I thought I'd share the information.
I'm happy to contribute to this amazing project.

Kazuki