### PR TITLE
Sanitize Pipe to Direct Write

### DIFF
--- a/facefusion/apis/asset_helper.py
+++ b/facefusion/apis/asset_helper.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import queue
 import uuid
 from typing import List, Optional
 
@@ -10,8 +9,8 @@ import facefusion.choices
 from facefusion import ffmpeg, process_manager, state_manager
 from facefusion.audio import detect_audio_duration
 from facefusion.ffprobe import detect_audio_channel_total, detect_audio_frame_total, detect_audio_sample_rate
-from facefusion.filesystem import create_directory, get_file_extension, get_file_format, is_audio, is_image, is_video
-from facefusion.types import AudioMetadata, ImageMetadata, MediaType, UploadQueue, VideoMetadata
+from facefusion.filesystem import create_directory, get_file_extension, get_file_format, is_audio, is_image, is_video, remove_file
+from facefusion.types import AudioMetadata, ImageMetadata, MediaType, VideoMetadata
 from facefusion.vision import count_video_frame_total, detect_image_resolution, detect_video_duration, detect_video_fps, detect_video_resolution
 
 
@@ -84,42 +83,36 @@ def validate_asset_files(upload_files : List[UploadFile]) -> bool:
 	return True
 
 
-async def feed_upload_queue(upload_file : UploadFile, upload_queue : UploadQueue) -> None:
-	while file_chunk := await upload_file.read(1024):
-		upload_queue.put(file_chunk)
-	upload_queue.put(b'')
-
-
 async def save_asset_files(upload_files : List[UploadFile]) -> List[str]:
 	asset_paths : List[str] = []
 	api_security_strategy = state_manager.get_item('api_security_strategy')
 
 	for upload_file in upload_files:
-		file_format = get_file_format(upload_file.filename)
 		file_extension = get_file_extension(upload_file.filename)
-		media_type = detect_media_type_by_format(file_format)
+		media_type = detect_media_type_by_format(get_file_format(upload_file.filename))
 		temp_path = state_manager.get_temp_path()
 
 		create_directory(temp_path)
 
-		asset_file_name = uuid.uuid4().hex
-		asset_path = os.path.join(temp_path, asset_file_name + file_extension)
-		upload_queue : UploadQueue = queue.SimpleQueue()
+		upload_path = os.path.join(temp_path, uuid.uuid4().hex + file_extension)
+		asset_path = os.path.join(temp_path, uuid.uuid4().hex + file_extension)
+
+		with open(upload_path, 'wb') as upload_file_handle:
+			while file_chunk := await upload_file.read(1024):
+				upload_file_handle.write(file_chunk)
 
 		process_manager.start()
 
-		upload_task = asyncio.create_task(feed_upload_queue(upload_file, upload_queue))
-
-		if media_type == 'audio' and await asyncio.to_thread(ffmpeg.sanitize_audio, file_format, upload_queue.get, asset_path, api_security_strategy):
+		if media_type == 'audio' and await asyncio.to_thread(ffmpeg.sanitize_audio, upload_path, asset_path, api_security_strategy):
 			asset_paths.append(asset_path)
 
-		if media_type == 'image' and await asyncio.to_thread(ffmpeg.sanitize_image, file_format, upload_queue.get, asset_path):
+		if media_type == 'image' and await asyncio.to_thread(ffmpeg.sanitize_image, upload_path, asset_path):
 			asset_paths.append(asset_path)
 
-		if media_type == 'video' and await asyncio.to_thread(ffmpeg.sanitize_video, file_format, upload_queue.get, asset_path, api_security_strategy):
+		if media_type == 'video' and await asyncio.to_thread(ffmpeg.sanitize_video, upload_path, asset_path, api_security_strategy):
 			asset_paths.append(asset_path)
 
-		await upload_task
+		remove_file(upload_path)
 
 		process_manager.end()
 

--- a/facefusion/ffmpeg.py
+++ b/facefusion/ffmpeg.py
@@ -48,10 +48,6 @@ def update_progress(progress : tqdm, frame_number : int) -> None:
 def run_ffmpeg(commands : List[Command]) -> subprocess.Popen[bytes]:
 	commands = ffmpeg_builder.run(commands)
 	process = subprocess.Popen(commands, stderr = subprocess.PIPE, stdout = subprocess.PIPE)
