### PR TITLE
Cleanup/stream part1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     with:
      python-version: '3.12'
   - if: matrix.os == 'macos-latest'
-    run: brew install openssl@3
+    run: echo "DYLD_LIBRARY_PATH=$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   - if: matrix.os == 'macos-latest'
     run: brew install opus
   - if: matrix.os == 'macos-latest'
-    run: brew install openssl
+    run: brew install openssl@3
   - if: matrix.os == 'windows-latest'
     run: C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx mingw-w64-x86_64-openssl
     shell: cmd
@@ -51,9 +51,10 @@ jobs:
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock
+  - run: pip install pytest-timeout
   - run: pip install httpx
   - run: pip install python-multipart
-  - run: pytest -v
+  - run: pytest -v --timeout=60
  report:
   needs: test
   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
     run: brew install libvpx
   - if: matrix.os == 'macos-latest'
     run: brew install opus
+  - if: matrix.os == 'macos-latest'
+    run: |
+      echo "brew prefix libvpx: $(brew --prefix libvpx)"
+      echo "brew prefix opus: $(brew --prefix opus)"
+      ls $(brew --prefix libvpx)/lib/
+      ls $(brew --prefix opus)/lib/
+      python -c "import ctypes.util; print('vpx:', ctypes.util.find_library('vpx')); print('opus:', ctypes.util.find_library('opus'))"
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,18 +43,13 @@ jobs:
     run: brew install opus
   - if: matrix.os == 'macos-latest'
     run: brew install openssl@3
-  - if: matrix.os == 'windows-latest'
-    run: C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx mingw-w64-x86_64-openssl
-    shell: cmd
-  - if: matrix.os == 'windows-latest'
-    run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock
   - run: pip install pytest-timeout
   - run: pip install httpx
   - run: pip install python-multipart
-  - run: pytest -v --timeout=60
+  - run: pytest
  report:
   needs: test
   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
   - if: matrix.os == 'windows-latest'
     run: echo "C:\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
   - if: matrix.os == 'windows-latest'
-    run: C:\msys64\usr\bin\bash -c "pacman -S --noconfirm mingw-w64-x86_64-libvpx"
+    run: C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-libvpx
+    shell: cmd
   - if: matrix.os == 'windows-latest'
     run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
   - run: python install.py --onnxruntime default --skip-conda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,16 @@ jobs:
     uses: actions/setup-python@v5
     with:
      python-version: '3.12'
-  - if: matrix.os == 'ubuntu-latest'
-    run: sudo apt-get install libvpx-dev
-  - if: matrix.os == 'ubuntu-latest'
-    run: sudo apt-get install libopus-dev
   - if: matrix.os == 'macos-latest'
     run: brew install libvpx
   - if: matrix.os == 'macos-latest'
     run: brew install opus
   - if: matrix.os == 'macos-latest'
     run: brew install openssl@3
+  - if: matrix.os == 'ubuntu-latest'
+    run: sudo apt-get install libvpx-dev
+  - if: matrix.os == 'ubuntu-latest'
+    run: sudo apt-get install libopus-dev
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   - if: matrix.os == 'macos-latest'
     run: brew install openssl@3
   - if: matrix.os == 'macos-latest'
-    run: echo "DYLD_LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib" >> $GITHUB_ENV
+    run: echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/openssl@3/lib" >> $GITHUB_ENV
   - if: matrix.os == 'windows-latest'
     run: vcpkg install opus:x64-windows openssl:x64-windows
   - if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,6 @@ jobs:
     uses: actions/setup-python@v5
     with:
      python-version: '3.12'
-  - if: matrix.os == 'macos-latest'
-    run: brew install libvpx
-  - if: matrix.os == 'macos-latest'
-    run: brew install opus
-  - if: matrix.os == 'macos-latest'
-    run: brew install openssl@3
-  - if: matrix.os == 'ubuntu-latest'
-    run: sudo apt-get install libvpx-dev
-  - if: matrix.os == 'ubuntu-latest'
-    run: sudo apt-get install libopus-dev
-  - if: matrix.os == 'windows-latest'
-    run: vcpkg install libvpx
-  - if: matrix.os == 'windows-latest'
-    run: vcpkg install opus
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock
@@ -66,8 +52,6 @@ jobs:
     uses: actions/setup-python@v5
     with:
      python-version: '3.12'
-  - run: sudo apt-get install libvpx-dev
-  - run: sudo apt-get install libopus-dev
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install coveralls
   - run: pip install pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,6 @@ jobs:
     run: vcpkg install opus:x64-windows libvpx:x64-windows openssl:x64-windows
   - if: matrix.os == 'windows-latest'
     run: echo "C:\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
-  - if: matrix.os == 'windows-latest'
-    run: |
-      dir C:\vcpkg\installed\x64-windows\bin\ | findstr /i "vpx opus ssl"
-      python -c "import ctypes.util; print('vpx:', ctypes.util.find_library('vpx')); print('opus:', ctypes.util.find_library('opus'))"
-    shell: cmd
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,7 @@ jobs:
   - if: matrix.os == 'macos-latest'
     run: brew install opus
   - if: matrix.os == 'macos-latest'
-    run: brew install openssl@3
-  - if: matrix.os == 'macos-latest'
-    run: echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/openssl@3/lib" >> $GITHUB_ENV
+    run: brew install openssl
   - if: matrix.os == 'windows-latest'
     run: vcpkg install opus:x64-windows openssl:x64-windows
   - if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,17 @@ jobs:
     run: sudo apt-get install libvpx-dev
   - if: matrix.os == 'ubuntu-latest'
     run: sudo apt-get install libopus-dev
+  - if: matrix.os == 'windows-latest'
+    run: vcpkg install libvpx
+  - if: matrix.os == 'windows-latest'
+    run: vcpkg install libopus
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock
   - run: pip install pytest-timeout
   - run: pip install httpx
   - run: pip install python-multipart
-  - run: pytest
+  - run: pytest tests/test_library_datachannel.py tests/test_library_opus.py tests/test_library_vpx.py
  report:
   needs: test
   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
   - run: pip install pytest-mock
   - run: pip install httpx
   - run: pip install python-multipart
-  - run: pytest
+  - run: pytest -v
  report:
   needs: test
   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
     run: vcpkg install opus:x64-windows libvpx:x64-windows openssl:x64-windows
   - if: matrix.os == 'windows-latest'
     run: echo "C:\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
+  - if: matrix.os == 'windows-latest'
+    run: dir C:\vcpkg\installed\x64-windows\bin\ | findstr /i vpx
+    shell: cmd
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
     run: brew install openssl@3
   - if: matrix.os == 'macos-latest'
     run: echo "DYLD_LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib" >> $GITHUB_ENV
+  - if: matrix.os == 'windows-latest'
+    run: vcpkg install opus:x64-windows libvpx:x64-windows
+  - if: matrix.os == 'windows-latest'
+    run: echo "C:\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,6 @@ jobs:
     run: brew install libvpx
   - if: matrix.os == 'macos-latest'
     run: brew install opus
-  - if: matrix.os == 'macos-latest'
-    run: |
-      echo "brew prefix libvpx: $(brew --prefix libvpx)"
-      echo "brew prefix opus: $(brew --prefix opus)"
-      ls $(brew --prefix libvpx)/lib/
-      ls $(brew --prefix opus)/lib/
-      python -c "import ctypes.util; print('vpx:', ctypes.util.find_library('vpx')); print('opus:', ctypes.util.find_library('opus'))"
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
   - if: matrix.os == 'windows-latest'
     run: vcpkg install libvpx
   - if: matrix.os == 'windows-latest'
-    run: vcpkg install libopus
+    run: vcpkg install opus
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,14 @@ jobs:
   - if: matrix.os == 'macos-latest'
     run: echo "DYLD_LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib" >> $GITHUB_ENV
   - if: matrix.os == 'windows-latest'
-    run: vcpkg install opus:x64-windows libvpx:x64-windows
+    run: vcpkg install opus:x64-windows libvpx:x64-windows openssl:x64-windows
   - if: matrix.os == 'windows-latest'
     run: echo "C:\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
+  - if: matrix.os == 'windows-latest'
+    run: |
+      dir C:\vcpkg\installed\x64-windows\bin\ | findstr /i "vpx opus ssl"
+      python -c "import ctypes.util; print('vpx:', ctypes.util.find_library('vpx')); print('opus:', ctypes.util.find_library('opus'))"
+    shell: cmd
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,7 @@ jobs:
   - if: matrix.os == 'macos-latest'
     run: brew install openssl
   - if: matrix.os == 'windows-latest'
-    run: vcpkg install opus:x64-windows openssl:x64-windows
-  - if: matrix.os == 'windows-latest'
-    run: echo "C:\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
-  - if: matrix.os == 'windows-latest'
-    run: C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-libvpx
+    run: C:\msys64\usr\bin\pacman -S --noconfirm mingw-w64-x86_64-opus mingw-w64-x86_64-libvpx mingw-w64-x86_64-openssl
     shell: cmd
   - if: matrix.os == 'windows-latest'
     run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
   - run: pip install pytest-timeout
   - run: pip install httpx
   - run: pip install python-multipart
-  - run: pytest tests/test_library_datachannel.py tests/test_library_opus.py tests/test_library_vpx.py
+  - run: pytest
  report:
   needs: test
   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     uses: actions/setup-python@v5
     with:
      python-version: '3.12'
+  - if: matrix.os == 'macos-latest'
+    run: brew install openssl@3
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,13 @@ jobs:
   - if: matrix.os == 'macos-latest'
     run: echo "DYLD_LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib" >> $GITHUB_ENV
   - if: matrix.os == 'windows-latest'
-    run: vcpkg install opus:x64-windows libvpx:x64-windows openssl:x64-windows
+    run: vcpkg install opus:x64-windows openssl:x64-windows
   - if: matrix.os == 'windows-latest'
     run: echo "C:\vcpkg\installed\x64-windows\bin" >> $GITHUB_PATH
   - if: matrix.os == 'windows-latest'
