### PR TITLE
Add stream helper utilities and IVF frame iterator

### DIFF
--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -11,7 +11,7 @@ from starlette.types import Scope
 
 from facefusion.common_helper import is_linux, is_macos
 from facefusion.streamer import process_vision_frame
-from facefusion.types import Resolution, StreamFrame, WebSocketStreamMode
+from facefusion.types import Resolution, StreamBuffer, WebSocketStreamMode
 
 
 def process_stream_frame(target_stream_frame : VideoFrame) -> VideoFrame:
@@ -88,7 +88,7 @@ def read_pipe_buffer(pipe_handle : int, size : int) -> Optional[bytes]:
 	return None
 
 
-def forward_stream_frame(process : subprocess.Popen[bytes]) -> Iterator[StreamFrame]:
+def forward_stream_frame(process : subprocess.Popen[bytes]) -> Iterator[StreamBuffer]:
 	pipe_handle = process.stdout.fileno()
 
 	if is_linux() or is_macos():

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import os
 import subprocess
 from typing import Iterator, Optional, Tuple, cast
@@ -50,10 +51,10 @@ def on_video_track(rtc_connection : RTCPeerConnection, output_track : QueuedVide
 		asyncio.create_task(process_and_enqueue(target_track, output_track))
 
 
-def calculate_bitrate(resolution : Resolution) -> int:
+def calculate_bitrate(resolution : Resolution) -> int: # TODO : improve the bitrate calculation
 	pixel_total = resolution[0] * resolution[1]
-	bitrate_factor = 5000 / (1920 * 1080)
-	return max(400, round(pixel_total * bitrate_factor))
+	bitrate_factor = 3500 / math.sqrt(1920 * 1080)
+	return max(400, round(math.sqrt(pixel_total) * bitrate_factor))
 
 
 def calculate_buffer_size(resolution : Resolution) -> int:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import subprocess
-from typing import Iterator, Optional, Tuple
+from typing import Optional, Tuple, cast
 
 from aiortc import MediaStreamTrack, QueuedVideoStreamTrack, RTCPeerConnection, RTCRtpSender
 from aiortc.mediastreams import MediaStreamError
@@ -11,7 +11,7 @@ from starlette.types import Scope
 
 from facefusion.common_helper import is_linux, is_macos
 from facefusion.streamer import process_vision_frame
-from facefusion.types import Resolution, WebSocketStreamMode
+from facefusion.types import FrameStream, Resolution, WebSocketStreamMode
 
 
 def process_stream_frame(target_stream_frame : VideoFrame) -> VideoFrame:
@@ -52,30 +52,12 @@ def on_video_track(rtc_connection : RTCPeerConnection, output_track : QueuedVide
 
 def calculate_bitrate(resolution : Resolution) -> int:
 	pixel_total = resolution[0] * resolution[1]
-
-	if pixel_total > 1920 * 1080:
-		return 5000
-	if pixel_total > 1280 * 720:
-		return 3500
-	if pixel_total > 640 * 480:
-		return 2000
-	if pixel_total > 320 * 240:
-		return 1000
-	return 400
+	bitrate_factor = 5000 / (1920 * 1080)
+	return max(400, round(pixel_total * bitrate_factor))
 
 
 def calculate_buffer_size(resolution : Resolution) -> int:
-	pixel_total = resolution[0] * resolution[1]
-
-	if pixel_total > 1920 * 1080:
-		return 10000
-	if pixel_total > 1280 * 720:
-		return 7000
-	if pixel_total > 640 * 480:
-		return 4000
-	if pixel_total > 320 * 240:
-		return 2000
-	return 800
+	return calculate_bitrate(resolution) * 2
 
 
 def get_stream_mode(scope : Scope) -> Optional[WebSocketStreamMode]:
@@ -86,7 +68,7 @@ def get_stream_mode(scope : Scope) -> Optional[WebSocketStreamMode]:
 			protocol = protocol.strip()
 
 			if protocol in [ 'image', 'video' ]:
-				return protocol #type:ignore[return-value]
+				return cast(WebSocketStreamMode, protocol)
 
 	return None
 
@@ -106,7 +88,7 @@ def read_pipe_buffer(pipe_handle : int, size : int) -> Optional[bytes]:
 	return None
 
 
-def iter_video_frames(process : subprocess.Popen[bytes]) -> Iterator[bytes]:
+def stream_frames(process : subprocess.Popen[bytes]) -> FrameStream:
 	pipe_handle = process.stdout.fileno()
 
 	if is_linux() or is_macos():

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import subprocess
-from typing import Optional, Tuple, cast
+from typing import Iterator, Optional, Tuple, cast
 
 from aiortc import MediaStreamTrack, QueuedVideoStreamTrack, RTCPeerConnection, RTCRtpSender
 from aiortc.mediastreams import MediaStreamError
@@ -11,7 +11,7 @@ from starlette.types import Scope
 
 from facefusion.common_helper import is_linux, is_macos
 from facefusion.streamer import process_vision_frame
-from facefusion.types import FrameStream, Resolution, WebSocketStreamMode
+from facefusion.types import Resolution, StreamFrame, WebSocketStreamMode
 
 
 def process_stream_frame(target_stream_frame : VideoFrame) -> VideoFrame:
@@ -60,15 +60,15 @@ def calculate_buffer_size(resolution : Resolution) -> int:
 	return calculate_bitrate(resolution) * 2
 
 
-def get_stream_mode(scope : Scope) -> Optional[WebSocketStreamMode]:
+def get_websocket_stream_mode(scope : Scope) -> Optional[WebSocketStreamMode]:
 	protocol_header = Headers(scope = scope).get('Sec-WebSocket-Protocol')
 
 	if protocol_header:
 		for protocol in protocol_header.split(','):
-			protocol = protocol.strip()
+			websocket_stream_mode = protocol.strip()
 
-			if protocol in [ 'image', 'video' ]:
-				return cast(WebSocketStreamMode, protocol)
+			if websocket_stream_mode in [ 'image', 'video' ]:
+				return cast(WebSocketStreamMode, websocket_stream_mode)
 
 	return None
 
@@ -88,7 +88,7 @@ def read_pipe_buffer(pipe_handle : int, size : int) -> Optional[bytes]:
 	return None
 
 
-def stream_frames(process : subprocess.Popen[bytes]) -> FrameStream:
+def forward_stream_frame(process : subprocess.Popen[bytes]) -> Iterator[StreamFrame]:
 	pipe_handle = process.stdout.fileno()
 
 	if is_linux() or is_macos():

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,11 +1,17 @@
 import asyncio
-from typing import Tuple
+import os
+import subprocess
+from typing import Iterator, Optional, Tuple
 
 from aiortc import MediaStreamTrack, QueuedVideoStreamTrack, RTCPeerConnection, RTCRtpSender
 from aiortc.mediastreams import MediaStreamError
 from av import VideoFrame
+from starlette.datastructures import Headers
+from starlette.types import Scope
 
+from facefusion.common_helper import is_linux, is_macos
 from facefusion.streamer import process_vision_frame
+from facefusion.types import Resolution, WebSocketStreamMode
 
 
 def process_stream_frame(target_stream_frame : VideoFrame) -> VideoFrame:
@@ -42,3 +48,80 @@ def on_video_track(rtc_connection : RTCPeerConnection, output_track : QueuedVide
 
 	if target_track.kind == 'video':
 		asyncio.create_task(process_and_enqueue(target_track, output_track))
+
+
+def calculate_bitrate(resolution : Resolution) -> int:
+	pixel_total = resolution[0] * resolution[1]
+
+	if pixel_total > 1920 * 1080:
+		return 5000
+	if pixel_total > 1280 * 720:
+		return 3500
+	if pixel_total > 640 * 480:
+		return 2000
+	if pixel_total > 320 * 240:
+		return 1000
+	return 400
+
+
+def calculate_buffer_size(resolution : Resolution) -> int:
+	pixel_total = resolution[0] * resolution[1]
+
+	if pixel_total > 1920 * 1080:
+		return 10000
+	if pixel_total > 1280 * 720:
+		return 7000
+	if pixel_total > 640 * 480:
+		return 4000
+	if pixel_total > 320 * 240:
+		return 2000
+	return 800
+
+
+def get_stream_mode(scope : Scope) -> Optional[WebSocketStreamMode]:
+	protocol_header = Headers(scope = scope).get('Sec-WebSocket-Protocol')
+
+	if protocol_header:
+		for protocol in protocol_header.split(','):
+			protocol = protocol.strip()
+
+			if protocol in [ 'image', 'video' ]:
+				return protocol #type:ignore[return-value]
+
+	return None
+
+
+def read_pipe_buffer(pipe_handle : int, size : int) -> Optional[bytes]:
+	byte_buffer = bytearray()
+	frame_data = os.read(pipe_handle, size - len(byte_buffer))
+
+	while frame_data:
+		byte_buffer += frame_data
+
+		if len(byte_buffer) == size:
+			return bytes(byte_buffer)
+
+		frame_data = os.read(pipe_handle, size - len(byte_buffer))
+
+	return None
+
+
+def iter_video_frames(process : subprocess.Popen[bytes]) -> Iterator[bytes]:
+	pipe_handle = process.stdout.fileno()
+
+	if is_linux() or is_macos():
+		os.set_blocking(pipe_handle, True)
+
+	header = read_pipe_buffer(pipe_handle, 32)
+
+	if header:
+		frame_header = read_pipe_buffer(pipe_handle, 12)
+
+		while frame_header:
+			frame_size = int.from_bytes(frame_header[0:4], 'little')
+			frame_data = read_pipe_buffer(pipe_handle, frame_size)
+
+			if frame_data:
+				yield frame_data
+
+			frame_header = read_pipe_buffer(pipe_handle, 12)

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -83,7 +83,6 @@ AudioBuffer : TypeAlias = bytes
 Audio : TypeAlias = NDArray[Any]
 AudioChunk : TypeAlias = NDArray[Any]
 AudioFrame : TypeAlias = NDArray[Any]
-StreamFrame : TypeAlias = bytes
 Spectrogram : TypeAlias = NDArray[Any]
 Mel : TypeAlias = NDArray[Any]
 MelFilterBank : TypeAlias = NDArray[Any]
@@ -266,6 +265,7 @@ BenchmarkCycleSet = TypedDict('BenchmarkCycleSet',
 WebcamMode = Literal['inline', 'udp', 'v4l2']
 StreamMode = Literal['udp', 'v4l2']
 WebSocketStreamMode = Literal['image', 'video']
+StreamBuffer : TypeAlias = bytes
 
 RtcOfferSet = TypedDict('RtcOfferSet',
 {

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -264,6 +264,7 @@ BenchmarkCycleSet = TypedDict('BenchmarkCycleSet',
 
 WebcamMode = Literal['inline', 'udp', 'v4l2']
 StreamMode = Literal['udp', 'v4l2']
+WebSocketStreamMode = Literal['image', 'video']
 
 RtcOfferSet = TypedDict('RtcOfferSet',
 {

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Literal, NotRequired, Optional, Tuple, TypeAlias, TypedDict, Union
+from typing import Any, Callable, Dict, Generator, List, Literal, NotRequired, Optional, Tuple, TypeAlias, TypedDict, Union
 
 import cv2
 import numpy
@@ -265,6 +265,7 @@ BenchmarkCycleSet = TypedDict('BenchmarkCycleSet',
 WebcamMode = Literal['inline', 'udp', 'v4l2']
 StreamMode = Literal['udp', 'v4l2']
 WebSocketStreamMode = Literal['image', 'video']
+FrameStream : TypeAlias = Generator[bytes, None, None]
 
 RtcOfferSet = TypedDict('RtcOfferSet',
 {

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from datetime import datetime
-from typing import Any, Callable, Dict, Generator, List, Literal, NotRequired, Optional, Tuple, TypeAlias, TypedDict, Union
+from typing import Any, Callable, Dict, List, Literal, NotRequired, Optional, Tuple, TypeAlias, TypedDict, Union
 
 import cv2
 import numpy
@@ -83,6 +83,7 @@ AudioBuffer : TypeAlias = bytes
 Audio : TypeAlias = NDArray[Any]
 AudioChunk : TypeAlias = NDArray[Any]
 AudioFrame : TypeAlias = NDArray[Any]
+StreamFrame : TypeAlias = bytes
 Spectrogram : TypeAlias = NDArray[Any]
 Mel : TypeAlias = NDArray[Any]
 MelFilterBank : TypeAlias = NDArray[Any]
@@ -265,7 +266,6 @@ BenchmarkCycleSet = TypedDict('BenchmarkCycleSet',
 WebcamMode = Literal['inline', 'udp', 'v4l2']
 StreamMode = Literal['udp', 'v4l2']
 WebSocketStreamMode = Literal['image', 'video']
-FrameStream : TypeAlias = Generator[bytes, None, None]
 
 RtcOfferSet = TypedDict('RtcOfferSet',
 {

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -15,19 +15,19 @@ def make_scope(protocol : str) -> dict[str, object]:
 
 
 def test_calculate_bitrate() -> None:
-	assert calculate_bitrate((320, 240)) == 400
-	assert calculate_bitrate((640, 480)) == 741
-	assert calculate_bitrate((1280, 720)) == 2222
-	assert calculate_bitrate((1920, 1080)) == 5000
-	assert calculate_bitrate((3840, 2160)) == 20000
+	assert calculate_bitrate((320, 240)) == 674
+	assert calculate_bitrate((640, 480)) == 1347
+	assert calculate_bitrate((1280, 720)) == 2333
+	assert calculate_bitrate((1920, 1080)) == 3500
+	assert calculate_bitrate((3840, 2160)) == 7000
 
 
 def test_calculate_buffer_size() -> None:
-	assert calculate_buffer_size((320, 240)) == 800
-	assert calculate_buffer_size((640, 480)) == 1482
-	assert calculate_buffer_size((1280, 720)) == 4444
-	assert calculate_buffer_size((1920, 1080)) == 10000
-	assert calculate_buffer_size((3840, 2160)) == 40000
+	assert calculate_buffer_size((320, 240)) == 1348
+	assert calculate_buffer_size((640, 480)) == 2694
+	assert calculate_buffer_size((1280, 720)) == 4666
+	assert calculate_buffer_size((1920, 1080)) == 7000
+	assert calculate_buffer_size((3840, 2160)) == 14000
 
 
 def test_get_websocket_stream_mode() -> None:

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -4,7 +4,7 @@ import subprocess
 from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, get_stream_mode, iter_video_frames, read_pipe_buffer
 
 
-def make_scope(protocol : str) -> dict:
+def make_scope(protocol : str) -> dict[str, object]:
 	return\
 	{
 		'type': 'websocket',

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
 
+from facefusion import ffmpeg_builder
 from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, forward_stream_frame, get_websocket_stream_mode, read_pipe_buffer
+from facefusion.vision import pack_resolution
 
 
 def make_scope(protocol : str) -> dict[str, object]:
@@ -46,27 +48,22 @@ def test_read_pipe_buffer() -> None:
 
 
 def test_forward_frames() -> None:
-	encoder = subprocess.Popen(
-	[
-		'ffmpeg',
-		'-loglevel', 'error',
-		'-f', 'rawvideo',
-		'-pix_fmt', 'rgb24',
-		'-s', '320x240',
-		'-r', '30',
-		'-i', '-',
-		'-c:v', 'libvpx',
-		'-deadline', 'realtime',
-		'-b:v', '400k',
-		'-an', '-f',
-		'ivf', '-'
-	], stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
-
-	frame_size = 320 * 240 * 3
+	resolution = (320, 240)
+	frame_size = resolution[0] * resolution[1] * 3
+	commands = ffmpeg_builder.run(ffmpeg_builder.chain(
+		ffmpeg_builder.capture_video(),
+		ffmpeg_builder.set_media_resolution(pack_resolution(resolution)),
+		ffmpeg_builder.set_input_fps(30),
+		ffmpeg_builder.set_input('-'),
+		ffmpeg_builder.set_video_encoder('libvpx'),
+		ffmpeg_builder.set_encoder_deadline('realtime'),
+		ffmpeg_builder.set_stream_quality(400),
+		ffmpeg_builder.set_muxer('ivf'),
+		ffmpeg_builder.set_output('-')
+	))
+	encoder = subprocess.Popen(commands, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
 	encoder.stdin.write(bytes(frame_size))
 	encoder.stdin.close()
 
-	stream_frames = list(forward_stream_frame(encoder))
-
-	assert len(stream_frames) == 1
-	assert all(0 < len(frame) < frame_size for frame in stream_frames)
+	for stream_buffer in forward_stream_frame(encoder):
+		assert 0 < len(stream_buffer) < frame_size

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, get_stream_mode, read_pipe_buffer, stream_frames
+from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, forward_stream_frame, get_websocket_stream_mode, read_pipe_buffer
 
 
 def make_scope(protocol : str) -> dict[str, object]:
@@ -28,9 +28,9 @@ def test_calculate_buffer_size() -> None:
 	assert calculate_buffer_size((3840, 2160)) == 40000
 
 
-def test_get_stream_mode() -> None:
-	assert get_stream_mode(make_scope('image')) == 'image'
-	assert get_stream_mode(make_scope('video')) == 'video'
+def test_get_websocket_stream_mode() -> None:
+	assert get_websocket_stream_mode(make_scope('image')) == 'image'
+	assert get_websocket_stream_mode(make_scope('video')) == 'video'
 
 
 def test_read_pipe_buffer() -> None:
@@ -45,7 +45,7 @@ def test_read_pipe_buffer() -> None:
 	os.close(read_fd)
 
 
-def test_stream_frames() -> None:
+def test_forward_frames() -> None:
 	encoder = subprocess.Popen(
 	[
 		'ffmpeg',
@@ -66,7 +66,7 @@ def test_stream_frames() -> None:
 	encoder.stdin.write(bytes(frame_size))
 	encoder.stdin.close()
 
-	frames_received = list(stream_frames(encoder))
+	frames_received = list(forward_stream_frame(encoder))
 
 	assert len(frames_received) > 0
 	assert all(isinstance(frame, bytes) for frame in frames_received)

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+
+from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, get_stream_mode, iter_video_frames, read_pipe_buffer
+
+
+def make_scope(protocol : str) -> dict:
+	return\
+	{
+		'type': 'websocket',
+		'headers': [ (b'sec-websocket-protocol', protocol.encode()) ]
+	}
+
+
+def test_calculate_bitrate() -> None:
+	assert calculate_bitrate((320, 240)) == 400
+	assert calculate_bitrate((640, 480)) == 1000
+	assert calculate_bitrate((1280, 720)) == 2000
+	assert calculate_bitrate((1920, 1080)) == 3500
+	assert calculate_bitrate((3840, 2160)) == 5000
+
+
+def test_calculate_buffer_size() -> None:
+	assert calculate_buffer_size((320, 240)) == 800
+	assert calculate_buffer_size((640, 480)) == 2000
+	assert calculate_buffer_size((1280, 720)) == 4000
+	assert calculate_buffer_size((1920, 1080)) == 7000
+	assert calculate_buffer_size((3840, 2160)) == 10000
+
+
+def test_get_stream_mode() -> None:
+	assert get_stream_mode(make_scope('image')) == 'image'
+	assert get_stream_mode(make_scope('video')) == 'video'
+
+
+def test_read_pipe_buffer() -> None:
+	read_fd, write_fd = os.pipe()
+	os.write(write_fd, b'abcdefgh')
+	os.close(write_fd)
+
+	assert read_pipe_buffer(read_fd, 4) == b'abcd'
+	assert read_pipe_buffer(read_fd, 4) == b'efgh'
+	assert read_pipe_buffer(read_fd, 1) is None
+
+	os.close(read_fd)
+
+
+def test_iter_video_frames() -> None:
+	encoder = subprocess.Popen(
+	[
+		'ffmpeg',
+		'-loglevel', 'error',
+		'-f', 'rawvideo',
+		'-pix_fmt', 'rgb24',
+		'-s', '320x240',
+		'-r', '30',
+		'-i', '-',
+		'-c:v', 'libvpx',
+		'-deadline', 'realtime',
+		'-b:v', '400k',
+		'-an', '-f',
+		'ivf', '-'
+	], stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+
+	frame_size = 320 * 240 * 3
+	encoder.stdin.write(bytes(frame_size))
+	encoder.stdin.close()
+
+	frames_received = list(iter_video_frames(encoder))
+
+	assert len(frames_received) > 0
+	assert all(isinstance(frame, bytes) for frame in frames_received)

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -66,7 +66,7 @@ def test_forward_frames() -> None:
 	encoder.stdin.write(bytes(frame_size))
 	encoder.stdin.close()
 
-	frames_received = list(forward_stream_frame(encoder))
+	stream_frames = list(forward_stream_frame(encoder))
 
-	assert len(frames_received) > 0
-	assert all(isinstance(frame, bytes) for frame in frames_received)
+	assert len(stream_frames) == 1
+	assert all(0 < len(frame) < frame_size for frame in stream_frames)

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, get_stream_mode, iter_video_frames, read_pipe_buffer
+from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, get_stream_mode, stream_frames, read_pipe_buffer
 
 
 def make_scope(protocol : str) -> dict[str, object]:
@@ -14,18 +14,18 @@ def make_scope(protocol : str) -> dict[str, object]:
 
 def test_calculate_bitrate() -> None:
 	assert calculate_bitrate((320, 240)) == 400
-	assert calculate_bitrate((640, 480)) == 1000
-	assert calculate_bitrate((1280, 720)) == 2000
-	assert calculate_bitrate((1920, 1080)) == 3500
-	assert calculate_bitrate((3840, 2160)) == 5000
+	assert calculate_bitrate((640, 480)) == 741
+	assert calculate_bitrate((1280, 720)) == 2222
+	assert calculate_bitrate((1920, 1080)) == 5000
+	assert calculate_bitrate((3840, 2160)) == 20000
 
 
 def test_calculate_buffer_size() -> None:
 	assert calculate_buffer_size((320, 240)) == 800
-	assert calculate_buffer_size((640, 480)) == 2000
-	assert calculate_buffer_size((1280, 720)) == 4000
-	assert calculate_buffer_size((1920, 1080)) == 7000
-	assert calculate_buffer_size((3840, 2160)) == 10000
+	assert calculate_buffer_size((640, 480)) == 1482
+	assert calculate_buffer_size((1280, 720)) == 4444
+	assert calculate_buffer_size((1920, 1080)) == 10000
+	assert calculate_buffer_size((3840, 2160)) == 40000
 
 
 def test_get_stream_mode() -> None:
@@ -45,7 +45,7 @@ def test_read_pipe_buffer() -> None:
 	os.close(read_fd)
 
 
-def test_iter_video_frames() -> None:
+def test_stream_frames() -> None:
 	encoder = subprocess.Popen(
 	[
 		'ffmpeg',
@@ -66,7 +66,7 @@ def test_iter_video_frames() -> None:
 	encoder.stdin.write(bytes(frame_size))
 	encoder.stdin.close()
 
-	frames_received = list(iter_video_frames(encoder))
+	frames_received = list(stream_frames(encoder))
 
 	assert len(frames_received) > 0
 	assert all(isinstance(frame, bytes) for frame in frames_received)

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, get_stream_mode, stream_frames, read_pipe_buffer
+from facefusion.apis.stream_helper import calculate_bitrate, calculate_buffer_size, get_stream_mode, read_pipe_buffer, stream_frames
 
 
 def make_scope(protocol : str) -> dict[str, object]:


### PR DESCRIPTION
  - Add calculate_bitrate and calculate_buffer_size for resolution-based VP8 encoder tuning                                                                                                                                                                              
  - Add get_stream_mode to extract WebSocket protocol (image / video) from connection scope                                                                                                                                                                              
  - Add read_pipe_buffer for exact-size blocking reads from a pipe file descriptor                                                                                                                                                                                       
  - Add iter_video_frames — generator that parses IVF container output and yields encoded VP8 frames                                                                                                                                                                     