-	return complete_process(process)
-
-
-def complete_process(process : subprocess.Popen[bytes]) -> subprocess.Popen[bytes]:
 	log_level = state_manager.get_item('log_level')
 
 	while process_manager.is_processing():

--- a/facefusion/ffmpeg.py
+++ b/facefusion/ffmpeg.py
@@ -10,7 +10,7 @@ import facefusion.choices
 from facefusion import ffmpeg_builder, logger, process_manager, state_manager, translator
 from facefusion.filesystem import get_file_format, remove_file
 from facefusion.temp_helper import get_temp_file_path, get_temp_frames_pattern
-from facefusion.types import ApiSecurityStrategy, AudioBuffer, AudioEncoder, Command, EncoderSet, Fps, MediaChunkReader, Resolution, UpdateProgress, VideoEncoder, VideoFormat
+from facefusion.types import ApiSecurityStrategy, AudioBuffer, AudioEncoder, Command, EncoderSet, Fps, Resolution, UpdateProgress, VideoEncoder, VideoFormat
 from facefusion.vision import detect_video_duration, detect_video_fps, pack_resolution, predict_video_frame_total
 
 
@@ -48,21 +48,6 @@ def update_progress(progress : tqdm, frame_number : int) -> None:
 def run_ffmpeg(commands : List[Command]) -> subprocess.Popen[bytes]:
 	commands = ffmpeg_builder.run(commands)
 	process = subprocess.Popen(commands, stderr = subprocess.PIPE, stdout = subprocess.PIPE)
-	return complete_process(process)
-
-
-def run_ffmpeg_with_pipe(commands : List[Command], media_chunk_reader : MediaChunkReader) -> subprocess.Popen[bytes]:
-	commands = ffmpeg_builder.run(commands)
-	process = subprocess.Popen(commands, stdin = subprocess.PIPE, stderr = subprocess.PIPE, stdout = subprocess.PIPE)
-
-	while media_chunk := media_chunk_reader():
-		if process.poll() is not None:
-			break
-		process.stdin.write(media_chunk)
-
-	if process.stdin and not process.stdin.closed:
-		process.stdin.close()
-
 	return complete_process(process)
 
 
@@ -308,44 +293,39 @@ def concat_video(output_path : str, temp_output_paths : List[str]) -> bool:
 	return process.returncode == 0
 
 
-def sanitize_audio(audio_format : str, media_chunk_reader : MediaChunkReader, asset_path : str, security_strategy : ApiSecurityStrategy) -> bool:
-	audio_pipe_format = ffmpeg_builder.resolve_audio_pipe_format(audio_format)
-
+def sanitize_audio(file_path : str, asset_path : str, security_strategy : ApiSecurityStrategy) -> bool:
 	if security_strategy == 'strict':
 		commands = ffmpeg_builder.chain(
-			ffmpeg_builder.pipe_input(audio_pipe_format),
+			ffmpeg_builder.set_input(file_path),
 			ffmpeg_builder.deep_copy_audio(),
 			ffmpeg_builder.strip_metadata(),
 			ffmpeg_builder.force_output(asset_path)
 		)
-		return run_ffmpeg_with_pipe(commands, media_chunk_reader).returncode == 0
+		return run_ffmpeg(commands).returncode == 0
 
 	commands = ffmpeg_builder.chain(
-		ffmpeg_builder.pipe_input(audio_pipe_format),
+		ffmpeg_builder.set_input(file_path),
 		ffmpeg_builder.copy_audio_encoder(),
 		ffmpeg_builder.strip_metadata(),
 		ffmpeg_builder.force_output(asset_path)
 	)
