### PR TITLE
Refine RTC bindings: callback-based SDP negotiation, peer state tracking, and type cleanup

### DIFF
--- a/facefusion/datachannel.py
+++ b/facefusion/datachannel.py
@@ -138,4 +138,16 @@ def init_ctypes(datachannel_library : ctypes.CDLL) -> ctypes.CDLL:
 
 	datachannel_library.rtcSetOpusPacketizer.restype = ctypes.c_int
 
+	datachannel_library.rtcSetUserPointer.argtypes = [ ctypes.c_int, ctypes.c_void_p ]
+	datachannel_library.rtcSetUserPointer.restype = None
+
+	datachannel_library.rtcSetLocalDescriptionCallback.argtypes = [ ctypes.c_int, ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_void_p) ]
+	datachannel_library.rtcSetLocalDescriptionCallback.restype = ctypes.c_int
+
+	datachannel_library.rtcSetGatheringStateChangeCallback.argtypes = [ ctypes.c_int, ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p) ]
+	datachannel_library.rtcSetGatheringStateChangeCallback.restype = ctypes.c_int
+
+	datachannel_library.rtcSetStateChangeCallback.argtypes = [ ctypes.c_int, ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p) ]
+	datachannel_library.rtcSetStateChangeCallback.restype = ctypes.c_int
+
 	return datachannel_library

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -1,10 +1,11 @@
 import ctypes
+import threading
 import time
 from typing import List, Optional
 
 from facefusion.datachannel import create_rtc_configuration, create_rtc_packetizer_init, create_static_datachannel_library, create_static_download_set
 from facefusion.download import conditional_download_hashes, conditional_download_sources
-from facefusion.types import MediaDirection, PeerConnection, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer
+from facefusion.types import MediaDirection, PeerConnectionId, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer
 
 
 def pre_check() -> bool:
@@ -27,7 +28,7 @@ def create_peer_connection(
 	port_range_begin : int = 0,
 	port_range_end : int = 0,
 	max_packet_size : int = 0,
-	max_message_size : int = 0) -> PeerConnection:
+	max_message_size : int = 0) -> PeerConnectionId:
 
 	datachannel_library = create_static_datachannel_library()
 	rtc_configuration = create_rtc_configuration()
@@ -62,7 +63,7 @@ def build_media_description(media_type : str, payload_type : int, rtp_codec : st
 	]).encode()
 
 
-def add_audio_track(peer_connection : PeerConnection, media_direction : MediaDirection) -> RtcAudioTrack:
+def add_audio_track(peer_connection : PeerConnectionId, media_direction : MediaDirection) -> RtcAudioTrack:
 	datachannel_library = create_static_datachannel_library()
 	media_description = build_media_description('audio', 111, 'opus/48000/2', media_direction, 1)
 