-    run: dir C:\vcpkg\installed\x64-windows\bin\ | findstr /i vpx
-    shell: cmd
+    run: C:\msys64\usr\bin\bash -c "pacman -S --noconfirm mingw-w64-x86_64-libvpx"
+  - if: matrix.os == 'windows-latest'
+    run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
     run: brew install libvpx
   - if: matrix.os == 'macos-latest'
     run: brew install opus
+  - if: matrix.os == 'macos-latest'
+    run: brew install openssl@3
+  - if: matrix.os == 'macos-latest'
+    run: echo "DYLD_LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib" >> $GITHUB_ENV
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
     uses: actions/setup-python@v5
     with:
      python-version: '3.12'
+  - if: matrix.os == 'ubuntu-latest'
+    run: sudo apt-get install libvpx-dev
+  - if: matrix.os == 'ubuntu-latest'
+    run: sudo apt-get install libopus-dev
+  - if: matrix.os == 'macos-latest'
+    run: brew install libvpx
+  - if: matrix.os == 'macos-latest'
+    run: brew install opus
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock
@@ -51,6 +59,8 @@ jobs:
     uses: actions/setup-python@v5
     with:
      python-version: '3.12'
+  - run: sudo apt-get install libvpx-dev
+  - run: sudo apt-get install libopus-dev
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install coveralls
   - run: pip install pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
     uses: actions/setup-python@v5
     with:
      python-version: '3.12'
-  - if: matrix.os == 'macos-latest'
-    run: echo "DYLD_LIBRARY_PATH=$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
   - run: python install.py --onnxruntime default --skip-conda
   - run: pip install pytest
   - run: pip install pytest-mock

--- a/facefusion.py
+++ b/facefusion.py
@@ -4,8 +4,8 @@ import os
 
 os.environ['OMP_NUM_THREADS'] = '1'
 
-from facefusion import conda, core
+from facefusion import environment, core
 
 if __name__ == '__main__':
-	conda.setup()
+	environment.setup()
 	core.cli()

--- a/facefusion.py
+++ b/facefusion.py
@@ -4,7 +4,7 @@ import os
 
 os.environ['OMP_NUM_THREADS'] = '1'
 
-from facefusion import environment, core
+from facefusion import core, environment
 
 if __name__ == '__main__':
 	environment.setup_for_conda()

--- a/facefusion.py
+++ b/facefusion.py
@@ -4,7 +4,7 @@ import os
 
 os.environ['OMP_NUM_THREADS'] = '1'
 
-from facefusion import environment, core
+from facefusion import core, environment
 
 if __name__ == '__main__':
 	environment.setup_conda()

--- a/facefusion.py
+++ b/facefusion.py
@@ -4,9 +4,8 @@ import os
 
 os.environ['OMP_NUM_THREADS'] = '1'
 
-from facefusion import core, environment
+from facefusion import conda, core
 
 if __name__ == '__main__':
-	environment.setup_for_conda()
-	environment.setup_for_system()
+	conda.setup()
 	core.cli()

--- a/facefusion.py
+++ b/facefusion.py
@@ -4,8 +4,9 @@ import os
 
 os.environ['OMP_NUM_THREADS'] = '1'
 
-from facefusion import conda, core
+from facefusion import environment, core
 
 if __name__ == '__main__':
-	conda.setup()
+	environment.setup_conda()
+	environment.setup_platform()
 	core.cli()

--- a/facefusion.py
+++ b/facefusion.py
@@ -7,5 +7,6 @@ os.environ['OMP_NUM_THREADS'] = '1'
 from facefusion import environment, core
 
 if __name__ == '__main__':
-	environment.setup()
+	environment.setup_for_conda()
+	environment.setup_for_system()
 	core.cli()

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -236,11 +236,13 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 
 	if session_id and source_paths:
 		stream_frames = receive_stream_frames(websocket)
-		first_frame_type, first_frame_buffer = await anext(stream_frames, (0, b''))
 		first_vision_frame = None
 