-	return run_ffmpeg_with_pipe(commands, media_chunk_reader).returncode == 0
+	return run_ffmpeg(commands).returncode == 0
 
 
-def sanitize_image(image_format : str, media_chunk_reader : MediaChunkReader, asset_path : str) -> bool:
-	image_pipe_format = ffmpeg_builder.resolve_image_pipe_format(image_format)
+def sanitize_image(file_path : str, asset_path : str) -> bool:
 	commands = ffmpeg_builder.chain(
-		ffmpeg_builder.pipe_image(image_pipe_format),
+		ffmpeg_builder.set_input(file_path),
 		ffmpeg_builder.deep_copy_image(),
 		ffmpeg_builder.strip_metadata(),
 		ffmpeg_builder.force_output(asset_path)
 	)
-	return run_ffmpeg_with_pipe(commands, media_chunk_reader).returncode == 0
+	return run_ffmpeg(commands).returncode == 0
 
 
-def sanitize_video(video_format : str, media_chunk_reader : MediaChunkReader, asset_path : str, security_strategy : ApiSecurityStrategy) -> bool:
-	video_pipe_format = ffmpeg_builder.resolve_video_pipe_format(video_format)
-
+def sanitize_video(file_path : str, asset_path : str, security_strategy : ApiSecurityStrategy) -> bool:
 	if security_strategy == 'strict':
 		commands = ffmpeg_builder.chain(
-			ffmpeg_builder.pipe_input(video_pipe_format),
+			ffmpeg_builder.set_input(file_path),
 			ffmpeg_builder.set_video_encoder('libx264'),
 			ffmpeg_builder.set_video_preset('libx264', 'ultrafast'),
 			ffmpeg_builder.set_pixel_format('libx264'),
@@ -354,16 +334,16 @@ def sanitize_video(video_format : str, media_chunk_reader : MediaChunkReader, as
 			ffmpeg_builder.strip_metadata(),
 			ffmpeg_builder.force_output(asset_path)
 		)
-		return run_ffmpeg_with_pipe(commands, media_chunk_reader).returncode == 0
+		return run_ffmpeg(commands).returncode == 0
 
 	commands = ffmpeg_builder.chain(
-		ffmpeg_builder.pipe_input(video_pipe_format),
+		ffmpeg_builder.set_input(file_path),
 		ffmpeg_builder.copy_video_encoder(),
 		ffmpeg_builder.copy_audio_encoder(),
 		ffmpeg_builder.strip_metadata(),
 		ffmpeg_builder.force_output(asset_path)
 	)
-	return run_ffmpeg_with_pipe(commands, media_chunk_reader).returncode == 0
+	return run_ffmpeg(commands).returncode == 0
 
 
 def fix_audio_encoder(video_format : VideoFormat, audio_encoder : AudioEncoder) -> AudioEncoder:

--- a/facefusion/ffmpeg_builder.py
+++ b/facefusion/ffmpeg_builder.py
@@ -47,14 +47,6 @@ def set_input(input_path : str) -> List[Command]:
 	return [ '-i', input_path ]
 
 
-def pipe_input(pipe_format : str) -> List[Command]:
-	return [ '-f', pipe_format, '-i', 'pipe:0' ]
-
-
-def pipe_image(image_format : str) -> List[Command]:
-	return [ '-f', 'image2pipe', '-c:v', image_format, '-i', 'pipe:0' ]
-
-
 def set_input_fps(input_fps : Fps) -> List[Command]:
 	return [ '-r', str(input_fps) ]
 
@@ -299,25 +291,3 @@ def map_qsv_preset(video_preset : VideoPreset) -> Optional[str]:
 	return None
 
 
-def resolve_audio_pipe_format(audio_format : str) -> str:
-	if audio_format == 'm4a':
-		return 'mp4'
-	if audio_format == 'opus':
-		return 'ogg'
-	return audio_format
-
-
-def resolve_image_pipe_format(image_format : str) -> str:
-	if image_format == 'jpeg':
-		return 'mjpeg'
-	return image_format
-
-
-def resolve_video_pipe_format(video_format : str) -> str:
-	if video_format == 'mkv':
-		return 'matroska'
-	if video_format == 'm4v':
-		return 'mp4'
-	if video_format == 'wmv':
-		return 'asf'
-	return video_format

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -1,4 +1,3 @@
-import queue
 from collections import namedtuple
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Literal, NotRequired, Optional, Tuple, TypeAlias, TypedDict, Union
@@ -363,8 +362,6 @@ DownloadSet : TypeAlias = Dict[str, Download]
 
 VideoMemoryStrategy = Literal['strict', 'moderate', 'tolerant']
 ApiSecurityStrategy = Literal['strict', 'moderate']
-UploadQueue : TypeAlias = queue.SimpleQueue[bytes]
-MediaChunkReader : TypeAlias = Callable[[], bytes]
 AppContext = Literal['cli', 'api']
 
 InferencePool : TypeAlias = Dict[str, InferenceSession]

--- a/tests/assert_helper.py
+++ b/tests/assert_helper.py
@@ -1,7 +1,5 @@
-import io
 import os
 import tempfile
-from functools import partial
 
 from facefusion.filesystem import are_images, create_directory, is_directory, is_file, remove_directory, resolve_file_paths
 from facefusion.types import JobStatus
@@ -48,8 +46,3 @@ def prepare_test_output_directory() -> bool:
 	remove_directory(test_outputs_directory)
 	create_directory(test_outputs_directory)
 	return is_directory(test_outputs_directory)
-
-
-def create_media_reader(file_path : str) -> partial[bytes]:
-	file_buffer = io.BytesIO(open(file_path, 'rb').read())
-	return partial(file_buffer.read, 1024)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -13,7 +13,7 @@ from facefusion.ffprobe import detect_audio_codec, detect_video_codec
 from facefusion.filesystem import copy_file, is_image
 from facefusion.temp_helper import clear_temp_directory, create_temp_directory, get_temp_file_path, resolve_temp_frame_paths
 from facefusion.types import EncoderSet
-from .assert_helper import create_media_reader, get_test_example_file, get_test_examples_directory, get_test_output_path, prepare_test_output_directory
+from .assert_helper import get_test_example_file, get_test_examples_directory, get_test_output_path, prepare_test_output_directory
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -226,10 +226,10 @@ def test_sanitize_audio() -> None:
 		get_test_output_path('test-sanitize-audio-moderate.wav')
 	]
 