@@ -80,7 +81,7 @@ def add_audio_track(peer_connection : PeerConnection, media_direction : MediaDir
 	return audio_track
 
 
-def add_video_track(peer_connection : PeerConnection, media_direction : MediaDirection) -> RtcVideoTrack:
+def add_video_track(peer_connection : PeerConnectionId, media_direction : MediaDirection) -> RtcVideoTrack:
 	datachannel_library = create_static_datachannel_library()
 	media_description = build_media_description('video', 96, 'VP8/90000', media_direction, 0)
 
@@ -100,7 +101,7 @@ def add_video_track(peer_connection : PeerConnection, media_direction : MediaDir
 	return video_track
 
 
-def create_sdp(peer_connection : PeerConnection) -> Optional[SdpOffer]:
+def create_sdp(peer_connection : PeerConnectionId) -> Optional[SdpOffer]:
 	datachannel_library = create_static_datachannel_library()
 	datachannel_library.rtcSetLocalDescription(peer_connection, b'offer')
 	buffer_size = 16384
@@ -112,22 +113,46 @@ def create_sdp(peer_connection : PeerConnection) -> Optional[SdpOffer]:
 	return None
 
 
-def negotiate_sdp(peer_connection : PeerConnection, sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
-	datachannel_library = create_static_datachannel_library()
-	datachannel_library.rtcSetRemoteDescription(peer_connection, sdp_offer.encode(), b'offer')
-	buffer_size = 16384
-	buffer_string = ctypes.create_string_buffer(buffer_size)
-	wait_limit = time.monotonic() + 5
+@ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_void_p)
+def on_sdp_ready(peer_connection : int, sdp : Optional[bytes], sdp_type : int, user_pointer : Optional[int]) -> None:
+	ctypes.cast(user_pointer, ctypes.py_object).value.set()
 
-	while time.monotonic() < wait_limit:
-		if datachannel_library.rtcGetLocalDescription(peer_connection, buffer_string, buffer_size) > 0:
-			return buffer_string.value.decode()
-		time.sleep(0.05)
+
+@ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
+def on_gathering_complete(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
+	if state == 2:
+		context = ctypes.cast(user_pointer, ctypes.py_object).value
+		context['event'].set()
+
+
+@ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
+def on_state_change(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
+	if state in (4, 5):
+		peer = ctypes.cast(user_pointer, ctypes.py_object).value
+		peer['connected'] = False
+
+
+def negotiate_sdp(peer_connection : PeerConnectionId, sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
+	datachannel_library = create_static_datachannel_library()
+	sdp_event = threading.Event()
+	sdp_event_pointer = ctypes.cast(id(sdp_event), ctypes.c_void_p)
+
+	datachannel_library.rtcSetUserPointer(peer_connection, sdp_event_pointer)
+	datachannel_library.rtcSetLocalDescriptionCallback(peer_connection, on_sdp_ready)
+	datachannel_library.rtcSetRemoteDescription(peer_connection, sdp_offer.encode(), b'offer')
+	sdp_event.wait(timeout = 5)
+
+	sdp_buffer_size = 16384
+	sdp_buffer = ctypes.create_string_buffer(sdp_buffer_size)
+
+	if datachannel_library.rtcGetLocalDescription(peer_connection, sdp_buffer, sdp_buffer_size) > 0:
+		return sdp_buffer.value.decode()
 
 	return None
 
 
 def handle_whep_offer(peers : List[RtcPeer], sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
+	datachannel_library = create_static_datachannel_library()
 	peer_connection = create_peer_connection()
 	audio_track = add_audio_track(peer_connection, 'sendonly')
 	video_track = add_video_track(peer_connection, 'sendonly')
@@ -136,10 +161,14 @@ def handle_whep_offer(peers : List[RtcPeer], sdp_offer : SdpOffer) -> Optional[S
 	if local_sdp:
 		rtc_peer : RtcPeer =\
 		{
-			'peer_connection': peer_connection,
+			'peer_connection_id': peer_connection,
 			'video_track': video_track,
-			'audio_track': audio_track
+			'audio_track': audio_track,
+			'connected': True
 		}
+		peer_pointer = ctypes.cast(id(rtc_peer), ctypes.c_void_p)
+		datachannel_library.rtcSetUserPointer(peer_connection, peer_pointer)
+		datachannel_library.rtcSetStateChangeCallback(peer_connection, on_state_change)
 		peers.append(rtc_peer)
 
 	return local_sdp
@@ -167,7 +196,7 @@ def delete_peers(peers : List[RtcPeer]) -> None:
 	datachannel_library = create_static_datachannel_library()
 
 	for rtc_peer in peers:
-		peer_connection_id = rtc_peer.get('peer_connection')
+		peer_connection_id = rtc_peer.get('peer_connection_id')
 
 		if peer_connection_id:
 			datachannel_library.rtcDeletePeerConnection(peer_connection_id)
@@ -175,13 +204,9 @@ def delete_peers(peers : List[RtcPeer]) -> None:
 	peers.clear()
 
 
-def is_peer_connected(peers : List[RtcPeer]) -> bool:
-	datachannel_library = create_static_datachannel_library()
-
+def has_connected_peer(peers : List[RtcPeer]) -> bool:
 	for rtc_peer in peers:
-		video_track_id = rtc_peer.get('video_track')
-
-		if video_track_id and datachannel_library.rtcIsOpen(video_track_id):
+		if rtc_peer.get('connected'):
 			return True
 
 	return False

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -119,17 +119,10 @@ def on_sdp_ready(peer_connection : int, sdp : Optional[bytes], sdp_type : int, u
 
 
 @ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
-def on_ice_gathering_complete(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
+def on_ice_complete(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
 	if state == 2:
 		context = ctypes.cast(user_pointer, ctypes.py_object).value
 		context['event'].set()
-
-
-@ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
-def on_peer_connection_lost(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
-	if state in (4, 5):
-		peer = ctypes.cast(user_pointer, ctypes.py_object).value
-		peer['connected'] = False
 
 
 def negotiate_sdp(peer_connection : PeerConnection, sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
@@ -151,38 +144,15 @@ def negotiate_sdp(peer_connection : PeerConnection, sdp_offer : SdpOffer) -> Opt
 	return None
 
 
-def handle_whep_offer(peers : List[RtcPeer], sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
-	datachannel_library = create_static_datachannel_library()
-	peer_connection = create_peer_connection()
-	audio_track = add_audio_track(peer_connection, 'sendonly')
-	video_track = add_video_track(peer_connection, 'sendonly')
-	local_sdp = negotiate_sdp(peer_connection, sdp_offer)
-
-	if local_sdp:
-		rtc_peer : RtcPeer =\
-		{
-			'peer_connection': peer_connection,
-			'video_track': video_track,
-			'audio_track': audio_track,
-			'connected': True
-		}
-		peer_pointer = ctypes.cast(id(rtc_peer), ctypes.c_void_p)
-		datachannel_library.rtcSetUserPointer(peer_connection, peer_pointer)
-		datachannel_library.rtcSetStateChangeCallback(peer_connection, on_peer_connection_lost)
-		peers.append(rtc_peer)
-
-	return local_sdp
-
-
-def send_to_peers(peers : List[RtcPeer], data : bytes) -> None:
+def send_to_peers(rtc_peers : List[RtcPeer], data : bytes) -> None:
 	datachannel_library = create_static_datachannel_library()
 
-	if peers:
+	if rtc_peers:
 		timestamp = int(time.monotonic() * 90000) & 0xFFFFFFFF
 		data_buffer = ctypes.create_string_buffer(data)
 		data_total = len(data)
 
-		for rtc_peer in peers:
+		for rtc_peer in rtc_peers:
 			video_track_id = rtc_peer.get('video_track')
 
 			if video_track_id and datachannel_library.rtcIsOpen(video_track_id):
@@ -192,21 +162,13 @@ def send_to_peers(peers : List[RtcPeer], data : bytes) -> None:
 	return None
 
 
-def delete_peers(peers : List[RtcPeer]) -> None:
+def delete_peers(rtc_peers : List[RtcPeer]) -> None:
 	datachannel_library = create_static_datachannel_library()
 
-	for rtc_peer in peers:
+	for rtc_peer in rtc_peers:
 		peer_connection_id = rtc_peer.get('peer_connection')
 
 		if peer_connection_id:
 			datachannel_library.rtcDeletePeerConnection(peer_connection_id)
 
-	peers.clear()
-
-
-def has_connected_peer(peers : List[RtcPeer]) -> bool:
-	for rtc_peer in peers:
-		if rtc_peer.get('connected'):
-			return True
-
-	return False
+	return None

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from facefusion.datachannel import create_rtc_configuration, create_rtc_packetizer_init, create_static_datachannel_library, create_static_download_set
 from facefusion.download import conditional_download_hashes, conditional_download_sources
-from facefusion.types import MediaDirection, PeerConnectionId, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer
+from facefusion.types import MediaDirection, PeerConnection, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer
 
 
 def pre_check() -> bool:
@@ -28,7 +28,7 @@ def create_peer_connection(
 	port_range_begin : int = 0,
 	port_range_end : int = 0,
 	max_packet_size : int = 0,
-	max_message_size : int = 0) -> PeerConnectionId:
+	max_message_size : int = 0) -> PeerConnection:
 
 	datachannel_library = create_static_datachannel_library()
 	rtc_configuration = create_rtc_configuration()
@@ -63,7 +63,7 @@ def build_media_description(media_type : str, payload_type : int, rtp_codec : st
 	]).encode()
 
 
-def add_audio_track(peer_connection : PeerConnectionId, media_direction : MediaDirection) -> RtcAudioTrack:
+def add_audio_track(peer_connection : PeerConnection, media_direction : MediaDirection) -> RtcAudioTrack:
 	datachannel_library = create_static_datachannel_library()
 	media_description = build_media_description('audio', 111, 'opus/48000/2', media_direction, 1)
 
@@ -81,7 +81,7 @@ def add_audio_track(peer_connection : PeerConnectionId, media_direction : MediaD
 	return audio_track
 
 
-def add_video_track(peer_connection : PeerConnectionId, media_direction : MediaDirection) -> RtcVideoTrack:
+def add_video_track(peer_connection : PeerConnection, media_direction : MediaDirection) -> RtcVideoTrack:
 	datachannel_library = create_static_datachannel_library()
 	media_description = build_media_description('video', 96, 'VP8/90000', media_direction, 0)
 
@@ -101,7 +101,7 @@ def add_video_track(peer_connection : PeerConnectionId, media_direction : MediaD
 	return video_track
 
 
-def create_sdp(peer_connection : PeerConnectionId) -> Optional[SdpOffer]:
+def create_sdp(peer_connection : PeerConnection) -> Optional[SdpOffer]:
 	datachannel_library = create_static_datachannel_library()
 	datachannel_library.rtcSetLocalDescription(peer_connection, b'offer')
 	buffer_size = 16384
@@ -119,20 +119,20 @@ def on_sdp_ready(peer_connection : int, sdp : Optional[bytes], sdp_type : int, u
 
 
 @ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
-def on_gathering_complete(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
+def on_ice_gathering_complete(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
 	if state == 2:
 		context = ctypes.cast(user_pointer, ctypes.py_object).value
 		context['event'].set()
 
 
 @ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
-def on_state_change(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
+def on_peer_connection_lost(peer_connection : int, state : int, user_pointer : Optional[int]) -> None:
 	if state in (4, 5):
 		peer = ctypes.cast(user_pointer, ctypes.py_object).value
 		peer['connected'] = False
 
 
-def negotiate_sdp(peer_connection : PeerConnectionId, sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
+def negotiate_sdp(peer_connection : PeerConnection, sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
 	datachannel_library = create_static_datachannel_library()
 	sdp_event = threading.Event()
 	sdp_event_pointer = ctypes.cast(id(sdp_event), ctypes.c_void_p)
@@ -161,14 +161,14 @@ def handle_whep_offer(peers : List[RtcPeer], sdp_offer : SdpOffer) -> Optional[S
 	if local_sdp:
 		rtc_peer : RtcPeer =\
 		{
-			'peer_connection_id': peer_connection,
+			'peer_connection': peer_connection,
 			'video_track': video_track,
 			'audio_track': audio_track,
 			'connected': True
 		}
 		peer_pointer = ctypes.cast(id(rtc_peer), ctypes.c_void_p)
 		datachannel_library.rtcSetUserPointer(peer_connection, peer_pointer)
-		datachannel_library.rtcSetStateChangeCallback(peer_connection, on_state_change)
+		datachannel_library.rtcSetStateChangeCallback(peer_connection, on_peer_connection_lost)
 		peers.append(rtc_peer)
 
 	return local_sdp
@@ -196,7 +196,7 @@ def delete_peers(peers : List[RtcPeer]) -> None:
 	datachannel_library = create_static_datachannel_library()
 
 	for rtc_peer in peers:
-		peer_connection_id = rtc_peer.get('peer_connection_id')
+		peer_connection_id = rtc_peer.get('peer_connection')
 
 		if peer_connection_id:
 			datachannel_library.rtcDeletePeerConnection(peer_connection_id)

--- a/facefusion/rtc_store.py
+++ b/facefusion/rtc_store.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from facefusion import rtc
-from facefusion.types import RtcPeer, RtcStreamStore, SdpAnswer, SdpOffer, SessionId
+from facefusion.types import PeerConnection, RtcAudioTrack, RtcPeer, RtcStreamStore, RtcVideoTrack, SdpAnswer, SdpOffer, SessionId
 
 RTC_STREAMS : RtcStreamStore = {}
 
@@ -15,21 +15,35 @@ def create_rtc_stream(session_id : SessionId) -> None:
 
 
 def destroy_rtc_stream(session_id : SessionId) -> None:
-	peers = RTC_STREAMS.pop(session_id, None)
+	rtc_peers = RTC_STREAMS.pop(session_id, None)
 
-	if peers:
-		rtc.delete_peers(peers)
+	if rtc_peers:
+		rtc.delete_peers(rtc_peers)
 
 
 def add_rtc_viewer(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
 	if session_id in RTC_STREAMS:
-		return rtc.handle_whep_offer(RTC_STREAMS.get(session_id), sdp_offer)
+		peer_connection : PeerConnection = rtc.create_peer_connection()
+		audio_track : RtcAudioTrack = rtc.add_audio_track(peer_connection, 'sendonly')
+		video_track : RtcVideoTrack = rtc.add_video_track(peer_connection, 'sendonly')
+		local_sdp = rtc.negotiate_sdp(peer_connection, sdp_offer)
+
+		if local_sdp:
+			rtc_peer : RtcPeer =\
+			{
+				'peer_connection': peer_connection,
+				'video_track': video_track,
+				'audio_track': audio_track
+			}
+			RTC_STREAMS[session_id].append(rtc_peer)
+
+		return local_sdp
 
 	return None
 
 
 def send_rtc_frame(session_id : SessionId, frame_data : bytes) -> None:
-	peers = get_rtc_stream(session_id)
+	rtc_peers = get_rtc_stream(session_id)
 
-	if peers:
-		rtc.send_to_peers(peers, frame_data)
+	if rtc_peers:
+		rtc.send_to_peers(rtc_peers, frame_data)

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -284,7 +284,6 @@ RtcPeer = TypedDict('RtcPeer',
 	'peer_connection': PeerConnection,
 	'video_track': RtcVideoTrack,
 	'audio_track': RtcAudioTrack,
-	'connected': bool
 })
 
 RtcStreamStore : TypeAlias = Dict[str, List[RtcPeer]]

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -274,14 +274,14 @@ RtcOfferSet = TypedDict('RtcOfferSet',
 
 RtcVideoTrack : TypeAlias = int
 RtcAudioTrack : TypeAlias = int
-PeerConnectionId : TypeAlias = int
+PeerConnection : TypeAlias = int
 SdpOffer : TypeAlias = str
 SdpAnswer : TypeAlias = str
 MediaDirection : TypeAlias = Literal['sendonly', 'recvonly', 'sendrecv', 'inactive']
 
 RtcPeer = TypedDict('RtcPeer',
 {
-	'peer_connection_id': PeerConnectionId,
+	'peer_connection': PeerConnection,
 	'video_track': RtcVideoTrack,
 	'audio_track': RtcAudioTrack,
 	'connected': bool

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -272,19 +272,21 @@ RtcOfferSet = TypedDict('RtcOfferSet',
 	'type': str
 })
 
-RtcPeer = TypedDict('RtcPeer',
-{
-	'peer_connection': int,
-	'video_track': int,
-	'audio_track': int
-})
-
 RtcVideoTrack : TypeAlias = int
 RtcAudioTrack : TypeAlias = int
-PeerConnection : TypeAlias = int
+PeerConnectionId : TypeAlias = int
 SdpOffer : TypeAlias = str
 SdpAnswer : TypeAlias = str
 MediaDirection : TypeAlias = Literal['sendonly', 'recvonly', 'sendrecv', 'inactive']
+
+RtcPeer = TypedDict('RtcPeer',
+{
+	'peer_connection_id': PeerConnectionId,
+	'video_track': RtcVideoTrack,
+	'audio_track': RtcAudioTrack,
+	'connected': bool
+})
+
 RtcStreamStore : TypeAlias = Dict[str, List[RtcPeer]]
 
 ModelOptions : TypeAlias = Dict[str, Any]

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -1,6 +1,7 @@
 import pytest
 
 from facefusion import rtc
+from facefusion.types import RtcPeer
 
 
 @pytest.fixture(scope = 'module')
@@ -65,3 +66,40 @@ def test_add_video_track() -> None:
 
 	assert datachannel_library.rtcDeletePeerConnection(sender_connection) == 0
 	assert datachannel_library.rtcDeletePeerConnection(receiver_connection) == 0
+
+
+def test_has_connected_peer() -> None:
+	connected_peer : RtcPeer =\
+	{
+		'peer_connection_id': 1,
+		'video_track': 1,
+		'audio_track': 1,
+		'connected': True
+	}
+	disconnected_peer : RtcPeer =\
+	{
+		'peer_connection_id': 2,
+		'video_track': 2,
+		'audio_track': 2,
+		'connected': False
+	}
+
+	assert rtc.has_connected_peer([ connected_peer ]) is True
+	assert rtc.has_connected_peer([ disconnected_peer ]) is False
+	assert rtc.has_connected_peer([]) is False
+	assert rtc.has_connected_peer([ disconnected_peer, connected_peer ]) is True
+
+
+def test_delete_peers(before_all : None) -> None:
+	peer_connection = rtc.create_peer_connection()
+	peers =\
+	[{
+		'peer_connection_id': peer_connection,
+		'video_track': 0,
+		'audio_track': 0,
+		'connected': True
+	}]
+
+	rtc.delete_peers(peers)
+
+	assert peers == []

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 
 from facefusion import rtc
@@ -92,7 +94,7 @@ def test_has_connected_peer() -> None:
 
 def test_delete_peers(before_all : None) -> None:
 	peer_connection = rtc.create_peer_connection()
-	peers =\
+	peers : List[RtcPeer] =\
 	[{
 		'peer_connection_id': peer_connection,
 		'video_track': 0,

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -67,11 +67,13 @@ def test_delete_peers() -> None:
 	datachannel_library = rtc.create_static_datachannel_library()
 	peer_connection = rtc.create_peer_connection()
 	rtc_peers : List[RtcPeer] =\
-	[{
-		'peer_connection': peer_connection,
-		'video_track': 0,
-		'audio_track': 0
-	}]
+	[
+		{
+			'peer_connection': peer_connection,
+			'video_track': 0,
+			'audio_track': 0
+		}
+	]
 
 	rtc.delete_peers(rtc_peers)
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -73,14 +73,14 @@ def test_add_video_track() -> None:
 def test_has_connected_peer() -> None:
 	connected_peer : RtcPeer =\
 	{
-		'peer_connection_id': 1,
+		'peer_connection': 1,
 		'video_track': 1,
 		'audio_track': 1,
 		'connected': True
 	}
 	disconnected_peer : RtcPeer =\
 	{
-		'peer_connection_id': 2,
+		'peer_connection': 2,
 		'video_track': 2,
 		'audio_track': 2,
 		'connected': False
@@ -96,7 +96,7 @@ def test_delete_peers(before_all : None) -> None:
 	peer_connection = rtc.create_peer_connection()
 	peers : List[RtcPeer] =\
 	[{
-		'peer_connection_id': peer_connection,
+		'peer_connection': peer_connection,
 		'video_track': 0,
 		'audio_track': 0,
 		'connected': True

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -25,83 +25,54 @@ def test_create_peer_connection() -> None:
 
 
 def test_add_audio_track() -> None:
+	peer_connection = rtc.create_peer_connection()
+
+	assert rtc.add_audio_track(peer_connection, 'sendonly') > 0
+
+	rtc.create_static_datachannel_library().rtcDeletePeerConnection(peer_connection)
+
+
+def test_add_video_track() -> None:
+	peer_connection = rtc.create_peer_connection()
+
+	assert rtc.add_video_track(peer_connection, 'sendonly') > 0
+
+	rtc.create_static_datachannel_library().rtcDeletePeerConnection(peer_connection)
+
+
+def test_negotiate_sdp() -> None:
 	datachannel_library = rtc.create_static_datachannel_library()
 
 	sender_connection = rtc.create_peer_connection()
-	sender_audio_track = rtc.add_audio_track(sender_connection, 'sendonly')
+	rtc.add_video_track(sender_connection, 'sendonly')
+	rtc.add_audio_track(sender_connection, 'sendonly')
 	sdp_offer = rtc.create_sdp(sender_connection)
 
 	receiver_connection = rtc.create_peer_connection()
-	receiver_audio_track = rtc.add_audio_track(receiver_connection, 'recvonly')
+	rtc.add_video_track(receiver_connection, 'recvonly')
+	rtc.add_audio_track(receiver_connection, 'recvonly')
 	sdp_answer = rtc.negotiate_sdp(receiver_connection, sdp_offer)
 
-	assert sender_audio_track > 0
-	assert receiver_audio_track > 0
-
-	assert 'm=audio' in sdp_offer
+	assert sdp_answer
+	assert 'm=video' in sdp_answer
+	assert 'VP8/90000' in sdp_answer
 	assert 'm=audio' in sdp_answer
-	assert 'opus/48000/2' in sdp_offer
 	assert 'opus/48000/2' in sdp_answer
 
 	assert datachannel_library.rtcDeletePeerConnection(sender_connection) == 0
 	assert datachannel_library.rtcDeletePeerConnection(receiver_connection) == 0
 
 
-def test_add_video_track() -> None:
+def test_delete_peers() -> None:
 	datachannel_library = rtc.create_static_datachannel_library()
-
-	sender_connection = rtc.create_peer_connection()
-	sender_video_track = rtc.add_video_track(sender_connection, 'sendonly')
-	sdp_offer = rtc.create_sdp(sender_connection)
-
-	receiver_connection = rtc.create_peer_connection()
-	receiver_video_track = rtc.add_video_track(receiver_connection, 'recvonly')
-	sdp_answer = rtc.negotiate_sdp(receiver_connection, sdp_offer)
-
-	assert sender_video_track > 0
-	assert receiver_video_track > 0
-
-	assert 'm=video' in sdp_offer
-	assert 'm=video' in sdp_answer
-	assert 'VP8/90000' in sdp_offer
-	assert 'VP8/90000' in sdp_answer
-
-	assert datachannel_library.rtcDeletePeerConnection(sender_connection) == 0
-	assert datachannel_library.rtcDeletePeerConnection(receiver_connection) == 0
-
-
-def test_has_connected_peer() -> None:
-	connected_peer : RtcPeer =\
-	{
-		'peer_connection': 1,
-		'video_track': 1,
-		'audio_track': 1,
-		'connected': True
-	}
-	disconnected_peer : RtcPeer =\
-	{
-		'peer_connection': 2,
-		'video_track': 2,
-		'audio_track': 2,
-		'connected': False
-	}
-
-	assert rtc.has_connected_peer([ connected_peer ]) is True
-	assert rtc.has_connected_peer([ disconnected_peer ]) is False
-	assert rtc.has_connected_peer([]) is False
-	assert rtc.has_connected_peer([ disconnected_peer, connected_peer ]) is True
-
-
-def test_delete_peers(before_all : None) -> None:
 	peer_connection = rtc.create_peer_connection()
-	peers : List[RtcPeer] =\
+	rtc_peers : List[RtcPeer] =\
 	[{
 		'peer_connection': peer_connection,
 		'video_track': 0,
-		'audio_track': 0,
-		'connected': True
+		'audio_track': 0
 	}]
 
-	rtc.delete_peers(peers)
+	rtc.delete_peers(rtc_peers)
 
-	assert peers == []
+	assert datachannel_library.rtcDeletePeerConnection(peer_connection) < 0


### PR DESCRIPTION

  - Added three module-level callbacks using `@ctypes.CFUNCTYPE(...)` directly as decorators:                                                                                                                                                                            
    - `on_sdp_ready` — one-liner, signals a `threading.Event` via the user pointer                                                                                                                                                                                       
    - `on_gathering_complete` — signals event when ICE gathering state == 2                                                                                                                                                                                              
    - `on_state_change` — sets `peer['connected'] = False` when state in (4, 5)                                                                                                                                                                                          
  - Replaced polling loop in `negotiate_sdp` with a bare `threading.Event` passed as user pointer; SDP read once via `rtcGetLocalDescription` after event fires                                                                                                          
  - `handle_whep_offer` registers `on_state_change` via `rtcSetStateChangeCallback`; peer created with `connected: True`                                                                                                                                                 
  - Renamed `is_peer_connected` → `has_connected_peer`; reads `connected` flag, no library call                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  - Renamed field `peer_connection` → `peer_connection_id`                                                                                                                                                                                                               
  - `RtcPeer` now uses proper type aliases (`PeerConnectionId`, `RtcVideoTrack`, `RtcAudioTrack`) instead of raw `int`   