-		if first_frame_type == 1:
-			first_vision_frame = cv2.imdecode(numpy.frombuffer(first_frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
+		# TODO: audio frames may arrive before video due to ScriptProcessor firing faster than canvas toBlob
+		async for first_frame_type, first_frame_buffer in stream_frames:
+			if first_frame_type == 1:
+				first_vision_frame = cv2.imdecode(numpy.frombuffer(first_frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
+				break
 
 		if numpy.any(first_vision_frame):
 			resolution : Resolution = (first_vision_frame.shape[1], first_vision_frame.shape[0])

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -230,11 +230,10 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 	access_token = extract_access_token(websocket.scope)
 	session_id = session_manager.find_session_id(access_token)
 	session_context.set_session_id(session_id)
-	source_paths = state_manager.get_item('source_paths')
 
 	await websocket.accept(subprotocol = subprotocol)
 
-	if session_id and source_paths:
+	if session_id:
 		stream_frames = receive_stream_frames(websocket)
 		first_vision_frame = None
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -64,7 +64,7 @@ def create_vpx_encoder(width : int, height : int, bitrate : int) -> Optional[cty
 			struct.pack_into('I', config_buffer, 128, 50)
 			context_buffer = ctypes.create_string_buffer(512)
 
-			if vpx_library.vpx_codec_enc_init_ver(context_buffer, ctypes.byref(vp8_iface), config_buffer, 0, 37) == 0:
+			if vpx_library.vpx_codec_enc_init_ver(context_buffer, ctypes.byref(vp8_iface), config_buffer, 0, 39) == 0:
 				vpx_library.vpx_codec_control_(context_buffer, 13, ctypes.c_int(16))
 				vpx_library.vpx_codec_control_(context_buffer, 12, ctypes.c_int(3))
 				vpx_library.vpx_codec_control_(context_buffer, 27, ctypes.c_int(10))

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -115,7 +115,6 @@ def create_opus_encoder(sample_rate : int, channels : int) -> Optional[ctypes.c_
 		encoder = opus_library.opus_encoder_create(sample_rate, channels, 2049, ctypes.byref(error))
 
 		if error.value == 0:
-			opus_library.opus_encoder_ctl(encoder, 4002, 64000)
 			return encoder
 
 	return None
@@ -190,7 +189,7 @@ def encode_audio_chunk(opus_encoder : ctypes.c_void_p, session_id : SessionId, p
 	while len(pcm_buffer) >= frame_samples:
 		chunk = pcm_buffer[:frame_samples]
 		pcm_buffer = pcm_buffer[frame_samples:]
-		pcm_pointer = ctypes.cast(chunk.ctypes.data, ctypes.c_void_p)
+		pcm_pointer = chunk.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
 		audio_buffer = encode_opus(opus_encoder, pcm_pointer, 960)
 
 		if audio_buffer:

--- a/facefusion/conda.py
+++ b/facefusion/conda.py
@@ -2,10 +2,10 @@ import os
 import sys
 from typing import List
 
-from facefusion.common_helper import is_linux, is_macos, is_windows
+from facefusion.common_helper import is_linux, is_windows
 
 
-def setup_for_conda() -> None:
+def setup() -> None:
 	conda_prefix = os.getenv('CONDA_PREFIX')
 	conda_ready = os.getenv('CONDA_READY')
 
@@ -39,37 +39,3 @@ def setup_for_conda() -> None:
 					library_paths.append(os.getenv('PATH'))
 				os.environ['PATH'] = os.pathsep.join(library_paths)
 				os.environ['CONDA_READY'] = '1'
-
-
-def setup_for_system() -> None:
-	if is_macos():
-		homebrew_path = os.environ.get('HOMEBREW_PREFIX')
-		system_ready = os.getenv('SYSTEM_READY')
-
-		if homebrew_path and not system_ready:
-			library_paths =\
-			[
-				os.path.join(homebrew_path, 'lib'),
-				os.path.join(homebrew_path, 'opt', 'openssl@3', 'lib')
-			]
-			library_paths = list(filter(os.path.isdir, library_paths))
-
-			if library_paths:
-				if os.getenv('DYLD_LIBRARY_PATH'):
-					library_paths.append(os.getenv('DYLD_LIBRARY_PATH'))
-				os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
-				os.environ['SYSTEM_READY'] = '1'
-				os.execv(sys.executable, [ sys.executable ] + sys.argv)
-
-	if is_windows():
-		vcpkg_path = os.environ.get('VCPKG_INSTALLATION_ROOT')
-		library_paths =\
-		[
-			os.path.join(vcpkg_path, 'installed', 'x64-windows', 'bin')
-		]
-		library_paths = list(filter(os.path.isdir, library_paths))
-
-		if library_paths:
-			if os.getenv('PATH'):
-				library_paths.append(os.getenv('PATH'))
-			os.environ['PATH'] = os.pathsep.join(library_paths)

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -11,6 +11,7 @@ from facefusion import args_helper, benchmarker, cli_helper, content_analyser, f
 from facefusion.apis.core import create_api
 from facefusion.args_helper import apply_args
 from facefusion.download import conditional_download_hashes, conditional_download_sources
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.exit_helper import hard_exit, signal_exit
 from facefusion.filesystem import get_file_extension, has_audio, has_image, has_video
 from facefusion.filesystem import get_file_name, resolve_file_paths, resolve_file_pattern
@@ -110,7 +111,10 @@ def common_pre_check() -> bool:
 		face_landmarker,
 		face_masker,
 		face_recognizer,
-		voice_extractor
+		voice_extractor,
+		datachannel_module,
+		opus_module,
+		vpx_module
 	]
 
 	content_analyser_content = inspect.getsource(content_analyser).encode()

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -15,8 +15,8 @@ from facefusion.exit_helper import hard_exit, signal_exit
 from facefusion.filesystem import get_file_extension, has_audio, has_image, has_video
 from facefusion.filesystem import get_file_name, resolve_file_paths, resolve_file_pattern
 from facefusion.jobs import job_helper, job_manager, job_runner
-from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.jobs.job_list import compose_job_list
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.processors.core import get_processors_modules
 from facefusion.program import create_program
 from facefusion.program_helper import validate_args

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -11,8 +11,8 @@ from facefusion import args_helper, benchmarker, cli_helper, content_analyser, f
 from facefusion.apis.core import create_api
 from facefusion.args_helper import apply_args
 from facefusion.download import conditional_download_hashes, conditional_download_sources
-from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.exit_helper import hard_exit, signal_exit
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.filesystem import get_file_extension, has_audio, has_image, has_video
 from facefusion.filesystem import get_file_name, resolve_file_paths, resolve_file_pattern
 from facefusion.jobs import job_helper, job_manager, job_runner
@@ -105,15 +105,15 @@ def pre_check() -> bool:
 def common_pre_check() -> bool:
 	common_modules =\
 	[
+		datachannel_module,
 		content_analyser,
 		face_classifier,
 		face_detector,
 		face_landmarker,
 		face_masker,
 		face_recognizer,
-		voice_extractor,
-		datachannel_module,
 		opus_module,
+		voice_extractor,
 		vpx_module
 	]
 

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -12,9 +12,9 @@ from facefusion.apis.core import create_api
 from facefusion.args_helper import apply_args
 from facefusion.download import conditional_download_hashes, conditional_download_sources
 from facefusion.exit_helper import hard_exit, signal_exit
-from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.filesystem import get_file_extension, has_audio, has_image, has_video
 from facefusion.filesystem import get_file_name, resolve_file_paths, resolve_file_pattern
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.jobs import job_helper, job_manager, job_runner
 from facefusion.jobs.job_list import compose_job_list
 from facefusion.processors.core import get_processors_modules

--- a/facefusion/core.py
+++ b/facefusion/core.py
@@ -14,8 +14,8 @@ from facefusion.download import conditional_download_hashes, conditional_downloa
 from facefusion.exit_helper import hard_exit, signal_exit
 from facefusion.filesystem import get_file_extension, has_audio, has_image, has_video
 from facefusion.filesystem import get_file_name, resolve_file_paths, resolve_file_pattern
-from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.jobs import job_helper, job_manager, job_runner
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.jobs.job_list import compose_job_list
 from facefusion.processors.core import get_processors_modules
 from facefusion.program import create_program

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -46,7 +46,6 @@ def setup_for_system() -> None:
 		library_paths =\
 		[
 			'/opt/homebrew/lib',
-			'/opt/homebrew/opt/openssl/lib',
 			'/opt/homebrew/opt/openssl@3/lib'
 		]
 		library_paths = list(filter(os.path.isdir, library_paths))

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -73,4 +73,3 @@ def setup_for_system() -> None:
 			if os.getenv('PATH'):
 				library_paths.append(os.getenv('PATH'))
 			os.environ['PATH'] = os.pathsep.join(library_paths)
-

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -44,8 +44,7 @@ def setup() -> None:
 		library_paths =\
 		[
 			'/opt/homebrew/lib',
-			'/opt/homebrew/opt/openssl/lib',
-			'/usr/local/lib'
+			'/opt/homebrew/opt/openssl/lib'
 		]
 		library_paths = list(filter(os.path.isdir, library_paths))
 

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import List
 
-from facefusion.common_helper import is_linux, is_windows
+from facefusion.common_helper import is_linux, is_macos, is_windows
 
 
 def setup() -> None:
@@ -39,3 +39,17 @@ def setup() -> None:
 					library_paths.append(os.getenv('PATH'))
 				os.environ['PATH'] = os.pathsep.join(library_paths)
 				os.environ['CONDA_READY'] = '1'
+
+	if is_macos():
+		library_paths =\
+		[
+			'/opt/homebrew/lib',
+			'/opt/homebrew/opt/openssl/lib',
+			'/usr/local/lib'
+		]
+		library_paths = list(filter(os.path.isdir, library_paths))
+
+		if library_paths:
+			if os.getenv('DYLD_LIBRARY_PATH'):
+				library_paths.append(os.getenv('DYLD_LIBRARY_PATH'))
+			os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -57,12 +57,10 @@ def setup_for_system() -> None:
 			os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
 
 	if is_windows():
-		system_drive = os.environ.get('SystemDrive')
 		vcpkg_path = os.environ.get('VCPKG_INSTALLATION_ROOT')
 		library_paths =\
 		[
-			os.path.join(vcpkg_path, 'installed', 'x64-windows', 'bin'),
-			os.path.join(system_drive, os.sep, 'msys64', 'mingw64', 'bin')
+			os.path.join(vcpkg_path, 'installed', 'x64-windows', 'bin')
 		]
 		library_paths = list(filter(os.path.isdir, library_paths))
 

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -2,10 +2,10 @@ import os
 import sys
 from typing import List
 
-from facefusion.common_helper import is_linux, is_windows
+from facefusion.common_helper import is_linux, is_macos, is_windows
 
 
-def setup() -> None:
+def setup_conda() -> None:
 	conda_prefix = os.getenv('CONDA_PREFIX')
 	conda_ready = os.getenv('CONDA_READY')
 
@@ -39,3 +39,24 @@ def setup() -> None:
 					library_paths.append(os.getenv('PATH'))
 				os.environ['PATH'] = os.pathsep.join(library_paths)
 				os.environ['CONDA_READY'] = '1'
+
+
+def setup_platform() -> None:
+	homebrew_path = os.environ.get('HOMEBREW_PREFIX')
+	system_ready = os.getenv('SYSTEM_READY')
+
+	if homebrew_path and not system_ready:
+		if is_macos():
+			library_paths =\
+			[
+				os.path.join(homebrew_path, 'lib'),
+				os.path.join(homebrew_path, 'opt', 'openssl@3', 'lib')
+			]
+			library_paths = list(filter(os.path.isdir, library_paths))
+
+			if library_paths:
+				if os.getenv('DYLD_LIBRARY_PATH'):
+					library_paths.append(os.getenv('DYLD_LIBRARY_PATH'))
+				os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
+				os.environ['SYSTEM_READY'] = '1'
+				os.execv(sys.executable, [ sys.executable ] + sys.argv)

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -43,10 +43,11 @@ def setup_for_conda() -> None:
 
 def setup_for_system() -> None:
 	if is_macos():
+		homebrew_path = os.environ.get('HOMEBREW_PREFIX')
 		library_paths =\
 		[
-			'/opt/homebrew/lib',
-			'/opt/homebrew/opt/openssl@3/lib'
+			os.path.join(homebrew_path, 'lib'),
+			os.path.join(homebrew_path, 'opt', 'openssl@3', 'lib')
 		]
 		library_paths = list(filter(os.path.isdir, library_paths))
 
@@ -54,4 +55,19 @@ def setup_for_system() -> None:
 			if os.getenv('DYLD_LIBRARY_PATH'):
 				library_paths.append(os.getenv('DYLD_LIBRARY_PATH'))
 			os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
+
+	if is_windows():
+		system_drive = os.environ.get('SystemDrive')
+		vcpkg_path = os.environ.get('VCPKG_INSTALLATION_ROOT')
+		library_paths =\
+		[
+			os.path.join(vcpkg_path, 'installed', 'x64-windows', 'bin'),
+			os.path.join(system_drive, os.sep, 'msys64', 'mingw64', 'bin')
+		]
+		library_paths = list(filter(os.path.isdir, library_paths))
+
+		if library_paths:
+			if os.getenv('PATH'):
+				library_paths.append(os.getenv('PATH'))
+			os.environ['PATH'] = os.pathsep.join(library_paths)
 

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -44,17 +44,22 @@ def setup_for_conda() -> None:
 def setup_for_system() -> None:
 	if is_macos():
 		homebrew_path = os.environ.get('HOMEBREW_PREFIX')
-		library_paths =\
-		[
-			os.path.join(homebrew_path, 'lib'),
-			os.path.join(homebrew_path, 'opt', 'openssl@3', 'lib')
-		]
-		library_paths = list(filter(os.path.isdir, library_paths))
+		system_ready = os.getenv('SYSTEM_READY')
 
-		if library_paths:
-			if os.getenv('DYLD_LIBRARY_PATH'):
-				library_paths.append(os.getenv('DYLD_LIBRARY_PATH'))
-			os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
+		if homebrew_path and not system_ready:
+			library_paths =\
+			[
+				os.path.join(homebrew_path, 'lib'),
+				os.path.join(homebrew_path, 'opt', 'openssl@3', 'lib')
+			]
+			library_paths = list(filter(os.path.isdir, library_paths))
+
+			if library_paths:
+				if os.getenv('DYLD_LIBRARY_PATH'):
+					library_paths.append(os.getenv('DYLD_LIBRARY_PATH'))
+				os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
+				os.environ['SYSTEM_READY'] = '1'
+				os.execv(sys.executable, [ sys.executable ] + sys.argv)
 
 	if is_windows():
 		vcpkg_path = os.environ.get('VCPKG_INSTALLATION_ROOT')

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -5,7 +5,7 @@ from typing import List
 from facefusion.common_helper import is_linux, is_macos, is_windows
 
 
-def setup() -> None:
+def setup_for_conda() -> None:
 	conda_prefix = os.getenv('CONDA_PREFIX')
 	conda_ready = os.getenv('CONDA_READY')
 
@@ -40,6 +40,8 @@ def setup() -> None:
 				os.environ['PATH'] = os.pathsep.join(library_paths)
 				os.environ['CONDA_READY'] = '1'
 
+
+def setup_for_system() -> None:
 	if is_macos():
 		library_paths =\
 		[

--- a/facefusion/environment.py
+++ b/facefusion/environment.py
@@ -46,7 +46,8 @@ def setup_for_system() -> None:
 		library_paths =\
 		[
 			'/opt/homebrew/lib',
-			'/opt/homebrew/opt/openssl/lib'
+			'/opt/homebrew/opt/openssl/lib',
+			'/opt/homebrew/opt/openssl@3/lib'
 		]
 		library_paths = list(filter(os.path.isdir, library_paths))
 
@@ -54,3 +55,4 @@ def setup_for_system() -> None:
 			if os.getenv('DYLD_LIBRARY_PATH'):
 				library_paths.append(os.getenv('DYLD_LIBRARY_PATH'))
 			os.environ['DYLD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
+

--- a/facefusion/libraries/amd_smi.py
+++ b/facefusion/libraries/amd_smi.py
@@ -1,22 +1,15 @@
 import ctypes
+import ctypes.util
 from functools import lru_cache
 from typing import List, Optional
-
-from facefusion.common_helper import is_linux
-
-
-def resolve_library_file() -> Optional[str]:
-	if is_linux():
-		return 'libamd_smi.so'
-	return None
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_file = resolve_library_file()
+	library_path = ctypes.util.find_library('amd_smi')
 
-	if library_file:
-		library = ctypes.CDLL(library_file)
+	if library_path:
+		library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -56,11 +56,6 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = create_static_library_set().get('sources').get('datachannel').get('path')
 
 	if library_path:
-		if is_windows():
-			for dll_dir in os.environ.get('PATH', '').split(os.pathsep):
-				if os.path.isdir(dll_dir):
-					os.add_dll_directory(dll_dir)  # type: ignore[attr-defined]
-
 		library = ctypes.CDLL(library_path)
 
 		if library:

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -57,7 +57,7 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 
 	if library_path:
 		if is_windows():
-			for dll_dir in [ 'C:/vcpkg/installed/x64-windows/bin', 'C:/msys64/mingw64/bin' ]:
+			for dll_dir in os.environ.get('PATH', '').split(os.pathsep):
 				if os.path.isdir(dll_dir):
 					os.add_dll_directory(dll_dir)  # type: ignore[attr-defined]
 

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -56,6 +56,11 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = create_static_library_set().get('sources').get('datachannel').get('path')
 
 	if library_path:
+		if is_windows():
+			for dll_dir in [ 'C:/vcpkg/installed/x64-windows/bin' ]:
+				if os.path.isdir(dll_dir):
+					os.add_dll_directory(dll_dir)
+
 		library = ctypes.CDLL(library_path)
 
 		if library:

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -1,4 +1,5 @@
 import ctypes
+import ctypes.util
 import os
 from functools import lru_cache
 from typing import Dict, Optional, Tuple
@@ -56,6 +57,9 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = create_static_library_set().get('sources').get('datachannel').get('path')
 
 	if library_path:
+		if is_macos() and ctypes.util.find_library('ssl'):
+			ctypes.CDLL(ctypes.util.find_library('ssl'))
+
 		if is_windows():
 			library = ctypes.CDLL(library_path, winmode = 0)
 		else:

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -1,5 +1,4 @@
 import ctypes
-import ctypes.util
 import os
 from functools import lru_cache
 from typing import Dict, Optional, Tuple
@@ -57,9 +56,6 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = create_static_library_set().get('sources').get('datachannel').get('path')
 
 	if library_path:
-		if is_macos() and ctypes.util.find_library('ssl'):
-			ctypes.CDLL(ctypes.util.find_library('ssl'))
-
 		if is_windows():
 			library = ctypes.CDLL(library_path, winmode = 0)
 		else:

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -59,7 +59,7 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 		if is_windows():
 			for dll_dir in [ 'C:/vcpkg/installed/x64-windows/bin', 'C:/msys64/mingw64/bin' ]:
 				if os.path.isdir(dll_dir):
-					os.add_dll_directory(dll_dir)
+					os.add_dll_directory(dll_dir)  # type: ignore[attr-defined]
 
 		library = ctypes.CDLL(library_path)
 

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -57,7 +57,7 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 
 	if library_path:
 		if is_windows():
-			for dll_dir in [ 'C:/vcpkg/installed/x64-windows/bin' ]:
+			for dll_dir in [ 'C:/vcpkg/installed/x64-windows/bin', 'C:/msys64/mingw64/bin' ]:
 				if os.path.isdir(dll_dir):
 					os.add_dll_directory(dll_dir)
 

--- a/facefusion/libraries/datachannel.py
+++ b/facefusion/libraries/datachannel.py
@@ -56,7 +56,10 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = create_static_library_set().get('sources').get('datachannel').get('path')
 
 	if library_path:
-		library = ctypes.CDLL(library_path)
+		if is_windows():
+			library = ctypes.CDLL(library_path, winmode = 0)
+		else:
+			library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/nvidia_ml.py
+++ b/facefusion/libraries/nvidia_ml.py
@@ -1,24 +1,15 @@
 import ctypes
+import ctypes.util
 from functools import lru_cache
 from typing import List, Optional
-
-from facefusion.common_helper import is_linux, is_windows
-
-
-def resolve_library_file() -> Optional[str]:
-	if is_linux():
-		return 'libnvidia-ml.so.1'
-	if is_windows():
-		return 'nvml.dll'
-	return None
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_file = resolve_library_file()
+	library_path = ctypes.util.find_library('nvidia-ml') or ctypes.util.find_library('nvml')
 
-	if library_file:
-		library = ctypes.CDLL(library_file)
+	if library_path:
+		library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/opus.py
+++ b/facefusion/libraries/opus.py
@@ -71,13 +71,10 @@ def init_ctypes(library : ctypes.CDLL) -> ctypes.CDLL:
 	library.opus_encoder_create.argtypes = [ ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.POINTER(ctypes.c_int) ]
 	library.opus_encoder_create.restype = ctypes.c_void_p
 
-	library.opus_encode_float.argtypes = [ ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int ]
+	library.opus_encode_float.argtypes = [ ctypes.c_void_p, ctypes.POINTER(ctypes.c_float), ctypes.c_int, ctypes.c_char_p, ctypes.c_int ]
 	library.opus_encode_float.restype = ctypes.c_int
 
 	library.opus_encoder_destroy.argtypes = [ ctypes.c_void_p ]
 	library.opus_encoder_destroy.restype = None
-
-	library.opus_encoder_ctl.argtypes = [ ctypes.c_void_p, ctypes.c_int, ctypes.c_int ]
-	library.opus_encoder_ctl.restype = ctypes.c_int
 
 	return library

--- a/facefusion/libraries/opus.py
+++ b/facefusion/libraries/opus.py
@@ -1,15 +1,65 @@
 import ctypes
-import ctypes.util
+import os
 from functools import lru_cache
-from typing import Optional
+from typing import Dict, Optional, Tuple
+
+from facefusion.common_helper import is_linux, is_macos, is_windows
+from facefusion.download import conditional_download_hashes, conditional_download_sources, resolve_download_url_by_provider
+from facefusion.filesystem import resolve_relative_path
+from facefusion.types import DownloadSet
+
+
+def resolve_library_paths() -> Optional[Tuple[str, str]]:
+	if is_linux():
+		return 'linux/libopus.hash', 'linux/libopus.so'
+	if is_macos():
+		return 'macos/libopus.hash', 'macos/libopus.dylib'
+	if is_windows():
+		return 'windows/opus.hash', 'windows/opus.dll'
+	return None
+
+
+@lru_cache
+def create_static_library_set() -> Dict[str, DownloadSet]:
+	library_hash_path, library_source_path = resolve_library_paths()
+
+	return\
+	{
+		'hashes':
+		{
+			'opus':
+			{
+				'url': resolve_download_url_by_provider('huggingface', 'libraries-4.0.0', library_hash_path),
+				'path': resolve_relative_path('../.libraries/' + os.path.basename(library_hash_path))
+			}
+		},
+		'sources':
+		{
+			'opus':
+			{
+				'url': resolve_download_url_by_provider('huggingface', 'libraries-4.0.0', library_source_path),
+				'path': resolve_relative_path('../.libraries/' + os.path.basename(library_source_path))
+			}
+		}
+	}
+
+
+def pre_check() -> bool:
+	library_hash_set = create_static_library_set().get('hashes')
+	library_source_set = create_static_library_set().get('sources')
+
+	return conditional_download_hashes(library_hash_set) and conditional_download_sources(library_source_set)
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_path = ctypes.util.find_library('opus') or ctypes.util.find_library('libopus')
+	library_path = create_static_library_set().get('sources').get('opus').get('path')
 
 	if library_path:
-		library = ctypes.CDLL(library_path)
+		if is_windows():
+			library = ctypes.CDLL(library_path, winmode = 0)
+		else:
+			library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/opus.py
+++ b/facefusion/libraries/opus.py
@@ -1,26 +1,15 @@
 import ctypes
+import ctypes.util
 from functools import lru_cache
 from typing import Optional
-
-from facefusion.common_helper import is_linux, is_macos, is_windows
-
-
-def resolve_library_file() -> Optional[str]:
-	if is_linux():
-		return 'libopus.so.0'
-	if is_macos():
-		return 'libopus.dylib'
-	if is_windows():
-		return 'opus.dll'
-	return None
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_file = resolve_library_file()
+	library_path = ctypes.util.find_library('opus')
 
-	if library_file:
-		library = ctypes.CDLL(library_file)
+	if library_path:
+		library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/opus.py
+++ b/facefusion/libraries/opus.py
@@ -1,12 +1,21 @@
 import ctypes
 import ctypes.util
+import os
 from functools import lru_cache
 from typing import Optional
+
+from facefusion.common_helper import is_macos
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = ctypes.util.find_library('opus')
+
+	if not library_path and is_macos():
+		for brew_path in [ '/opt/homebrew/lib/libopus.dylib', '/usr/local/lib/libopus.dylib' ]:
+			if os.path.isfile(brew_path):
+				library_path = brew_path
+				break
 
 	if library_path:
 		library = ctypes.CDLL(library_path)

--- a/facefusion/libraries/opus.py
+++ b/facefusion/libraries/opus.py
@@ -4,7 +4,7 @@ import os
 from functools import lru_cache
 from typing import Optional
 
-from facefusion.common_helper import is_macos
+from facefusion.common_helper import is_macos, is_windows
 
 
 @lru_cache
@@ -15,6 +15,12 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 		for brew_path in [ '/opt/homebrew/lib/libopus.dylib', '/usr/local/lib/libopus.dylib' ]:
 			if os.path.isfile(brew_path):
 				library_path = brew_path
+				break
+
+	if not library_path and is_windows():
+		for windows_path in [ 'C:/vcpkg/installed/x64-windows/bin/opus.dll' ]:
+			if os.path.isfile(windows_path):
+				library_path = windows_path
 				break
 
 	if library_path:

--- a/facefusion/libraries/opus.py
+++ b/facefusion/libraries/opus.py
@@ -1,27 +1,12 @@
 import ctypes
 import ctypes.util
-import os
 from functools import lru_cache
 from typing import Optional
-
-from facefusion.common_helper import is_macos, is_windows
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = ctypes.util.find_library('opus')
-
-	if not library_path and is_macos():
-		for brew_path in [ '/opt/homebrew/lib/libopus.dylib', '/usr/local/lib/libopus.dylib' ]:
-			if os.path.isfile(brew_path):
-				library_path = brew_path
-				break
-
-	if not library_path and is_windows():
-		for windows_path in [ 'C:/vcpkg/installed/x64-windows/bin/opus.dll' ]:
-			if os.path.isfile(windows_path):
-				library_path = windows_path
-				break
 
 	if library_path:
 		library = ctypes.CDLL(library_path)

--- a/facefusion/libraries/opus.py
+++ b/facefusion/libraries/opus.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_path = ctypes.util.find_library('opus')
+	library_path = ctypes.util.find_library('opus') or ctypes.util.find_library('libopus')
 
 	if library_path:
 		library = ctypes.CDLL(library_path)

--- a/facefusion/libraries/rocm_core.py
+++ b/facefusion/libraries/rocm_core.py
@@ -1,22 +1,15 @@
 import ctypes
+import ctypes.util
 from functools import lru_cache
 from typing import Optional
-
-from facefusion.common_helper import is_linux
-
-
-def resolve_library_file() -> Optional[str]:
-	if is_linux():
-		return 'librocm-core.so'
-	return None
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_file = resolve_library_file()
+	library_path = ctypes.util.find_library('rocm-core')
 
-	if library_file:
-		library = ctypes.CDLL(library_file)
+	if library_path:
+		library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -1,15 +1,65 @@
 import ctypes
-import ctypes.util
+import os
 from functools import lru_cache
-from typing import Optional
+from typing import Dict, Optional, Tuple
+
+from facefusion.common_helper import is_linux, is_macos, is_windows
+from facefusion.download import conditional_download_hashes, conditional_download_sources, resolve_download_url_by_provider
+from facefusion.filesystem import resolve_relative_path
+from facefusion.types import DownloadSet
+
+
+def resolve_library_paths() -> Optional[Tuple[str, str]]:
+	if is_linux():
+		return 'linux/libvpx.hash', 'linux/libvpx.so'
+	if is_macos():
+		return 'macos/libvpx.hash', 'macos/libvpx.dylib'
+	if is_windows():
+		return 'windows/vpx.hash', 'windows/vpx.dll'
+	return None
+
+
+@lru_cache
+def create_static_library_set() -> Dict[str, DownloadSet]:
+	library_hash_path, library_source_path = resolve_library_paths()
+
+	return\
+	{
+		'hashes':
+		{
+			'vpx':
+			{
+				'url': resolve_download_url_by_provider('huggingface', 'libraries-4.0.0', library_hash_path),
+				'path': resolve_relative_path('../.libraries/' + os.path.basename(library_hash_path))
+			}
+		},
+		'sources':
+		{
+			'vpx':
+			{
+				'url': resolve_download_url_by_provider('huggingface', 'libraries-4.0.0', library_source_path),
+				'path': resolve_relative_path('../.libraries/' + os.path.basename(library_source_path))
+			}
+		}
+	}
+
+
+def pre_check() -> bool:
+	library_hash_set = create_static_library_set().get('hashes')
+	library_source_set = create_static_library_set().get('sources')
+
+	return conditional_download_hashes(library_hash_set) and conditional_download_sources(library_source_set)
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_path = ctypes.util.find_library('vpx') or ctypes.util.find_library('libvpx')
+	library_path = create_static_library_set().get('sources').get('vpx').get('path')
 
 	if library_path:
-		library = ctypes.CDLL(library_path)
+		if is_windows():
+			library = ctypes.CDLL(library_path, winmode = 0)
+		else:
+			library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_path = ctypes.util.find_library('vpx')
+	library_path = ctypes.util.find_library('vpx') or ctypes.util.find_library('libvpx')
 
 	if library_path:
 		library = ctypes.CDLL(library_path)

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -1,12 +1,21 @@
 import ctypes
 import ctypes.util
+import os
 from functools import lru_cache
 from typing import Optional
+
+from facefusion.common_helper import is_macos
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = ctypes.util.find_library('vpx')
+
+	if not library_path and is_macos():
+		for brew_path in [ '/opt/homebrew/lib/libvpx.dylib', '/usr/local/lib/libvpx.dylib' ]:
+			if os.path.isfile(brew_path):
+				library_path = brew_path
+				break
 
 	if library_path:
 		library = ctypes.CDLL(library_path)

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -1,26 +1,15 @@
 import ctypes
+import ctypes.util
 from functools import lru_cache
 from typing import Optional
-
-from facefusion.common_helper import is_linux, is_macos, is_windows
-
-
-def resolve_library_file() -> Optional[str]:
-	if is_linux():
-		return 'libvpx.so'
-	if is_macos():
-		return 'libvpx.dylib'
-	if is_windows():
-		return 'vpx.dll'
-	return None
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
-	library_file = resolve_library_file()
+	library_path = ctypes.util.find_library('vpx')
 
-	if library_file:
-		library = ctypes.CDLL(library_file)
+	if library_path:
+		library = ctypes.CDLL(library_path)
 
 		if library:
 			return init_ctypes(library)

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -1,27 +1,12 @@
 import ctypes
 import ctypes.util
-import os
 from functools import lru_cache
 from typing import Optional
-
-from facefusion.common_helper import is_macos, is_windows
 
 
 @lru_cache
 def create_static_library() -> Optional[ctypes.CDLL]:
 	library_path = ctypes.util.find_library('vpx')
-
-	if not library_path and is_macos():
-		for brew_path in [ '/opt/homebrew/lib/libvpx.dylib', '/usr/local/lib/libvpx.dylib' ]:
-			if os.path.isfile(brew_path):
-				library_path = brew_path
-				break
-
-	if not library_path and is_windows():
-		for windows_path in [ 'C:/msys64/mingw64/bin/libvpx-1.dll', 'C:/vcpkg/installed/x64-windows/bin/vpx.dll' ]:
-			if os.path.isfile(windows_path):
-				library_path = windows_path
-				break
 
 	if library_path:
 		library = ctypes.CDLL(library_path)

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -4,7 +4,7 @@ import os
 from functools import lru_cache
 from typing import Optional
 
-from facefusion.common_helper import is_macos
+from facefusion.common_helper import is_macos, is_windows
 
 
 @lru_cache
@@ -15,6 +15,12 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 		for brew_path in [ '/opt/homebrew/lib/libvpx.dylib', '/usr/local/lib/libvpx.dylib' ]:
 			if os.path.isfile(brew_path):
 				library_path = brew_path
+				break
+
+	if not library_path and is_windows():
+		for windows_path in [ 'C:/vcpkg/installed/x64-windows/bin/vpx-1.dll' ]:
+			if os.path.isfile(windows_path):
+				library_path = windows_path
 				break
 
 	if library_path:

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -18,7 +18,7 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 				break
 
 	if not library_path and is_windows():
-		for windows_path in [ 'C:/vcpkg/installed/x64-windows/bin/vpx-1.dll' ]:
+		for windows_path in [ 'C:/vcpkg/installed/x64-windows/bin/vpx.dll', 'C:/vcpkg/installed/x64-windows/bin/vpx-1.dll' ]:
 			if os.path.isfile(windows_path):
 				library_path = windows_path
 				break

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -18,7 +18,7 @@ def create_static_library() -> Optional[ctypes.CDLL]:
 				break
 
 	if not library_path and is_windows():
-		for windows_path in [ 'C:/vcpkg/installed/x64-windows/bin/vpx.dll', 'C:/vcpkg/installed/x64-windows/bin/vpx-1.dll' ]:
+		for windows_path in [ 'C:/msys64/mingw64/bin/libvpx-1.dll', 'C:/vcpkg/installed/x64-windows/bin/vpx.dll' ]:
 			if os.path.isfile(windows_path):
 				library_path = windows_path
 				break

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -20,6 +20,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.mp3',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_api_state.py
+++ b/tests/test_api_state.py
@@ -49,6 +49,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -8,8 +8,8 @@ import pytest
 from starlette.testclient import TestClient
 
 from facefusion import metadata, session_manager, state_manager
-from facefusion.common_helper import is_macos, is_windows
 from facefusion.apis import asset_store
+from facefusion.common_helper import is_macos, is_windows
 from facefusion.apis.core import create_api
 from facefusion.core import common_pre_check, processors_pre_check
 from facefusion.download import conditional_download
@@ -102,7 +102,7 @@ def test_stream_image(test_client : TestClient) -> None:
 
 
 #TODO: figure out why this fails
-@pytest.mark.skipif(is_macos() or is_windows())
+@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
 def test_stream_video(test_client : TestClient) -> None:
 	create_session_response = test_client.post('/session', json =
 	{

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -12,7 +12,7 @@ from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
 from facefusion.core import common_pre_check, processors_pre_check
 from facefusion.download import conditional_download
-from facefusion.libraries import datachannel as datachannel_module
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from .assert_helper import get_test_example_file, get_test_examples_directory
 from .stream_helper import create_sdp_offer, open_websocket_stream
 
@@ -39,7 +39,6 @@ def before_all() -> None:
 
 	common_pre_check()
 	processors_pre_check()
-	datachannel_module.pre_check()
 
 	conditional_download(get_test_examples_directory(),
 	[

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -7,7 +7,7 @@ import numpy
 import pytest
 from starlette.testclient import TestClient
 
-from facefusion import metadata, session_manager, state_manager
+from facefusion import environment, metadata, session_manager, state_manager
 from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
 
@@ -20,6 +20,7 @@ from .stream_helper import create_sdp_offer, open_websocket_stream
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
+	environment.setup()
 	state_manager.init_item('execution_device_ids', [ 0 ])
 	state_manager.init_item('execution_providers', [ 'cpu' ])
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -10,7 +10,6 @@ from starlette.testclient import TestClient
 from facefusion import environment, metadata, session_manager, state_manager
 from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
-
 from facefusion.core import common_pre_check, processors_pre_check
 from facefusion.download import conditional_download
 from facefusion.libraries import datachannel as datachannel_module

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -8,6 +8,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from facefusion import metadata, session_manager, state_manager
+from facefusion.common_helper import is_macos, is_windows
 from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
 from facefusion.core import common_pre_check, processors_pre_check
@@ -100,6 +101,8 @@ def test_stream_image(test_client : TestClient) -> None:
 	assert output_vision_frame.shape == (1024, 1024, 3)
 
 
+#TODO: figure out why this fails
+@pytest.mark.skipif(is_macos() or is_windows())
 def test_stream_video(test_client : TestClient) -> None:
 	create_session_response = test_client.post('/session', json =
 	{

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -10,7 +10,7 @@ from starlette.testclient import TestClient
 from facefusion import metadata, session_manager, state_manager
 from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
-from facefusion.common_helper import is_macos, is_windows
+from facefusion.common_helper import is_windows
 from facefusion.core import common_pre_check, processors_pre_check
 from facefusion.download import conditional_download
 from facefusion.libraries import datachannel as datachannel_module
@@ -101,8 +101,7 @@ def test_stream_image(test_client : TestClient) -> None:
 	assert output_vision_frame.shape == (1024, 1024, 3)
 
 
-#TODO: figure out why this fails
-@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_stream_video(test_client : TestClient) -> None:
 	create_session_response = test_client.post('/session', json =
 	{

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -7,7 +7,7 @@ import numpy
 import pytest
 from starlette.testclient import TestClient
 
-from facefusion import environment, metadata, session_manager, state_manager
+from facefusion import metadata, session_manager, state_manager
 from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
 from facefusion.core import common_pre_check, processors_pre_check
@@ -19,8 +19,6 @@ from .stream_helper import create_sdp_offer, open_websocket_stream
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup_for_system()
-
 	state_manager.init_item('execution_device_ids', [ 0 ])
 	state_manager.init_item('execution_providers', [ 'cpu' ])
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -10,7 +10,7 @@ from starlette.testclient import TestClient
 from facefusion import metadata, session_manager, state_manager
 from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
-from facefusion.common_helper import is_windows
+
 from facefusion.core import common_pre_check, processors_pre_check
 from facefusion.download import conditional_download
 from facefusion.libraries import datachannel as datachannel_module
@@ -101,7 +101,6 @@ def test_stream_image(test_client : TestClient) -> None:
 	assert output_vision_frame.shape == (1024, 1024, 3)
 
 
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_stream_video(test_client : TestClient) -> None:
 	create_session_response = test_client.post('/session', json =
 	{

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -12,7 +12,6 @@ from facefusion.apis import asset_store
 from facefusion.apis.core import create_api
 from facefusion.core import common_pre_check, processors_pre_check
 from facefusion.download import conditional_download
-from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from .assert_helper import get_test_example_file, get_test_examples_directory
 from .stream_helper import create_sdp_offer, open_websocket_stream
 

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -21,6 +21,7 @@ from .stream_helper import create_sdp_offer, open_websocket_stream
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	environment.setup_for_system()
+
 	state_manager.init_item('execution_device_ids', [ 0 ])
 	state_manager.init_item('execution_providers', [ 'cpu' ])
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -20,7 +20,7 @@ from .stream_helper import create_sdp_offer, open_websocket_stream
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup()
+	environment.setup_for_system()
 	state_manager.init_item('execution_device_ids', [ 0 ])
 	state_manager.init_item('execution_providers', [ 'cpu' ])
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])

--- a/tests/test_api_stream.py
+++ b/tests/test_api_stream.py
@@ -9,8 +9,8 @@ from starlette.testclient import TestClient
 
 from facefusion import metadata, session_manager, state_manager
 from facefusion.apis import asset_store
-from facefusion.common_helper import is_macos, is_windows
 from facefusion.apis.core import create_api
+from facefusion.common_helper import is_macos, is_windows
 from facefusion.core import common_pre_check, processors_pre_check
 from facefusion.download import conditional_download
 from facefusion.libraries import datachannel as datachannel_module

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -14,6 +14,7 @@ def before_all() -> None:
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.mp3'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.mp3'), get_test_example_file('source.wav') ])
 
 

--- a/tests/test_cli_age_modifier.py
+++ b/tests/test_cli_age_modifier.py
@@ -14,6 +14,7 @@ def before_all() -> None:
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_background_remover.py
+++ b/tests/test_cli_background_remover.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_batch_runner.py
+++ b/tests/test_cli_batch_runner.py
@@ -14,6 +14,7 @@ def before_all() -> None:
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p-batch-1.jpg') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '2', get_test_example_file('target-240p-batch-2.jpg') ])
 

--- a/tests/test_cli_expression_restorer.py
+++ b/tests/test_cli_expression_restorer.py
@@ -14,6 +14,7 @@ def before_all() -> None:
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_face_debugger.py
+++ b/tests/test_cli_face_debugger.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_face_editor.py
+++ b/tests/test_cli_face_editor.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_face_enhancer.py
+++ b/tests/test_cli_face_enhancer.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_face_swapper.py
+++ b/tests/test_cli_face_swapper.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_frame_colorizer.py
+++ b/tests/test_cli_frame_colorizer.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', '-vf', 'hue=s=0', get_test_example_file('target-240p-0sat.jpg') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vf', 'hue=s=0', get_test_example_file('target-240p-0sat.mp4') ])
 

--- a/tests/test_cli_frame_enhancer.py
+++ b/tests/test_cli_frame_enhancer.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_job_manager.py
+++ b/tests/test_cli_job_manager.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_job_runner.py
+++ b/tests/test_cli_job_runner.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_lip_syncer.py
+++ b/tests/test_cli_lip_syncer.py
@@ -16,6 +16,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.mp3',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_cli_output_scale.py
+++ b/tests/test_cli_output_scale.py
@@ -17,6 +17,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_face_analyser.py
+++ b/tests/test_face_analyser.py
@@ -12,13 +12,6 @@ from .assert_helper import get_test_example_file, get_test_examples_directory
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	conditional_download(get_test_examples_directory(),
-	[
-		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg'
-	])
-	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.jpg'), '-vf', 'crop=iw*0.8:ih*0.8', get_test_example_file('source-80crop.jpg') ])
-	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.jpg'), '-vf', 'crop=iw*0.7:ih*0.7', get_test_example_file('source-70crop.jpg') ])
-	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.jpg'), '-vf', 'crop=iw*0.6:ih*0.6', get_test_example_file('source-60crop.jpg') ])
 	state_manager.init_item('execution_device_ids', [ 0 ])
 	state_manager.init_item('execution_providers', [ 'cpu' ])
 	state_manager.init_item('download_providers', [ 'github' ])
@@ -27,9 +20,19 @@ def before_all() -> None:
 	state_manager.init_item('face_detector_score', 0.5)
 	state_manager.init_item('face_landmarker_model', 'many')
 	state_manager.init_item('face_landmarker_score', 0.5)
+
 	face_classifier.pre_check()
 	face_landmarker.pre_check()
 	face_recognizer.pre_check()
+
+	conditional_download(get_test_examples_directory(),
+	[
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg'
+	])
+
+	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.jpg'), '-vf', 'crop=iw*0.8:ih*0.8', get_test_example_file('source-80crop.jpg') ])
+	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.jpg'), '-vf', 'crop=iw*0.7:ih*0.7', get_test_example_file('source-70crop.jpg') ])
+	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.jpg'), '-vf', 'crop=iw*0.6:ih*0.6', get_test_example_file('source-60crop.jpg') ])
 
 
 @pytest.fixture(autouse = True)

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -18,12 +18,22 @@ from .assert_helper import get_test_example_file, get_test_examples_directory, g
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	process_manager.start()
+	state_manager.init_item('temp_path', tempfile.gettempdir())
+	state_manager.init_item('temp_frame_format', 'png')
+	state_manager.init_item('output_audio_encoder', 'aac')
+	state_manager.init_item('output_audio_quality', 100)
+	state_manager.init_item('output_audio_volume', 100)
+	state_manager.init_item('output_video_encoder', 'libx264')
+	state_manager.init_item('output_video_quality', 100)
+	state_manager.init_item('output_video_preset', 'ultrafast')
+
 	conditional_download(get_test_examples_directory(),
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.mp3',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.mp3'), get_test_example_file('source.wav') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vf', 'fps=25', get_test_example_file('target-240p-25fps.mp4') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vf', 'fps=30', get_test_example_file('target-240p-30fps.mp4') ])
@@ -34,14 +44,6 @@ def before_all() -> None:
 
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.mp3'), '-i', get_test_example_file('target-240p.mp4'), '-ar', '48000', get_test_example_file('target-240p-48khz.mp4') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-c:v', 'libx265', '-an', '-movflags', '+faststart', get_test_example_file('target-240p-h265.mp4') ])
-	state_manager.init_item('temp_path', tempfile.gettempdir())
-	state_manager.init_item('temp_frame_format', 'png')
-	state_manager.init_item('output_audio_encoder', 'aac')
-	state_manager.init_item('output_audio_quality', 100)
-	state_manager.init_item('output_audio_volume', 100)
-	state_manager.init_item('output_video_encoder', 'libx264')
-	state_manager.init_item('output_video_quality', 100)
-	state_manager.init_item('output_video_preset', 'ultrafast')
 
 
 @pytest.fixture(scope = 'function', autouse = True)

--- a/tests/test_ffprobe.py
+++ b/tests/test_ffprobe.py
@@ -11,11 +11,13 @@ from .assert_helper import get_test_example_file, get_test_examples_directory
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	process_manager.start()
+
 	conditional_download(get_test_examples_directory(),
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.mp3',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('source.mp3'), '-t', '1.9', '-ar', '48000', '-ac', '2', get_test_example_file('source-48000khz-2ch.wav') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-t', '1', get_test_example_file('target-240p-1s.mov') ])
 

--- a/tests/test_inference_manager.py
+++ b/tests/test_inference_manager.py
@@ -12,6 +12,7 @@ def before_all() -> None:
 	state_manager.init_item('execution_device_ids', [ 0 ])
 	state_manager.init_item('execution_providers', [ 'cpu' ])
 	state_manager.init_item('download_providers', [ 'github' ])
+
 	content_analyser.pre_check()
 
 

--- a/tests/test_job_runner.py
+++ b/tests/test_job_runner.py
@@ -18,6 +18,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 
 

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -9,6 +9,7 @@ from facefusion.libraries import datachannel as datachannel_module
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+
 	datachannel_module.pre_check()
 
 

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -1,0 +1,7 @@
+import ctypes
+
+from facefusion.libraries import datachannel as datachannel_module
+
+
+def test_create_static_library() -> None:
+	assert isinstance(datachannel_module.create_static_library(), ctypes.CDLL)

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -2,13 +2,15 @@ import ctypes
 
 import pytest
 
-from facefusion import state_manager
+from facefusion import environment, state_manager
 from facefusion.libraries import datachannel as datachannel_module
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+
+	environment.setup_platform()
 
 	datachannel_module.pre_check()
 

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -2,12 +2,13 @@ import ctypes
 
 import pytest
 
-from facefusion import state_manager
+from facefusion import environment, state_manager
 from facefusion.libraries import datachannel as datachannel_module
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
+	environment.setup()
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -3,6 +3,7 @@ import ctypes
 import pytest
 
 from facefusion import state_manager
+from facefusion.common_helper import is_windows
 from facefusion.libraries import datachannel as datachannel_module
 
 
@@ -12,5 +13,7 @@ def before_all() -> None:
 	datachannel_module.pre_check()
 
 
+# TODO: add support for Windows
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_static_library() -> None:
 	assert isinstance(datachannel_module.create_static_library(), ctypes.CDLL)

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -2,13 +2,12 @@ import ctypes
 
 import pytest
 
-from facefusion import environment, state_manager
+from facefusion import state_manager
 from facefusion.libraries import datachannel as datachannel_module
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup_for_system()
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -3,7 +3,6 @@ import ctypes
 import pytest
 
 from facefusion import state_manager
-from facefusion.common_helper import is_windows
 from facefusion.libraries import datachannel as datachannel_module
 
 
@@ -13,7 +12,5 @@ def before_all() -> None:
 	datachannel_module.pre_check()
 
 
-# TODO: add support for Windows
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_static_library() -> None:
 	assert isinstance(datachannel_module.create_static_library(), ctypes.CDLL)

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -1,6 +1,15 @@
 import ctypes
 
+import pytest
+
+from facefusion import state_manager
 from facefusion.libraries import datachannel as datachannel_module
+
+
+@pytest.fixture(scope = 'module', autouse = True)
+def before_all() -> None:
+	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+	datachannel_module.pre_check()
 
 
 def test_create_static_library() -> None:

--- a/tests/test_library_datachannel.py
+++ b/tests/test_library_datachannel.py
@@ -8,7 +8,7 @@ from facefusion.libraries import datachannel as datachannel_module
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup()
+	environment.setup_for_system()
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 

--- a/tests/test_library_opus.py
+++ b/tests/test_library_opus.py
@@ -1,6 +1,14 @@
 import ctypes
 
+import pytest
+
+from facefusion import environment
 from facefusion.libraries import opus as opus_module
+
+
+@pytest.fixture(scope = 'module', autouse = True)
+def before_all() -> None:
+	environment.setup()
 
 
 def test_create_static_library() -> None:

--- a/tests/test_library_opus.py
+++ b/tests/test_library_opus.py
@@ -1,12 +1,19 @@
 import ctypes
 
+import pytest
+
+from facefusion.common_helper import is_windows
 from facefusion.libraries import opus as opus_module
 
 
+# TODO: add support for Windows
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_static_library() -> None:
 	assert isinstance(opus_module.create_static_library(), ctypes.CDLL)
 
 
+# TODO: add support for Windows
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_opus_encoder() -> None:
 	opus_library = opus_module.create_static_library()
 

--- a/tests/test_library_opus.py
+++ b/tests/test_library_opus.py
@@ -2,13 +2,14 @@ import ctypes
 
 import pytest
 
-from facefusion import environment
+from facefusion import state_manager
 from facefusion.libraries import opus as opus_module
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup_for_system()
+	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+	opus_module.pre_check()
 
 
 def test_create_static_library() -> None:

--- a/tests/test_library_opus.py
+++ b/tests/test_library_opus.py
@@ -9,6 +9,7 @@ from facefusion.libraries import opus as opus_module
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+
 	opus_module.pre_check()
 
 

--- a/tests/test_library_opus.py
+++ b/tests/test_library_opus.py
@@ -1,0 +1,13 @@
+import ctypes
+
+from facefusion.libraries import opus as opus_module
+
+
+def test_create_static_library() -> None:
+	assert isinstance(opus_module.create_static_library(), ctypes.CDLL)
+
+
+def test_create_opus_encoder() -> None:
+	opus_library = opus_module.create_static_library()
+
+	assert isinstance(opus_library, ctypes.CDLL)

--- a/tests/test_library_opus.py
+++ b/tests/test_library_opus.py
@@ -1,19 +1,12 @@
 import ctypes
 
-import pytest
-
-from facefusion.common_helper import is_windows
 from facefusion.libraries import opus as opus_module
 
 
-# TODO: add support for Windows
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_static_library() -> None:
 	assert isinstance(opus_module.create_static_library(), ctypes.CDLL)
 
 
-# TODO: add support for Windows
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_opus_encoder() -> None:
 	opus_library = opus_module.create_static_library()
 

--- a/tests/test_library_opus.py
+++ b/tests/test_library_opus.py
@@ -8,7 +8,7 @@ from facefusion.libraries import opus as opus_module
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup()
+	environment.setup_for_system()
 
 
 def test_create_static_library() -> None:

--- a/tests/test_library_vpx.py
+++ b/tests/test_library_vpx.py
@@ -1,19 +1,12 @@
 import ctypes
 
-import pytest
-
-from facefusion.common_helper import is_windows
 from facefusion.libraries import vpx as vpx_module
 
 
-# TODO: add support for Windows
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_static_library() -> None:
 	assert isinstance(vpx_module.create_static_library(), ctypes.CDLL)
 
 
-# TODO: add support for Windows
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_vpx_encoder() -> None:
 	vpx_library = vpx_module.create_static_library()
 

--- a/tests/test_library_vpx.py
+++ b/tests/test_library_vpx.py
@@ -1,12 +1,19 @@
 import ctypes
 
+import pytest
+
+from facefusion.common_helper import is_windows
 from facefusion.libraries import vpx as vpx_module
 
 
+# TODO: add support for Windows
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_static_library() -> None:
 	assert isinstance(vpx_module.create_static_library(), ctypes.CDLL)
 
 
+# TODO: add support for Windows
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_vpx_encoder() -> None:
 	vpx_library = vpx_module.create_static_library()
 

--- a/tests/test_library_vpx.py
+++ b/tests/test_library_vpx.py
@@ -1,0 +1,13 @@
+import ctypes
+
+from facefusion.libraries import vpx as vpx_module
+
+
+def test_create_static_library() -> None:
+	assert isinstance(vpx_module.create_static_library(), ctypes.CDLL)
+
+
+def test_create_vpx_encoder() -> None:
+	vpx_library = vpx_module.create_static_library()
+
+	assert isinstance(vpx_library, ctypes.CDLL)

--- a/tests/test_library_vpx.py
+++ b/tests/test_library_vpx.py
@@ -8,7 +8,7 @@ from facefusion.libraries import vpx as vpx_module
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup()
+	environment.setup_for_system()
 
 
 def test_create_static_library() -> None:

--- a/tests/test_library_vpx.py
+++ b/tests/test_library_vpx.py
@@ -1,6 +1,14 @@
 import ctypes
 
+import pytest
+
+from facefusion import environment
 from facefusion.libraries import vpx as vpx_module
+
+
+@pytest.fixture(scope = 'module', autouse = True)
+def before_all() -> None:
+	environment.setup()
 
 
 def test_create_static_library() -> None:

--- a/tests/test_library_vpx.py
+++ b/tests/test_library_vpx.py
@@ -2,13 +2,14 @@ import ctypes
 
 import pytest
 
-from facefusion import environment
+from facefusion import state_manager
 from facefusion.libraries import vpx as vpx_module
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup_for_system()
+	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+	vpx_module.pre_check()
 
 
 def test_create_static_library() -> None:

--- a/tests/test_library_vpx.py
+++ b/tests/test_library_vpx.py
@@ -9,6 +9,7 @@ from facefusion.libraries import vpx as vpx_module
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+
 	vpx_module.pre_check()
 
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -2,13 +2,14 @@ from typing import List
 
 import pytest
 
-from facefusion import rtc
+from facefusion import rtc, state_manager
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import RtcPeer
 
 
-@pytest.fixture(scope = 'module')
+@pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
+	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 
 
@@ -18,8 +19,6 @@ def test_build_media_description() -> None:
 	assert rtc.build_media_description('video', 96, 'VP8/90000', 'recvonly', 0) == b'm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=recvonly\r\na=mid:0\r\na=rtcp-mux\r\n'
 
 
-# TODO: enable again
-@pytest.mark.skip
 def test_create_peer_connection() -> None:
 	peer_connection = rtc.create_peer_connection()
 	datachannel_library = datachannel_module.create_static_library()
@@ -28,8 +27,6 @@ def test_create_peer_connection() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(peer_connection) == 0
 
 
-# TODO: enable again
-@pytest.mark.skip
 def test_add_audio_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -38,8 +35,6 @@ def test_add_audio_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
-# TODO: enable again
-@pytest.mark.skip
 def test_add_video_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -48,8 +43,6 @@ def test_add_video_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
-# TODO: enable again
-@pytest.mark.skip
 def test_negotiate_sdp() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 
@@ -73,8 +66,6 @@ def test_negotiate_sdp() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(receiver_connection) == 0
 
 
-# TODO: enable again
-@pytest.mark.skip
 def test_delete_peers() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	peer_connection = rtc.create_peer_connection()

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -3,14 +3,17 @@ from typing import List
 import pytest
 
 from facefusion import rtc, state_manager
-from facefusion.libraries import datachannel as datachannel_module
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.types import RtcPeer
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+
 	datachannel_module.pre_check()
+	opus_module.pre_check()
+	vpx_module.pre_check()
 
 
 # TODO: add test_parse_sdp_payload_types

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -3,7 +3,6 @@ from typing import List
 import pytest
 
 from facefusion import rtc, state_manager
-from facefusion.common_helper import is_windows
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import RtcPeer
 
@@ -15,13 +14,11 @@ def before_all() -> None:
 
 
 # TODO: add test_parse_sdp_payload_types
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_build_media_description() -> None:
 	assert rtc.build_media_description('audio', 111, 'opus/48000/2', 'sendonly', 1) == b'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\na=rtcp-fb:111 nack\r\na=rtcp-fb:111 nack pli\r\na=sendonly\r\na=mid:1\r\na=rtcp-mux\r\n'
 	assert rtc.build_media_description('video', 96, 'VP8/90000', 'recvonly', 0) == b'm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=recvonly\r\na=mid:0\r\na=rtcp-mux\r\n'
 
 
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_peer_connection() -> None:
 	peer_connection = rtc.create_peer_connection()
 	datachannel_library = datachannel_module.create_static_library()
@@ -30,7 +27,6 @@ def test_create_peer_connection() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(peer_connection) == 0
 
 
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_add_audio_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -39,7 +35,6 @@ def test_add_audio_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_add_video_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -48,7 +43,6 @@ def test_add_video_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_negotiate_sdp() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 
@@ -72,7 +66,6 @@ def test_negotiate_sdp() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(receiver_connection) == 0
 
 
-@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_delete_peers() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	peer_connection = rtc.create_peer_connection()

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -3,6 +3,7 @@ from typing import List
 import pytest
 
 from facefusion import rtc, state_manager
+from facefusion.common_helper import is_macos, is_windows
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import RtcPeer
 
@@ -14,11 +15,13 @@ def before_all() -> None:
 
 
 # TODO: add test_parse_sdp_payload_types
+@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
 def test_build_media_description() -> None:
 	assert rtc.build_media_description('audio', 111, 'opus/48000/2', 'sendonly', 1) == b'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\na=rtcp-fb:111 nack\r\na=rtcp-fb:111 nack pli\r\na=sendonly\r\na=mid:1\r\na=rtcp-mux\r\n'
 	assert rtc.build_media_description('video', 96, 'VP8/90000', 'recvonly', 0) == b'm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=recvonly\r\na=mid:0\r\na=rtcp-mux\r\n'
 
 
+@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
 def test_create_peer_connection() -> None:
 	peer_connection = rtc.create_peer_connection()
 	datachannel_library = datachannel_module.create_static_library()
@@ -27,6 +30,7 @@ def test_create_peer_connection() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(peer_connection) == 0
 
 
+@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
 def test_add_audio_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -35,6 +39,7 @@ def test_add_audio_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
+@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
 def test_add_video_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -43,6 +48,7 @@ def test_add_video_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
+@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
 def test_negotiate_sdp() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 
@@ -66,6 +72,7 @@ def test_negotiate_sdp() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(receiver_connection) == 0
 
 
+@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
 def test_delete_peers() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	peer_connection = rtc.create_peer_connection()

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -9,7 +9,7 @@ from facefusion.types import RtcPeer
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup()
+	environment.setup_for_system()
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 from facefusion import rtc, state_manager
-from facefusion.common_helper import is_macos, is_windows
+from facefusion.common_helper import is_windows
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import RtcPeer
 
@@ -15,13 +15,13 @@ def before_all() -> None:
 
 
 # TODO: add test_parse_sdp_payload_types
-@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_build_media_description() -> None:
 	assert rtc.build_media_description('audio', 111, 'opus/48000/2', 'sendonly', 1) == b'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\na=rtcp-fb:111 nack\r\na=rtcp-fb:111 nack pli\r\na=sendonly\r\na=mid:1\r\na=rtcp-mux\r\n'
 	assert rtc.build_media_description('video', 96, 'VP8/90000', 'recvonly', 0) == b'm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=recvonly\r\na=mid:0\r\na=rtcp-mux\r\n'
 
 
-@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_create_peer_connection() -> None:
 	peer_connection = rtc.create_peer_connection()
 	datachannel_library = datachannel_module.create_static_library()
@@ -30,7 +30,7 @@ def test_create_peer_connection() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(peer_connection) == 0
 
 
-@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_add_audio_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -39,7 +39,7 @@ def test_add_audio_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
-@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_add_video_track() -> None:
 	peer_connection = rtc.create_peer_connection()
 
@@ -48,7 +48,7 @@ def test_add_video_track() -> None:
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
 
 
-@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_negotiate_sdp() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 
@@ -72,7 +72,7 @@ def test_negotiate_sdp() -> None:
 	assert datachannel_library.rtcDeletePeerConnection(receiver_connection) == 0
 
 
-@pytest.mark.skipif(is_macos() or is_windows(), reason = 'not supported on macOS and Windows')
+@pytest.mark.skipif(is_windows(), reason = 'not supported on Windows')
 def test_delete_peers() -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	peer_connection = rtc.create_peer_connection()

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -2,14 +2,13 @@ from typing import List
 
 import pytest
 
-from facefusion import environment, rtc, state_manager
+from facefusion import rtc, state_manager
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import RtcPeer
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
-	environment.setup_for_system()
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -2,13 +2,14 @@ from typing import List
 
 import pytest
 
-from facefusion import rtc, state_manager
+from facefusion import environment, rtc, state_manager
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import RtcPeer
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
+	environment.setup()
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 

--- a/tests/test_rtc_store.py
+++ b/tests/test_rtc_store.py
@@ -1,13 +1,16 @@
 import pytest
 
 from facefusion import state_manager
-from facefusion.libraries import datachannel as datachannel_module
+from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+
 	datachannel_module.pre_check()
+	opus_module.pre_check()
+	vpx_module.pre_check()
 
 
 # TODO: test create_rtc_stream, get_rtc_stream, destroy_rtc_stream lifecycle

--- a/tests/test_rtc_store.py
+++ b/tests/test_rtc_store.py
@@ -1,10 +1,12 @@
 import pytest
 
+from facefusion import state_manager
 from facefusion.libraries import datachannel as datachannel_module
 
 
-@pytest.fixture(scope = 'module')
+@pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
+	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
 	datachannel_module.pre_check()
 
 

--- a/tests/test_temp_helper.py
+++ b/tests/test_temp_helper.py
@@ -11,12 +11,13 @@ from .assert_helper import get_test_example_file, get_test_examples_directory
 
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
+	state_manager.init_item('temp_path', tempfile.gettempdir())
+	state_manager.init_item('temp_frame_format', 'png')
+
 	conditional_download(get_test_examples_directory(),
 	[
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
 	])
-	state_manager.init_item('temp_path', tempfile.gettempdir())
-	state_manager.init_item('temp_frame_format', 'png')
 
 
 def test_get_temp_file_path() -> None:

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -15,6 +15,7 @@ def before_all() -> None:
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4',
 		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-1080p.mp4'
 	])
+
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('目标-240p.webp') ])
 	subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-1080p.mp4'), '-vframes', '1', get_test_example_file('target-1080p.jpg') ])


### PR DESCRIPTION
## Summary

- Switch `datachannel`, `opus` and `vpx` from system-installed to self-hosted binaries downloaded from HuggingFace with hash verification
- Each library module now has `resolve_library_paths()`, `create_static_library_set()` and `pre_check()` following the model download pattern
- Simplify `amd_smi`, `nvidia_ml` and `rocm_core` by removing hardcoded filenames in favor of `ctypes.util.find_library`
- Rename `conda.py` to `environment.py` and split into `setup_conda()` and `setup_platform()`
- Add `setup_platform()` to resolve macOS library linking against Homebrew's OpenSSL
- Add Windows support for all libraries via `winmode = 0`
- Add `test_library_datachannel`, `test_library_opus` and `test_library_vpx`
- Run all tests in CI instead of a cherry-picked subset


## Test Plan

- [ ] Verify `test_library_datachannel`, `test_library_opus` and `test_library_vpx` pass on Linux and Windows
- [ ] Verify self-hosted binaries download correctly with hash verification
- [ ] Verify RTC and streaming tests still pass
- [ ] Verify GPU detection libraries (`amd_smi`, `nvidia_ml`, `rocm_core`) still load via `find_library`

@harisreedhar marked so you can follow the changes
