### PR TITLE
Introduce pip mirror to bypass China's great firewall

### DIFF
--- a/facefusion/installer.py
+++ b/facefusion/installer.py
@@ -3,12 +3,25 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 from argparse import ArgumentParser, HelpFormatter
 from functools import partial
 from types import FrameType
 
+# Try to import requests, if it fails, prompt the user to install it
+try:
+	import requests
+except ImportError:
+	print("Error: 'requests' library is not installed. Please install it first by running 'pip install requests'.")
+	sys.exit(1)
+
 from facefusion import metadata, wording
 from facefusion.common_helper import is_linux, is_windows
+
+# Define official and mirror pip sources
+PIP_OFFICIAL_MIRROR = 'https://pypi.python.org/simple'
+PIP_TUNA_MIRROR = 'https://pypi.tuna.tsinghua.edu.cn/simple'
+PIP_ALIYUN_MIRROR = 'https://mirrors.aliyun.com/pypi/simple/'
 
 ONNXRUNTIME_SET =\
 {
@@ -21,6 +34,71 @@ if is_windows():
 	ONNXRUNTIME_SET['directml'] = ('onnxruntime-directml', '1.17.3')
 if is_linux():
 	ONNXRUNTIME_SET['rocm'] = ('onnxruntime-rocm', '1.21.0')
+
+
+def choose_pip_mirror() -> str:
+	"""
+	Tests pip sources by measuring their actual download speed (bandwidth)
+	and returns the fastest one. This version includes a User-Agent header
+	to avoid being blocked by anti-scraping mechanisms.
+	"""
+	mirrors = {
+		"Official Source": PIP_OFFICIAL_MIRROR,
+		"Tsinghua Mirror": PIP_TUNA_MIRROR,
+		"Aliyun Mirror": PIP_ALIYUN_MIRROR
+	}
+	speeds = {}
+
+	# Size of the data chunk to download for testing, e.g., 512 KB
+	test_chunk_size_bytes = 512 * 1024
+
+	# Masquerade as a common browser User-Agent to avoid being rejected by the server.
+	headers = {
+		'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 Edg/139.0.0.0'
+	}
+
+	print("Testing pip source download speeds (bandwidth)...")
+
+	for name, url in mirrors.items():
+		try:
+			print(f"- Testing {name} ({url})...")
+			start_time = time.time()
+
+			# Add the headers to the request.
+			response = requests.get(url, stream=True, timeout=10, headers=headers)
+			response.raise_for_status()
+
+			downloaded_bytes = 0
+			for chunk in response.iter_content(chunk_size=8192):
+				downloaded_bytes += len(chunk)
+				if downloaded_bytes >= test_chunk_size_bytes:
+					break
+
+			end_time = time.time()
+			duration = end_time - start_time
+
+			if duration == 0:
+				speed_kbps = float('inf')
+			else:
+				speed_kbps = (downloaded_bytes / 1024) / duration
+
+			speeds[name] = speed_kbps
+			print(f"  => Speed: {speed_kbps:.2f} KB/s")
+
+		except requests.RequestException as e:
+			speeds[name] = 0
+			print(f"  => Test failed: {e}")
+
+	if not speeds or all(speed == 0 for speed in speeds.values()):
+		print("\nAll pip sources are unreachable. Falling back to the default Official Source.")
+		return PIP_OFFICIAL_MIRROR
+
+	# Find the source with the highest speed.
+	fastest_mirror_name = max(speeds, key=speeds.get)
+	fastest_mirror_url = mirrors[fastest_mirror_name]
+
+	print(f"\nTesting complete. Selected the fastest source: {fastest_mirror_name} ({fastest_mirror_url})\n")
+	return fastest_mirror_url
 
 
 def cli() -> None:
@@ -41,6 +119,10 @@ def run(program : ArgumentParser) -> None:
 	has_conda = 'CONDA_PREFIX' in os.environ
 	onnxruntime_name, onnxruntime_version = ONNXRUNTIME_SET.get(args.onnxruntime)
 
+	# Choose the fastest pip source
+
+	PIP_MIRROR = choose_pip_mirror()
+
 	if not args.skip_conda and not has_conda:
 		sys.stdout.write(wording.get('conda_not_activated') + os.linesep)
 		sys.exit(1)
@@ -50,7 +132,7 @@ def run(program : ArgumentParser) -> None:
 		for line in file.readlines():
 			__line__ = line.strip()
 			if not __line__.startswith('onnxruntime'):
-				subprocess.call([ shutil.which('pip'), 'install', line, '--force-reinstall' ])
+				subprocess.call([ shutil.which('pip'), 'install', line, '--force-reinstall', '-i', PIP_MIRROR ])
 
 	if args.onnxruntime == 'rocm':
 		python_id = 'cp' + str(sys.version_info.major) + str(sys.version_info.minor)
@@ -58,9 +140,9 @@ def run(program : ArgumentParser) -> None:
 		if python_id in [ 'cp310', 'cp312' ]:
 			wheel_name = 'onnxruntime_rocm-' + onnxruntime_version + '-' + python_id + '-' + python_id + '-linux_x86_64.whl'
 			wheel_url = 'https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/' + wheel_name
-			subprocess.call([ shutil.which('pip'), 'install', wheel_url, '--force-reinstall' ])
+			subprocess.call([ shutil.which('pip'), 'install', wheel_url, '--force-reinstall', '-i', PIP_MIRROR ])
 	else:
-		subprocess.call([ shutil.which('pip'), 'install', onnxruntime_name + '==' + onnxruntime_version, '--force-reinstall' ])
+		subprocess.call([ shutil.which('pip'), 'install', onnxruntime_name + '==' + onnxruntime_version, '--force-reinstall', '-i',PIP_MIRROR ])
 
 	if args.onnxruntime == 'cuda' and has_conda:
 		library_paths = []
@@ -93,4 +175,4 @@ def run(program : ArgumentParser) -> None:
 			subprocess.call([ shutil.which('conda'), 'env', 'config', 'vars', 'set', 'PATH=' + os.pathsep.join(library_paths) ])
 
 	if args.onnxruntime == 'directml':
-		subprocess.call([ shutil.which('pip'), 'install', 'numpy==1.26.4', '--force-reinstall' ])
+		subprocess.call([ shutil.which('pip'), 'install', 'numpy==1.26.4', '--force-reinstall', '-i', PIP_MIRROR ])


### PR DESCRIPTION
The people in china,use official pip source to install package is too slowly.
So I introduce some pip mirror to make it faster.
Firstly,the new code will test the download speed for each pip source
then the code will use the fastest pip source to install package to ensure the people in china or not in china will both have a nice speed.

btw,if you merge the code,you need to let user install requests package first.
So in the Installation of the docs,may be create conda environment like this
`conda create --name facefusion python=3.12 pip=25.0 requests=2.32.4`