-	assert sanitize_audio('wav', create_media_reader(file_path), output_paths[0], 'strict') is True
+	assert sanitize_audio(file_path, output_paths[0], 'strict') is True
 	assert detect_audio_codec(output_paths[0]) == 'mp3'
 
-	assert sanitize_audio('wav', create_media_reader(file_path), output_paths[1], 'moderate') is True
+	assert sanitize_audio(file_path, output_paths[1], 'moderate') is True
 	assert detect_audio_codec(output_paths[1]) == 'pcm_s16le'
 
 
@@ -237,7 +237,7 @@ def test_sanitize_image() -> None:
 	file_path = get_test_example_file('source.jpg')
 	output_path = get_test_output_path('test-sanitize-image.jpg')
 
-	assert sanitize_image('jpeg', create_media_reader(file_path), output_path) is True
+	assert sanitize_image(file_path, output_path) is True
 	assert is_image(output_path) is True
 
 
@@ -249,8 +249,8 @@ def test_sanitize_video() -> None:
 		get_test_output_path('test-sanitize-video-moderate.mp4')
 	]
 
-	assert sanitize_video('mp4', create_media_reader(file_path), output_paths[0], 'strict') is True
+	assert sanitize_video(file_path, output_paths[0], 'strict') is True
 	assert detect_video_codec(output_paths[0]) == 'h264'
 
-	assert sanitize_video('mp4', create_media_reader(file_path), output_paths[1], 'moderate') is True
+	assert sanitize_video(file_path, output_paths[1], 'moderate') is True
 	assert detect_video_codec(output_paths[1]) == 'hevc'


### PR DESCRIPTION
Simplify media sanitization by replacing the pipe-based streaming approach with direct file input, removing the chunk reader and queue machinery entirely. The sanitizers now derive the file format internally from the file path, eliminating the need for callers to pass format and chunk reader arguments.

## Benchmark

| Strategy | Magic Pipe (before) | Direct Write (after) | Delta |                                                                                                                      
  |----------|--------------|--------------|-------|
  | strict | 25.72s | 26.19s | +0.47s |                                                                                                                                    
  | moderate | 0.38s | 0.21s | -0.17s |