### PR TITLE
Fix hardcoded fps

### DIFF
--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -339,6 +339,10 @@ def conditional_process() -> ErrorCode:
 		if not processor_module.pre_process('output'):
 			return 2
 
+	if state_manager.get_item('workflow') in [ 'audio-to-image:video', 'audio-to-image:frames' ]:
+		if not state_manager.get_item('output_video_fps'):
+			logger.error(translator.get('output_video_fps_not_set'), __name__)
+			return 1
 	if state_manager.get_item('workflow') == 'audio-to-image:video':
 		return audio_to_image.process(start_time)
 	if state_manager.get_item('workflow') == 'audio-to-image:frames':

--- a/facefusion/locales.py
+++ b/facefusion/locales.py
@@ -150,6 +150,7 @@ LOCALES : Locales =\
 			'output_video_quality': 'specify the video quality which translates to the video compression',
 			'output_video_scale': 'specify the video scale based on the target video',
 			'output_video_fps': 'specify the video fps based on the target video',
+			'output_video_fps_not_set': 'output video fps is required for the audio-to-image workflow',
 			'processors': 'load a single or multiple processors (choices: {choices}, ...)',
 			'background-remover-model': 'choose the model responsible for removing the background',
 			'background-remover-color': 'apply red, green blue and alpha values of the background',

--- a/facefusion/workflows/as_frames.py
+++ b/facefusion/workflows/as_frames.py
@@ -12,7 +12,6 @@ from facefusion.workflows.core import is_process_stopping
 
 
 def create_temp_frames() -> ErrorCode:
-	state_manager.set_item('output_video_fps', 25.0)  # TODO: set default fps value
 	source_audio_path = get_first(filter_audio_paths(state_manager.get_item('source_paths')))
 	output_image_resolution = scale_resolution(detect_image_resolution(state_manager.get_item('target_path')), state_manager.get_item('output_image_scale'))
 	temp_image_resolution = restrict_image_resolution(state_manager.get_item('target_path'), output_image_resolution)

--- a/tests/test_cli_lip_syncer.py
+++ b/tests/test_cli_lip_syncer.py
@@ -27,14 +27,14 @@ def before_each() -> None:
 
 
 def test_sync_lip_to_image() -> None:
-	commands = [ sys.executable, 'facefusion.py', 'run', '--workflow', 'audio-to-image:video', '--jobs-path', get_test_jobs_directory(), '--processors', 'lip_syncer', '-s', get_test_example_file('source.mp3'), '-t', get_test_example_file('target-240p.jpg'), '-o', get_test_output_path('test_sync_lip_to_image.mp4') ]
+	commands = [ sys.executable, 'facefusion.py', 'run', '--workflow', 'audio-to-image:video', '--jobs-path', get_test_jobs_directory(), '--processors', 'lip_syncer', '-s', get_test_example_file('source.mp3'), '-t', get_test_example_file('target-240p.jpg'), '-o', get_test_output_path('test_sync_lip_to_image.mp4'), '--output-video-fps', '25' ]
 
 	assert subprocess.run(commands).returncode == 0
 	assert is_test_output_file('test_sync_lip_to_image.mp4') is True
 
 
 def test_sync_lip_to_image_as_frames() -> None:
-	commands = [ sys.executable, 'facefusion.py', 'run', '--workflow', 'audio-to-image:frames', '--jobs-path', get_test_jobs_directory(), '--processors', 'lip_syncer', '-s', get_test_example_file('source.mp3'), '-t', get_test_example_file('target-240p.jpg'), '-o', get_test_output_path('test_sync_lip_to_image_as_frames') ]
+	commands = [ sys.executable, 'facefusion.py', 'run', '--workflow', 'audio-to-image:frames', '--jobs-path', get_test_jobs_directory(), '--processors', 'lip_syncer', '-s', get_test_example_file('source.mp3'), '-t', get_test_example_file('target-240p.jpg'), '-o', get_test_output_path('test_sync_lip_to_image_as_frames'), '--output-video-fps', '25' ]
 
 	assert subprocess.run(commands).returncode == 0
 	assert is_test_output_sequence(get_test_output_path('test_sync_lip_to_image_as_frames')) is True


### PR DESCRIPTION
Remove hardcoded fps and made ouput-video-fps mandatory for audio-to-image workflow