### PR TITLE
Refactor stream_helper: queue-based audio/video loops with unified threading

### DIFF
--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -156,12 +156,12 @@ def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 		output_resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 
 		if output_resolution == temp_resolution:
-			yuv_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
-			frame_buffer = encode_aom_buffer(aom_encoder, yuv_frame.tobytes(), output_resolution, timestamp)
+			output_frame_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+			output_frame_buffer = encode_aom_buffer(aom_encoder, output_frame_buffer, output_resolution, timestamp)
 			rtc_peers = rtc_store.get_rtc_peers(session_id)
 
-			if frame_buffer and rtc_peers:
-				rtc.send_video_to_peers(rtc_peers, frame_buffer)
+			if output_frame_buffer and rtc_peers:
+				rtc.send_video_to_peers(rtc_peers, output_frame_buffer)
 
 			timestamp += 1
 			vision_frame = vision_frame_queue.get()
@@ -188,12 +188,12 @@ def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 		output_resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 
 		if output_resolution == temp_resolution:
-			yuv_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
-			frame_buffer = encode_vpx_buffer(vpx_encoder, yuv_frame.tobytes(), output_resolution, timestamp)
+			output_frame_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+			output_frame_buffer = encode_vpx_buffer(vpx_encoder, output_frame_buffer, output_resolution, timestamp)
 			rtc_peers = rtc_store.get_rtc_peers(session_id)
 
-			if frame_buffer and rtc_peers:
-				rtc.send_video_to_peers(rtc_peers, frame_buffer)
+			if output_frame_buffer and rtc_peers:
+				rtc.send_video_to_peers(rtc_peers, output_frame_buffer)
 
 			timestamp += 1
 			vision_frame = vision_frame_queue.get()

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -14,7 +14,7 @@ from facefusion.codecs.aom import create_aom_encoder, destroy_aom_encoder, encod
 from facefusion.codecs.opus import create_opus_encoder, destroy_opus_encoder, encode_opus_buffer
 from facefusion.codecs.vpx import create_vpx_encoder, destroy_vpx_encoder, encode_vpx_buffer
 from facefusion.streamer import process_vision_frame
-from facefusion.types import AudioCodec, OpusEncoder, PeerConnection, Resolution, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame
+from facefusion.types import AudioCodec, PeerConnection, Resolution, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame
 
 
 async def handle_video_stream(websocket : WebSocket) -> None:
@@ -43,7 +43,6 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 			vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
 			audio_chunk_queue : queue.Queue[Optional[bytes]] = queue.Queue()
 			audio_temp = numpy.array([], dtype = numpy.float32)
-			opus_encoder = create_opus_encoder(48000, 2)
 
 			vision_frame_queue.put(first_vision_frame)
 			rtc_store.create_rtc_peers(session_id)
@@ -55,7 +54,7 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 			if stream_codec == 'vp8':
 				video_encode_task = event_loop.run_in_executor(None, run_vp8_encode_loop, vision_frame_queue, session_id, resolution)
 
-			audio_encode_task = event_loop.run_in_executor(None, run_opus_encode_loop, audio_chunk_queue, session_id, opus_encoder)
+			audio_encode_task = event_loop.run_in_executor(None, run_opus_encode_loop, audio_chunk_queue, session_id)
 			await websocket.send_text('ready')
 
 			async for frame_type, frame_buffer in stream_frames:
@@ -208,7 +207,8 @@ def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 		destroy_vpx_encoder(vpx_encoder)
 
 
-def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], session_id : SessionId, opus_encoder : OpusEncoder) -> None:
+def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], session_id : SessionId) -> None:
+	opus_encoder = create_opus_encoder(48000, 2)
 	audio_timestamp = 0
 
 	audio_chunk = audio_chunk_queue.get()

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -17,6 +17,7 @@ from facefusion.streamer import process_vision_frame
 from facefusion.types import AudioCodec, PeerConnection, Resolution, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame
 
 
+# TODO: refine this method
 async def handle_video_stream(websocket : WebSocket) -> None:
 	subprotocol = get_sec_websocket_protocol(websocket.scope)
 	access_token = extract_access_token(websocket.scope)
@@ -143,6 +144,7 @@ def add_rtc_viewer(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[Sdp
 	return None
 
 
+# TODO: combine both encode loop method to one
 def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, frame_resolution : Resolution) -> None:
 	aom_encoder = create_aom_encoder(frame_resolution, 4500, 8, 10)
 	temp_resolution = frame_resolution
@@ -175,6 +177,7 @@ def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 		destroy_aom_encoder(aom_encoder)
 
 
+# TODO: combine both encode loop method to one
 def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, frame_resolution : Resolution) -> None:
 	vpx_encoder = create_vpx_encoder(frame_resolution, 4500, 8, 16)
 	temp_resolution = frame_resolution
@@ -213,7 +216,7 @@ def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], sessi
 
 	audio_chunk = audio_chunk_queue.get()
 
-	while audio_chunk:
+	while audio_chunk: # TODO: improve this condition with b''
 		audio_buffer = encode_opus_buffer(opus_encoder, audio_chunk, 960)
 		rtc_peers = rtc_store.get_rtc_peers(session_id)
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -63,10 +63,8 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 					vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
 
 					if numpy.any(vision_frame):
-						try:
+						if vision_frame_queue.qsize():
 							vision_frame_queue.get_nowait()
-						except queue.Empty:
-							pass
 						vision_frame_queue.put(vision_frame)
 
 				if frame_type == 2:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,5 +1,5 @@
 import asyncio
-import queue
+import queue # TODO: try deque
 from collections.abc import AsyncIterator
 from typing import Optional, Tuple, cast, get_args
 
@@ -144,7 +144,7 @@ def add_rtc_viewer(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[Sdp
 	return None
 
 
-# TODO: combine both encode loop method to one
+# TODO: switch to loop_encode_video or encode_video_loop ... pass video_codec to follow standards
 def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, frame_resolution : Resolution) -> None:
 	aom_encoder = create_aom_encoder(frame_resolution, 4500, 8, 10)
 	temp_resolution = frame_resolution
@@ -177,7 +177,7 @@ def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 		destroy_aom_encoder(aom_encoder)
 
 
-# TODO: combine both encode loop method to one
+# TODO: switch to loop_encode_video or encode_video_loop ... pass video_codec to follow standards
 def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, frame_resolution : Resolution) -> None:
 	vpx_encoder = create_vpx_encoder(frame_resolution, 4500, 8, 16)
 	temp_resolution = frame_resolution
@@ -210,6 +210,7 @@ def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 		destroy_vpx_encoder(vpx_encoder)
 
 
+# TODO: switch to loop_encode_audio or encode_audio_loop ... pass audio_codec to follow standards
 def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], session_id : SessionId) -> None:
 	opus_encoder = create_opus_encoder(48000, 2)
 	audio_timestamp = 0
@@ -230,6 +231,7 @@ def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], sessi
 		destroy_opus_encoder(opus_encoder)
 
 
+# TODO: needs refinement
 async def receive_stream_frames(websocket : WebSocket) -> AsyncIterator[Tuple[int, bytes]]:
 	websocket_event = await websocket.receive()
 
@@ -242,6 +244,7 @@ async def receive_stream_frames(websocket : WebSocket) -> AsyncIterator[Tuple[in
 		websocket_event = await websocket.receive()
 
 
+# TODO: needs refinement, does it receive frames or a buffer?
 async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFrame]:
 	websocket_event = await websocket.receive()
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections import deque
+import queue
 from collections.abc import AsyncIterator
 from typing import Optional, Tuple, cast, get_args
 
@@ -14,7 +14,7 @@ from facefusion.codecs.aom import create_aom_encoder, destroy_aom_encoder, encod
 from facefusion.codecs.opus import create_opus_encoder, destroy_opus_encoder, encode_opus_buffer
 from facefusion.codecs.vpx import create_vpx_encoder, destroy_vpx_encoder, encode_vpx_buffer
 from facefusion.streamer import process_vision_frame
-from facefusion.types import AudioCodec, PeerConnection, Resolution, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame
+from facefusion.types import AudioCodec, OpusEncoder, PeerConnection, Resolution, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame
 
 
 async def handle_video_stream(websocket : WebSocket) -> None:
@@ -31,9 +31,8 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 
 	if session_id:
 		stream_frames = receive_stream_frames(websocket)
-		first_vision_frame = None
+		first_vision_frame : Optional[VisionFrame] = None
 
-		# TODO: audio frames may arrive before video due to ScriptProcessor firing faster than canvas toBlob
 		async for first_frame_type, first_frame_buffer in stream_frames:
 			if first_frame_type == 1:
 				first_vision_frame = cv2.imdecode(numpy.frombuffer(first_frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
@@ -41,22 +40,22 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 
 		if numpy.any(first_vision_frame):
 			resolution : Resolution = (first_vision_frame.shape[1], first_vision_frame.shape[0])
-			keyframe_interval = int(state_manager.get_item('output_video_fps') or 30) # TODO: remove hardcoded via stream_video_fps
-			vision_frame_deque : deque[VisionFrame] = deque(maxlen = 1)
-			opus_encoder = create_opus_encoder(48000, 2) # TODO: guard against opus_encoder being None
+			keyframe_interval = int(state_manager.get_item('output_video_fps') or 30)
+			vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
+			audio_chunk_queue : queue.Queue[Optional[bytes]] = queue.Queue()
 			audio_temp = numpy.array([], dtype = numpy.float32)
-			audio_timestamp = 0
-
-			vision_frame_deque.append(first_vision_frame)
-			rtc_store.create_rtc_peers(session_id)
-
-			event_loop = asyncio.get_running_loop()
+			opus_encoder = create_opus_encoder(48000, 2)
 			encode_loop = run_aom_encode_loop
 
 			if stream_codec == 'vp8':
 				encode_loop = run_vp8_encode_loop
 
-			video_encode_task = event_loop.run_in_executor(None, encode_loop, vision_frame_deque, session_id, resolution, keyframe_interval)
+			vision_frame_queue.put(first_vision_frame)
+			rtc_store.create_rtc_peers(session_id)
+
+			event_loop = asyncio.get_running_loop()
+			video_encode_task = event_loop.run_in_executor(None, encode_loop, vision_frame_queue, session_id, resolution, keyframe_interval)
+			audio_encode_task = event_loop.run_in_executor(None, run_opus_encode_loop, audio_chunk_queue, session_id, opus_encoder)
 			await websocket.send_text('ready')
 
 			async for frame_type, frame_buffer in stream_frames:
@@ -64,29 +63,23 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 					vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
 
 					if numpy.any(vision_frame):
-						vision_frame_deque.append(vision_frame)
+						try:
+							vision_frame_queue.get_nowait()
+						except queue.Empty:
+							pass
+						vision_frame_queue.put(vision_frame)
 
 				if frame_type == 2:
 					audio_temp = numpy.concatenate([ audio_temp, numpy.frombuffer(frame_buffer, dtype = numpy.float32) ])
 
 					while len(audio_temp) >= 1920:
-						audio_chunk = audio_temp[:1920]
+						audio_chunk_queue.put(audio_temp[:1920].tobytes())
 						audio_temp = audio_temp[1920:]
-						audio_buffer = encode_opus_buffer(opus_encoder, audio_chunk.tobytes(), 960)
 
-						if audio_buffer:
-							rtc_peers = rtc_store.get_rtc_peers(session_id)
-
-							if rtc_peers:
-								rtc.send_audio_to_peers(rtc_peers, audio_buffer, audio_timestamp)
-
-						audio_timestamp += 960
-
-			vision_frame_deque.clear()
+			vision_frame_queue.put(None)
+			audio_chunk_queue.put(None)
 			await video_encode_task
-
-			if opus_encoder:
-				destroy_opus_encoder(opus_encoder)
+			await audio_encode_task
 
 			rtc_store.destroy_rtc_peers(session_id)
 
@@ -152,13 +145,17 @@ def add_rtc_viewer(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[Sdp
 	return None
 
 
-def run_aom_encode_loop(vision_frame_deque : deque[VisionFrame], session_id : SessionId, initial_resolution : Resolution, keyframe_interval : int) -> None:
+def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution, keyframe_interval : int) -> None:
 	aom_encoder = create_aom_encoder(initial_resolution, 4500, 8, 10)
 	current_resolution = initial_resolution
 	pts = 0
 
-	while vision_frame_deque:
-		vision_frame = vision_frame_deque[-1]
+	while True:
+		vision_frame = vision_frame_queue.get()
+
+		if vision_frame is None:
+			break
+
 		output_frame = process_vision_frame(vision_frame)
 		frame_resolution = (output_frame.shape[1], output_frame.shape[0])
 
@@ -186,13 +183,17 @@ def run_aom_encode_loop(vision_frame_deque : deque[VisionFrame], session_id : Se
 		destroy_aom_encoder(aom_encoder)
 
 
-def run_vp8_encode_loop(vision_frame_deque : deque[VisionFrame], session_id : SessionId, initial_resolution : Resolution, keyframe_interval : int) -> None:
+def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution, keyframe_interval : int) -> None:
 	vpx_encoder = create_vpx_encoder(initial_resolution, 4500, 8, 16)
 	current_resolution = initial_resolution
 	pts = 0
 
-	while vision_frame_deque:
-		vision_frame = vision_frame_deque[-1]
+	while True:
+		vision_frame = vision_frame_queue.get()
+
+		if vision_frame is None:
+			break
+
 		output_frame = process_vision_frame(vision_frame)
 		frame_resolution = (output_frame.shape[1], output_frame.shape[0])
 
@@ -218,6 +219,29 @@ def run_vp8_encode_loop(vision_frame_deque : deque[VisionFrame], session_id : Se
 
 	if vpx_encoder:
 		destroy_vpx_encoder(vpx_encoder)
+
+
+def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], session_id : SessionId, opus_encoder : OpusEncoder) -> None:
+	audio_timestamp = 0
+
+	while True:
+		audio_chunk = audio_chunk_queue.get()
+
+		if audio_chunk is None:
+			break
+
+		audio_buffer = encode_opus_buffer(opus_encoder, audio_chunk, 960)
+
+		if audio_buffer:
+			rtc_peers = rtc_store.get_rtc_peers(session_id)
+
+			if rtc_peers:
+				rtc.send_audio_to_peers(rtc_peers, audio_buffer, audio_timestamp)
+
+		audio_timestamp += 960
+
+	if opus_encoder:
+		destroy_opus_encoder(opus_encoder)
 
 
 async def receive_stream_frames(websocket : WebSocket) -> AsyncIterator[Tuple[int, bytes]]:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -144,73 +144,65 @@ def add_rtc_viewer(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[Sdp
 	return None
 
 
-def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution) -> None:
-	aom_encoder = create_aom_encoder(initial_resolution, 4500, 8, 10)
-	current_resolution = initial_resolution
-	pts = 0
+def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, frame_resolution : Resolution) -> None:
+	aom_encoder = create_aom_encoder(frame_resolution, 4500, 8, 10)
+	temp_resolution = frame_resolution
+	timestamp = 0
 
 	vision_frame = vision_frame_queue.get()
 
-	while numpy.any(vision_frame):
-		output_frame = process_vision_frame(vision_frame)
-		frame_resolution = (output_frame.shape[1], output_frame.shape[0])
+	while numpy.any(vision_frame) and aom_encoder:
+		output_vision_frame = process_vision_frame(vision_frame)
+		output_resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 
-		if frame_resolution != current_resolution:
-			if aom_encoder:
-				destroy_aom_encoder(aom_encoder)
+		if output_resolution == temp_resolution:
+			yuv_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
+			frame_buffer = encode_aom_buffer(aom_encoder, yuv_frame.tobytes(), output_resolution, timestamp)
+			rtc_peers = rtc_store.get_rtc_peers(session_id)
 
-			current_resolution = frame_resolution
-			aom_encoder = create_aom_encoder(current_resolution, 4500, 8, 10)
-			pts = 0
+			if frame_buffer and rtc_peers:
+				rtc.send_video_to_peers(rtc_peers, frame_buffer)
 
-		if aom_encoder:
-			yuv_frame = cv2.cvtColor(output_frame, cv2.COLOR_BGR2YUV_I420)
-			frame_buffer = encode_aom_buffer(aom_encoder, yuv_frame.tobytes(), frame_resolution, pts)
+			timestamp += 1
+			vision_frame = vision_frame_queue.get()
+			continue
 
-			if frame_buffer:
-				rtc_peers = rtc_store.get_rtc_peers(session_id)
-
-				if rtc_peers:
-					rtc.send_video_to_peers(rtc_peers, frame_buffer)
-
-		pts += 1
-		vision_frame = vision_frame_queue.get()
+		destroy_aom_encoder(aom_encoder)
+		temp_resolution = output_resolution
+		aom_encoder = create_aom_encoder(temp_resolution, 4500, 8, 10)
+		timestamp = 0
 
 	if aom_encoder:
 		destroy_aom_encoder(aom_encoder)
 
 
-def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution) -> None:
-	vpx_encoder = create_vpx_encoder(initial_resolution, 4500, 8, 16)
-	current_resolution = initial_resolution
-	pts = 0
+def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, frame_resolution : Resolution) -> None:
+	vpx_encoder = create_vpx_encoder(frame_resolution, 4500, 8, 16)
+	temp_resolution = frame_resolution
+	timestamp = 0
 
 	vision_frame = vision_frame_queue.get()
 
-	while numpy.any(vision_frame):
-		output_frame = process_vision_frame(vision_frame)
-		frame_resolution = (output_frame.shape[1], output_frame.shape[0])
+	while numpy.any(vision_frame) and vpx_encoder:
+		output_vision_frame = process_vision_frame(vision_frame)
+		output_resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 
-		if frame_resolution != current_resolution:
-			if vpx_encoder:
-				destroy_vpx_encoder(vpx_encoder)
+		if output_resolution == temp_resolution:
+			yuv_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
+			frame_buffer = encode_vpx_buffer(vpx_encoder, yuv_frame.tobytes(), output_resolution, timestamp)
+			rtc_peers = rtc_store.get_rtc_peers(session_id)
 
-			current_resolution = frame_resolution
-			vpx_encoder = create_vpx_encoder(current_resolution, 4500, 8, 16)
-			pts = 0
+			if frame_buffer and rtc_peers:
+				rtc.send_video_to_peers(rtc_peers, frame_buffer)
 
-		if vpx_encoder:
-			yuv_frame = cv2.cvtColor(output_frame, cv2.COLOR_BGR2YUV_I420)
-			frame_buffer = encode_vpx_buffer(vpx_encoder, yuv_frame.tobytes(), frame_resolution, pts)
+			timestamp += 1
+			vision_frame = vision_frame_queue.get()
+			continue
 
-			if frame_buffer:
-				rtc_peers = rtc_store.get_rtc_peers(session_id)
-
-				if rtc_peers:
-					rtc.send_video_to_peers(rtc_peers, frame_buffer)
-
-		pts += 1
-		vision_frame = vision_frame_queue.get()
+		destroy_vpx_encoder(vpx_encoder)
+		temp_resolution = output_resolution
+		vpx_encoder = create_vpx_encoder(temp_resolution, 4500, 8, 16)
+		timestamp = 0
 
 	if vpx_encoder:
 		destroy_vpx_encoder(vpx_encoder)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -40,21 +40,21 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 
 		if numpy.any(first_vision_frame):
 			resolution : Resolution = (first_vision_frame.shape[1], first_vision_frame.shape[0])
-			keyframe_interval = int(state_manager.get_item('output_video_fps') or 30)
 			vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
 			audio_chunk_queue : queue.Queue[Optional[bytes]] = queue.Queue()
 			audio_temp = numpy.array([], dtype = numpy.float32)
 			opus_encoder = create_opus_encoder(48000, 2)
-			encode_loop = run_aom_encode_loop
-
-			if stream_codec == 'vp8':
-				encode_loop = run_vp8_encode_loop
 
 			vision_frame_queue.put(first_vision_frame)
 			rtc_store.create_rtc_peers(session_id)
 
 			event_loop = asyncio.get_running_loop()
-			video_encode_task = event_loop.run_in_executor(None, encode_loop, vision_frame_queue, session_id, resolution, keyframe_interval)
+
+			if stream_codec == 'av1':
+				video_encode_task = event_loop.run_in_executor(None, run_aom_encode_loop, vision_frame_queue, session_id, resolution)
+			if stream_codec == 'vp8':
+				video_encode_task = event_loop.run_in_executor(None, run_vp8_encode_loop, vision_frame_queue, session_id, resolution)
+
 			audio_encode_task = event_loop.run_in_executor(None, run_opus_encode_loop, audio_chunk_queue, session_id, opus_encoder)
 			await websocket.send_text('ready')
 
@@ -78,6 +78,7 @@ async def handle_video_stream(websocket : WebSocket) -> None:
 
 			vision_frame_queue.put(None)
 			audio_chunk_queue.put(None)
+
 			await video_encode_task
 			await audio_encode_task
 
@@ -145,7 +146,7 @@ def add_rtc_viewer(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[Sdp
 	return None
 
 
-def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution, keyframe_interval : int) -> None:
+def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution) -> None:
 	aom_encoder = create_aom_encoder(initial_resolution, 4500, 8, 10)
 	current_resolution = initial_resolution
 	pts = 0
@@ -183,7 +184,7 @@ def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 		destroy_aom_encoder(aom_encoder)
 
 
-def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution, keyframe_interval : int) -> None:
+def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]], session_id : SessionId, initial_resolution : Resolution) -> None:
 	vpx_encoder = create_vpx_encoder(initial_resolution, 4500, 8, 16)
 	current_resolution = initial_resolution
 	pts = 0

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -17,29 +17,105 @@ from facefusion.streamer import process_vision_frame
 from facefusion.types import AudioCodec, PeerConnection, Resolution, RtcAudioTrack, RtcPeer, RtcVideoTrack, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame
 
 
-async def receive_stream_frames(websocket : WebSocket) -> AsyncIterator[Tuple[int, bytes]]:
-	websocket_event = await websocket.receive()
+async def handle_video_stream(websocket : WebSocket) -> None:
+	subprotocol = get_sec_websocket_protocol(websocket.scope)
+	access_token = extract_access_token(websocket.scope)
+	session_id = session_manager.find_session_id(access_token)
+	session_context.set_session_id(session_id)
+	stream_codec : VideoCodec = 'av1'
 
-	while websocket_event.get('type') == 'websocket.receive':
-		frame_buffer = websocket_event.get('bytes') or bytes()
+	if websocket.query_params.get('codec') in get_args(VideoCodec):
+		stream_codec = cast(VideoCodec, websocket.query_params.get('codec'))
 
-		if len(frame_buffer) > 1:
-			yield frame_buffer[0], frame_buffer[1:]
+	await websocket.accept(subprotocol = subprotocol)
 
-		websocket_event = await websocket.receive()
+	if session_id:
+		stream_frames = receive_stream_frames(websocket)
+		first_vision_frame = None
+
+		# TODO: audio frames may arrive before video due to ScriptProcessor firing faster than canvas toBlob
+		async for first_frame_type, first_frame_buffer in stream_frames:
+			if first_frame_type == 1:
+				first_vision_frame = cv2.imdecode(numpy.frombuffer(first_frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
+				break
+
+		if numpy.any(first_vision_frame):
+			resolution : Resolution = (first_vision_frame.shape[1], first_vision_frame.shape[0])
+			keyframe_interval = int(state_manager.get_item('output_video_fps') or 30) # TODO: remove hardcoded via stream_video_fps
+			vision_frame_deque : deque[VisionFrame] = deque(maxlen = 1)
+			opus_encoder = create_opus_encoder(48000, 2) # TODO: guard against opus_encoder being None
+			audio_temp = numpy.array([], dtype = numpy.float32)
+			audio_timestamp = 0
+
+			vision_frame_deque.append(first_vision_frame)
+			rtc_store.create_rtc_peers(session_id)
+
+			event_loop = asyncio.get_running_loop()
+			encode_loop = run_aom_encode_loop
+
+			if stream_codec == 'vp8':
+				encode_loop = run_vp8_encode_loop
+
+			video_encode_task = event_loop.run_in_executor(None, encode_loop, vision_frame_deque, session_id, resolution, keyframe_interval)
+			await websocket.send_text('ready')
+
+			async for frame_type, frame_buffer in stream_frames:
+				if frame_type == 1:
+					vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
+
+					if numpy.any(vision_frame):
+						vision_frame_deque.append(vision_frame)
+
+				if frame_type == 2:
+					audio_temp = numpy.concatenate([ audio_temp, numpy.frombuffer(frame_buffer, dtype = numpy.float32) ])
+
+					while len(audio_temp) >= 1920:
+						audio_chunk = audio_temp[:1920]
+						audio_temp = audio_temp[1920:]
+						audio_buffer = encode_opus_buffer(opus_encoder, audio_chunk.tobytes(), 960)
+
+						if audio_buffer:
+							rtc_peers = rtc_store.get_rtc_peers(session_id)
+
+							if rtc_peers:
+								rtc.send_audio_to_peers(rtc_peers, audio_buffer, audio_timestamp)
+
+						audio_timestamp += 960
+
+			vision_frame_deque.clear()
+			await video_encode_task
+
+			if opus_encoder:
+				destroy_opus_encoder(opus_encoder)
+
+			rtc_store.destroy_rtc_peers(session_id)
+
+	if websocket.client_state == WebSocketState.CONNECTED:
+		await websocket.close()
 
 
-async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFrame]:
-	websocket_event = await websocket.receive()
+# TODO: extract shared session setup from handle_image_stream and handle_video_stream, guard session_id like handle_video_stream
+async def handle_image_stream(websocket : WebSocket) -> None:
+	subprotocol = get_sec_websocket_protocol(websocket.scope)
+	access_token = extract_access_token(websocket.scope)
+	session_id = session_manager.find_session_id(access_token)
+	session_context.set_session_id(session_id)
+	source_paths = state_manager.get_item('source_paths')
 
-	while websocket_event.get('type') == 'websocket.receive':
-		frame_buffer = websocket_event.get('bytes') or bytes()
-		vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
+	await websocket.accept(subprotocol = subprotocol)
 
-		if numpy.any(vision_frame):
-			yield vision_frame
+	if source_paths:
+		capture_vision_frame = await anext(receive_vision_frames(websocket), None)
 
-		websocket_event = await websocket.receive()
+		if numpy.any(capture_vision_frame):
+			output_vision_frame = process_vision_frame(capture_vision_frame)
+			is_success, output_frame_buffer = cv2.imencode('.jpg', output_vision_frame)
+
+			if is_success:
+				await websocket.send_bytes(output_frame_buffer.tobytes())
+
+	if websocket.client_state == WebSocketState.CONNECTED:
+		await websocket.close()
 
 
 # TODO: clean up peer connection on failed sdp negotiation, wrap in run_in_executor to avoid blocking async event loop
@@ -144,102 +220,26 @@ def run_vp8_encode_loop(vision_frame_deque : deque[VisionFrame], session_id : Se
 		destroy_vpx_encoder(vpx_encoder)
 
 
-# TODO: extract shared session setup from handle_image_stream and handle_video_stream, guard session_id like handle_video_stream
-async def handle_image_stream(websocket : WebSocket) -> None:
-	subprotocol = get_sec_websocket_protocol(websocket.scope)
-	access_token = extract_access_token(websocket.scope)
-	session_id = session_manager.find_session_id(access_token)
-	session_context.set_session_id(session_id)
-	source_paths = state_manager.get_item('source_paths')
+async def receive_stream_frames(websocket : WebSocket) -> AsyncIterator[Tuple[int, bytes]]:
+	websocket_event = await websocket.receive()
 
-	await websocket.accept(subprotocol = subprotocol)
+	while websocket_event.get('type') == 'websocket.receive':
+		frame_buffer = websocket_event.get('bytes') or bytes()
 
-	if source_paths:
-		capture_vision_frame = await anext(receive_vision_frames(websocket), None)
+		if len(frame_buffer) > 1:
+			yield frame_buffer[0], frame_buffer[1:]
 
-		if numpy.any(capture_vision_frame):
-			output_vision_frame = process_vision_frame(capture_vision_frame)
-			is_success, output_frame_buffer = cv2.imencode('.jpg', output_vision_frame)
-
-			if is_success:
-				await websocket.send_bytes(output_frame_buffer.tobytes())
-
-	if websocket.client_state == WebSocketState.CONNECTED:
-		await websocket.close()
+		websocket_event = await websocket.receive()
 
 
-async def handle_video_stream(websocket : WebSocket) -> None:
-	subprotocol = get_sec_websocket_protocol(websocket.scope)
-	access_token = extract_access_token(websocket.scope)
-	session_id = session_manager.find_session_id(access_token)
-	session_context.set_session_id(session_id)
-	stream_codec : VideoCodec = 'av1'
+async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFrame]:
+	websocket_event = await websocket.receive()
 
-	if websocket.query_params.get('codec') in get_args(VideoCodec):
-		stream_codec = cast(VideoCodec, websocket.query_params.get('codec'))
+	while websocket_event.get('type') == 'websocket.receive':
+		frame_buffer = websocket_event.get('bytes') or bytes()
+		vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
 
-	await websocket.accept(subprotocol = subprotocol)
+		if numpy.any(vision_frame):
+			yield vision_frame
 
-	if session_id:
-		stream_frames = receive_stream_frames(websocket)
-		first_vision_frame = None
-
-		# TODO: audio frames may arrive before video due to ScriptProcessor firing faster than canvas toBlob
-		async for first_frame_type, first_frame_buffer in stream_frames:
-			if first_frame_type == 1:
-				first_vision_frame = cv2.imdecode(numpy.frombuffer(first_frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
-				break
-
-		if numpy.any(first_vision_frame):
-			resolution : Resolution = (first_vision_frame.shape[1], first_vision_frame.shape[0])
-			keyframe_interval = int(state_manager.get_item('output_video_fps') or 30) # TODO: remove hardcoded via stream_video_fps
-			vision_frame_deque : deque[VisionFrame] = deque(maxlen = 1)
-			opus_encoder = create_opus_encoder(48000, 2) # TODO: guard against opus_encoder being None
-			audio_temp = numpy.array([], dtype = numpy.float32)
-			audio_timestamp = 0
-
-			vision_frame_deque.append(first_vision_frame)
-			rtc_store.create_rtc_peers(session_id)
-
-			event_loop = asyncio.get_running_loop()
-			encode_loop = run_aom_encode_loop
-
-			if stream_codec == 'vp8':
-				encode_loop = run_vp8_encode_loop
-
-			video_encode_task = event_loop.run_in_executor(None, encode_loop, vision_frame_deque, session_id, resolution, keyframe_interval)
-			await websocket.send_text('ready')
-
-			async for frame_type, frame_buffer in stream_frames:
-				if frame_type == 1:
-					vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
-
-					if numpy.any(vision_frame):
-						vision_frame_deque.append(vision_frame)
-
-				if frame_type == 2:
-					audio_temp = numpy.concatenate([ audio_temp, numpy.frombuffer(frame_buffer, dtype = numpy.float32) ])
-
-					while len(audio_temp) >= 1920:
-						audio_chunk = audio_temp[:1920]
-						audio_temp = audio_temp[1920:]
-						audio_buffer = encode_opus_buffer(opus_encoder, audio_chunk.tobytes(), 960)
-
-						if audio_buffer:
-							rtc_peers = rtc_store.get_rtc_peers(session_id)
-
-							if rtc_peers:
-								rtc.send_audio_to_peers(rtc_peers, audio_buffer, audio_timestamp)
-
-						audio_timestamp += 960
-
-			vision_frame_deque.clear()
-			await video_encode_task
-
-			if opus_encoder:
-				destroy_opus_encoder(opus_encoder)
-
-			rtc_store.destroy_rtc_peers(session_id)
-
-	if websocket.client_state == WebSocketState.CONNECTED:
-		await websocket.close()
+		websocket_event = await websocket.receive()

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -149,16 +149,13 @@ def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 	current_resolution = initial_resolution
 	pts = 0
 
-	while True:
-		vision_frame = vision_frame_queue.get()
+	vision_frame = vision_frame_queue.get()
 
-		if vision_frame is None:
-			break
-
+	while numpy.any(vision_frame):
 		output_frame = process_vision_frame(vision_frame)
 		frame_resolution = (output_frame.shape[1], output_frame.shape[0])
 
-		if frame_resolution[0] != current_resolution[0] or frame_resolution[1] != current_resolution[1]:
+		if frame_resolution != current_resolution:
 			if aom_encoder:
 				destroy_aom_encoder(aom_encoder)
 
@@ -177,6 +174,7 @@ def run_aom_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 					rtc.send_video_to_peers(rtc_peers, frame_buffer)
 
 		pts += 1
+		vision_frame = vision_frame_queue.get()
 
 	if aom_encoder:
 		destroy_aom_encoder(aom_encoder)
@@ -187,16 +185,13 @@ def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 	current_resolution = initial_resolution
 	pts = 0
 
-	while True:
-		vision_frame = vision_frame_queue.get()
+	vision_frame = vision_frame_queue.get()
 
-		if vision_frame is None:
-			break
-
+	while numpy.any(vision_frame):
 		output_frame = process_vision_frame(vision_frame)
 		frame_resolution = (output_frame.shape[1], output_frame.shape[0])
 
-		if frame_resolution[0] != current_resolution[0] or frame_resolution[1] != current_resolution[1]:
+		if frame_resolution != current_resolution:
 			if vpx_encoder:
 				destroy_vpx_encoder(vpx_encoder)
 
@@ -215,6 +210,7 @@ def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 					rtc.send_video_to_peers(rtc_peers, frame_buffer)
 
 		pts += 1
+		vision_frame = vision_frame_queue.get()
 
 	if vpx_encoder:
 		destroy_vpx_encoder(vpx_encoder)
@@ -223,12 +219,9 @@ def run_vp8_encode_loop(vision_frame_queue : queue.Queue[Optional[VisionFrame]],
 def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], session_id : SessionId, opus_encoder : OpusEncoder) -> None:
 	audio_timestamp = 0
 
-	while True:
-		audio_chunk = audio_chunk_queue.get()
+	audio_chunk = audio_chunk_queue.get()
 
-		if audio_chunk is None:
-			break
-
+	while audio_chunk:
 		audio_buffer = encode_opus_buffer(opus_encoder, audio_chunk, 960)
 
 		if audio_buffer:
@@ -238,6 +231,7 @@ def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], sessi
 				rtc.send_audio_to_peers(rtc_peers, audio_buffer, audio_timestamp)
 
 		audio_timestamp += 960
+		audio_chunk = audio_chunk_queue.get()
 
 	if opus_encoder:
 		destroy_opus_encoder(opus_encoder)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -215,12 +215,10 @@ def run_opus_encode_loop(audio_chunk_queue : queue.Queue[Optional[bytes]], sessi
 
 	while audio_chunk:
 		audio_buffer = encode_opus_buffer(opus_encoder, audio_chunk, 960)
+		rtc_peers = rtc_store.get_rtc_peers(session_id)
 
-		if audio_buffer:
-			rtc_peers = rtc_store.get_rtc_peers(session_id)
-
-			if rtc_peers:
-				rtc.send_audio_to_peers(rtc_peers, audio_buffer, audio_timestamp)
+		if audio_buffer and rtc_peers:
+			rtc.send_audio_to_peers(rtc_peers, audio_buffer, audio_timestamp)
 
 		audio_timestamp += 960
 		audio_chunk = audio_chunk_queue.get()

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -49,6 +49,7 @@ def _make_video_packet(frame : NDArray[Any]) -> bytes:
 	_, encoded = cv2.imencode('.jpg', frame)
 	return b'\x01' + encoded.tobytes()
 
+
 # TODO: inline or move to helper
 def _make_audio_packet(samples : NDArray[Any]) -> bytes:
 	return b'\x02' + samples.tobytes()

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -91,8 +91,6 @@ def test_receive_vision_frames() -> None:
 
 def test_run_vp8_encode_loop() -> None:
 	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
-	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
-	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
 
 	vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
 	vision_frame_queue.put(frame)
@@ -106,20 +104,6 @@ def test_run_vp8_encode_loop() -> None:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
 		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_rtc.send_video_to_peers.assert_called_once()
-
-	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(small_frame)
-	vision_frame_queue.put(small_frame)
-	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
-		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()) as mock_create, \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = None), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
-		patch('facefusion.apis.stream_helper.rtc_store'), \
-		patch('facefusion.apis.stream_helper.rtc'):
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		assert mock_create.call_count == 2
-		assert mock_destroy.call_count == 2
 
 	vision_frame_queue = queue.Queue()
 	vision_frame_queue.put(frame)

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import cv2
 import numpy
-from numpy.typing import NDArray
 import pytest
+from numpy.typing import NDArray
 from starlette.websockets import WebSocketState
 
 from facefusion.apis.stream_helper import handle_video_stream, receive_stream_frames, receive_vision_frames, run_vp8_encode_loop

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,7 +1,6 @@
 import asyncio
-from collections import deque
-from functools import partial
-from typing import Any
+import queue
+from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import cv2
@@ -10,20 +9,10 @@ import pytest
 from numpy.typing import NDArray
 from starlette.websockets import WebSocketState
 
-from facefusion.apis.stream_helper import handle_video_stream, receive_stream_frames, receive_vision_frames, run_vp8_encode_loop
+from facefusion.apis.stream_helper import handle_video_stream, receive_stream_frames, receive_vision_frames, run_opus_encode_loop, run_vp8_encode_loop
 from facefusion.common_helper import is_linux, is_macos, is_windows
 from facefusion.hash_helper import create_hash
-
-
-def _clear_deque(deque_ref : deque[Any], return_value : Any, *args : Any) -> Any:
-	deque_ref.clear()
-	return return_value
-
-
-def _countdown_clear(deque_ref : deque[Any], counter : list[int], *args : Any) -> None:
-	counter[0] -= 1
-	if counter[0] <= 0:
-		deque_ref.clear()
+from facefusion.types import VisionFrame
 
 
 async def _collect_stream_frames(events : list[Any]) -> list[tuple[int, bytes]]:
@@ -105,48 +94,107 @@ def test_run_vp8_encode_loop() -> None:
 	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
 
-	vision_frame_deque : deque[NDArray[Any]] = deque([ frame ], maxlen = 1)
+	vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
 	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
 		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_clear_deque, vision_frame_deque, b'encoded')), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b'encoded'), \
 		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
 		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
 		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
 		mock_rtc.send_video_to_peers.assert_called_once()
 
-	vision_frame_deque = deque([ small_frame ], maxlen = 1)
-	counter = [ 2 ]
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(small_frame)
+	vision_frame_queue.put(small_frame)
+	vision_frame_queue.put(None)
 	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
 		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()) as mock_create, \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_countdown_clear, vision_frame_deque, counter)), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = None), \
 		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc'):
-		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
 		assert mock_create.call_count == 2
 		assert mock_destroy.call_count == 2
 
-	vision_frame_deque = deque([ frame ], maxlen = 1)
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
 	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
 		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_clear_deque, vision_frame_deque, b'')), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b''), \
 		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
 		mock_rtc.send_video_to_peers.assert_not_called()
 
-	vision_frame_deque = deque([ frame ], maxlen = 1)
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
 	mock_encoder = MagicMock()
 	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
 		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = mock_encoder), \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_clear_deque, vision_frame_deque, None)), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = None), \
 		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc'):
-		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
+		mock_destroy.assert_called_with(mock_encoder)
+
+
+def test_run_opus_encode_loop() -> None:
+	audio_chunk = numpy.zeros(1920, dtype = numpy.float32).tobytes()
+
+	audio_chunk_queue : queue.Queue[Optional[bytes]] = queue.Queue()
+	audio_chunk_queue.put(audio_chunk)
+	audio_chunk_queue.put(None)
+	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'encoded'), \
+		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_opus_encode_loop(audio_chunk_queue, 'session-1', MagicMock())
+		mock_rtc.send_audio_to_peers.assert_called_once()
+		assert mock_rtc.send_audio_to_peers.call_args[0][2] == 0
+
+	audio_chunk_queue = queue.Queue()
+	audio_chunk_queue.put(audio_chunk)
+	audio_chunk_queue.put(audio_chunk)
+	audio_chunk_queue.put(None)
+	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'encoded'), \
+		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_opus_encode_loop(audio_chunk_queue, 'session-1', MagicMock())
+		assert mock_rtc.send_audio_to_peers.call_count == 2
+		assert mock_rtc.send_audio_to_peers.call_args_list[0][0][2] == 0
+		assert mock_rtc.send_audio_to_peers.call_args_list[1][0][2] == 960
+
+	audio_chunk_queue = queue.Queue()
+	audio_chunk_queue.put(audio_chunk)
+	audio_chunk_queue.put(None)
+	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b''), \
+		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store'), \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		run_opus_encode_loop(audio_chunk_queue, 'session-1', MagicMock())
+		mock_rtc.send_audio_to_peers.assert_not_called()
+
+	audio_chunk_queue = queue.Queue()
+	audio_chunk_queue.put(audio_chunk)
+	audio_chunk_queue.put(None)
+	mock_encoder = MagicMock()
+	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = None), \
+		patch('facefusion.apis.stream_helper.destroy_opus_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc_store'), \
+		patch('facefusion.apis.stream_helper.rtc'):
+		run_opus_encode_loop(audio_chunk_queue, 'session-1', mock_encoder)
 		mock_destroy.assert_called_with(mock_encoder)
 
 
@@ -162,8 +210,8 @@ def test_handle_video_stream() -> None:
 		patch('facefusion.apis.stream_helper.session_context.set_session_id'), \
 		patch('facefusion.apis.stream_helper.state_manager.get_item', return_value = 30), \
 		patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
 		patch('facefusion.apis.stream_helper.run_aom_encode_loop') as mock_loop, \
+		patch('facefusion.apis.stream_helper.run_opus_encode_loop'), \
 		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc:
 		asyncio.run(handle_video_stream(websocket))
 		websocket.accept.assert_called_once_with(subprotocol = 'proto')
@@ -193,12 +241,9 @@ def test_handle_video_stream() -> None:
 		patch('facefusion.apis.stream_helper.session_context.set_session_id'), \
 		patch('facefusion.apis.stream_helper.state_manager.get_item', return_value = 30), \
 		patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'opus') as mock_encode, \
-		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
 		patch('facefusion.apis.stream_helper.run_aom_encode_loop'), \
-		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		patch('facefusion.apis.stream_helper.run_opus_encode_loop') as mock_audio_loop, \
+		patch('facefusion.apis.stream_helper.rtc_store'):
 		asyncio.run(handle_video_stream(websocket))
-		assert create_hash(mock_encode.call_args[0][1]) == '6d72f0fc'
-		mock_rtc.send_audio_to_peers.assert_called_once()
+		audio_queue = mock_audio_loop.call_args[0][0]
+		assert create_hash(audio_queue.get_nowait()) == '6d72f0fc'

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -91,6 +91,8 @@ def test_receive_vision_frames() -> None:
 
 def test_run_vp8_encode_loop() -> None:
 	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
 
 	vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
 	vision_frame_queue.put(frame)
@@ -104,6 +106,20 @@ def test_run_vp8_encode_loop() -> None:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
 		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_rtc.send_video_to_peers.assert_called_once()
+
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(small_frame)
+	vision_frame_queue.put(small_frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
+		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()) as mock_create, \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = None), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc_store'), \
+		patch('facefusion.apis.stream_helper.rtc'):
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		assert mock_create.call_count == 2
+		assert mock_destroy.call_count == 2
 
 	vision_frame_queue = queue.Queue()
 	vision_frame_queue.put(frame)
@@ -137,12 +153,13 @@ def test_run_opus_encode_loop() -> None:
 	audio_chunk_queue : queue.Queue[Optional[bytes]] = queue.Queue()
 	audio_chunk_queue.put(audio_chunk)
 	audio_chunk_queue.put(None)
-	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'encoded'), \
+	with patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'encoded'), \
 		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
 		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
 		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_opus_encode_loop(audio_chunk_queue, 'session-1', MagicMock())
+		run_opus_encode_loop(audio_chunk_queue, 'session-1')
 		mock_rtc.send_audio_to_peers.assert_called_once()
 		assert mock_rtc.send_audio_to_peers.call_args[0][2] == 0
 
@@ -150,12 +167,13 @@ def test_run_opus_encode_loop() -> None:
 	audio_chunk_queue.put(audio_chunk)
 	audio_chunk_queue.put(audio_chunk)
 	audio_chunk_queue.put(None)
-	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'encoded'), \
+	with patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'encoded'), \
 		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
 		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
 		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_opus_encode_loop(audio_chunk_queue, 'session-1', MagicMock())
+		run_opus_encode_loop(audio_chunk_queue, 'session-1')
 		assert mock_rtc.send_audio_to_peers.call_count == 2
 		assert mock_rtc.send_audio_to_peers.call_args_list[0][0][2] == 0
 		assert mock_rtc.send_audio_to_peers.call_args_list[1][0][2] == 960
@@ -163,23 +181,24 @@ def test_run_opus_encode_loop() -> None:
 	audio_chunk_queue = queue.Queue()
 	audio_chunk_queue.put(audio_chunk)
 	audio_chunk_queue.put(None)
-	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b''), \
+	with patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b''), \
 		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_opus_encode_loop(audio_chunk_queue, 'session-1', MagicMock())
+		run_opus_encode_loop(audio_chunk_queue, 'session-1')
 		mock_rtc.send_audio_to_peers.assert_not_called()
 
 	audio_chunk_queue = queue.Queue()
 	audio_chunk_queue.put(audio_chunk)
 	audio_chunk_queue.put(None)
-	mock_encoder = MagicMock()
-	with patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = None), \
+	with patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = None), \
 		patch('facefusion.apis.stream_helper.destroy_opus_encoder') as mock_destroy, \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc'):
-		run_opus_encode_loop(audio_chunk_queue, 'session-1', mock_encoder)
-		mock_destroy.assert_called_with(mock_encoder)
+		run_opus_encode_loop(audio_chunk_queue, 'session-1')
+		mock_destroy.assert_called_once()
 
 
 def test_handle_video_stream() -> None:
@@ -193,7 +212,6 @@ def test_handle_video_stream() -> None:
 		patch('facefusion.apis.stream_helper.session_manager.find_session_id', return_value = 'session-1'), \
 		patch('facefusion.apis.stream_helper.session_context.set_session_id'), \
 		patch('facefusion.apis.stream_helper.state_manager.get_item', return_value = 30), \
-		patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
 		patch('facefusion.apis.stream_helper.run_aom_encode_loop') as mock_loop, \
 		patch('facefusion.apis.stream_helper.run_opus_encode_loop'), \
 		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc:
@@ -224,7 +242,6 @@ def test_handle_video_stream() -> None:
 		patch('facefusion.apis.stream_helper.session_manager.find_session_id', return_value = 'session-1'), \
 		patch('facefusion.apis.stream_helper.session_context.set_session_id'), \
 		patch('facefusion.apis.stream_helper.state_manager.get_item', return_value = 30), \
-		patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
 		patch('facefusion.apis.stream_helper.run_aom_encode_loop'), \
 		patch('facefusion.apis.stream_helper.run_opus_encode_loop') as mock_audio_loop, \
 		patch('facefusion.apis.stream_helper.rtc_store'):

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -9,26 +9,30 @@ import pytest
 from numpy.typing import NDArray
 from starlette.websockets import WebSocketState
 
-from facefusion.apis.stream_helper import handle_video_stream, receive_stream_frames, receive_vision_frames, run_opus_encode_loop, run_vp8_encode_loop
+from facefusion.apis.stream_helper import handle_video_stream, receive_stream_frames, receive_vision_frames, run_aom_encode_loop, run_opus_encode_loop, run_vp8_encode_loop
 from facefusion.common_helper import is_linux, is_macos, is_windows
 from facefusion.hash_helper import create_hash
 from facefusion.types import VisionFrame
 
 
+# TODO: inline or move to helper
 async def _collect_stream_frames(events : list[Any]) -> list[tuple[int, bytes]]:
 	return [ item async for item in receive_stream_frames(_make_websocket(events)) ]
 
 
+# TODO: inline or move to helper
 async def _collect_vision_frames(events : list[Any]) -> list[NDArray[Any]]:
 	return [ item async for item in receive_vision_frames(_make_websocket(events)) ]
 
 
+# TODO: inline or move to helper
 def _make_websocket(events : list[Any]) -> MagicMock:
 	mock = MagicMock()
 	mock.receive = AsyncMock(side_effect = events)
 	return mock
 
 
+# TODO: inline or move to helper
 def _make_handler_websocket(events : list[Any]) -> MagicMock:
 	mock = MagicMock()
 	mock.scope = {}
@@ -40,15 +44,17 @@ def _make_handler_websocket(events : list[Any]) -> MagicMock:
 	return mock
 
 
+# TODO: inline or move to helper
 def _make_video_packet(frame : NDArray[Any]) -> bytes:
 	_, encoded = cv2.imencode('.jpg', frame)
 	return b'\x01' + encoded.tobytes()
 
-
+# TODO: inline or move to helper
 def _make_audio_packet(samples : NDArray[Any]) -> bytes:
 	return b'\x02' + samples.tobytes()
 
 
+# TODO: refine test
 def test_receive_stream_frames() -> None:
 	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	video_packet = _make_video_packet(frame)
@@ -73,6 +79,7 @@ def test_receive_stream_frames() -> None:
 	assert len(asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.disconnect'}, {'type': 'websocket.receive', 'bytes': video_packet} ]))) == 1
 
 
+# TODO: refine test
 def test_receive_vision_frames() -> None:
 	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	_, encoded = cv2.imencode('.jpg', frame)
@@ -89,10 +96,12 @@ def test_receive_vision_frames() -> None:
 	assert asyncio.run(_collect_vision_frames([ {'type': 'websocket.receive', 'bytes': b'not_an_image'}, {'type': 'websocket.disconnect'} ])) == []
 
 
+# TODO: refine test
 def test_run_vp8_encode_loop() -> None:
 	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
+	black_frame = numpy.zeros((64, 64, 3), dtype = numpy.uint8)
 
 	vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
 	vision_frame_queue.put(frame)
@@ -146,7 +155,55 @@ def test_run_vp8_encode_loop() -> None:
 		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_destroy.assert_called_with(mock_encoder)
 
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
+		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b'encoded'), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		assert mock_rtc.send_video_to_peers.call_count == 3
 
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(black_frame)
+	with patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		mock_rtc.send_video_to_peers.assert_not_called()
+		mock_destroy.assert_called_once()
+
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(small_frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
+		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()) as mock_create, \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b'encoded'), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		assert mock_create.call_count == 2
+		assert mock_destroy.call_count == 2
+		mock_rtc.send_video_to_peers.assert_called_once()
+
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = None), \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		mock_rtc.send_video_to_peers.assert_not_called()
+
+
+# TODO: refine test
 def test_run_opus_encode_loop() -> None:
 	audio_chunk = numpy.zeros(1920, dtype = numpy.float32).tobytes()
 
@@ -200,7 +257,85 @@ def test_run_opus_encode_loop() -> None:
 		run_opus_encode_loop(audio_chunk_queue, 'session-1')
 		mock_destroy.assert_called_once()
 
+	audio_chunk_queue = queue.Queue()
+	audio_chunk_queue.put(b'')
+	with patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.destroy_opus_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		run_opus_encode_loop(audio_chunk_queue, 'session-1')
+		mock_rtc.send_audio_to_peers.assert_not_called()
+		mock_destroy.assert_called_once()
 
+
+# TODO: refine test
+def test_run_aom_encode_loop() -> None:
+	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
+	black_frame = numpy.zeros((64, 64, 3), dtype = numpy.uint8)
+
+	vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
+		patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_aom_buffer', return_value = b'encoded'), \
+		patch('facefusion.apis.stream_helper.destroy_aom_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		mock_rtc.send_video_to_peers.assert_called_once()
+
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
+		patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_aom_buffer', return_value = b'encoded'), \
+		patch('facefusion.apis.stream_helper.destroy_aom_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		assert mock_rtc.send_video_to_peers.call_count == 3
+
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(black_frame)
+	with patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.destroy_aom_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		mock_rtc.send_video_to_peers.assert_not_called()
+		mock_destroy.assert_called_once()
+
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(small_frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
+		patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()) as mock_create, \
+		patch('facefusion.apis.stream_helper.encode_aom_buffer', return_value = b'encoded'), \
+		patch('facefusion.apis.stream_helper.destroy_aom_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		assert mock_create.call_count == 2
+		assert mock_destroy.call_count == 2
+		mock_rtc.send_video_to_peers.assert_called_once()
+
+	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
+	with patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = None), \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		mock_rtc.send_video_to_peers.assert_not_called()
+
+
+# TODO: refine test
 def test_handle_video_stream() -> None:
 	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	video_packet = _make_video_packet(frame)

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -104,7 +104,7 @@ def test_run_vp8_encode_loop() -> None:
 		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
 		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_rtc.send_video_to_peers.assert_called_once()
 
 	vision_frame_queue = queue.Queue()
@@ -117,7 +117,7 @@ def test_run_vp8_encode_loop() -> None:
 		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc'):
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
 		assert mock_create.call_count == 2
 		assert mock_destroy.call_count == 2
 
@@ -130,7 +130,7 @@ def test_run_vp8_encode_loop() -> None:
 		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_rtc.send_video_to_peers.assert_not_called()
 
 	vision_frame_queue = queue.Queue()
@@ -143,7 +143,7 @@ def test_run_vp8_encode_loop() -> None:
 		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
 		patch('facefusion.apis.stream_helper.rtc_store'), \
 		patch('facefusion.apis.stream_helper.rtc'):
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64), 30)
+		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_destroy.assert_called_with(mock_encoder)
 
 
@@ -219,7 +219,7 @@ def test_handle_video_stream() -> None:
 		websocket.close.assert_called_once()
 		mock_rtc.create_rtc_peers.assert_called_once_with('session-1')
 		mock_rtc.destroy_rtc_peers.assert_called_once_with('session-1')
-		_, loop_session_id, loop_resolution, _ = mock_loop.call_args[0]
+		_, loop_session_id, loop_resolution = mock_loop.call_args[0]
 		assert loop_session_id == 'session-1'
 		assert loop_resolution == (64, 64)
 

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,0 +1,203 @@
+import asyncio
+from collections import deque
+from functools import partial
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import cv2
+import numpy
+import pytest
+from starlette.websockets import WebSocketState
+
+from facefusion.apis.stream_helper import handle_video_stream, receive_stream_frames, receive_vision_frames, run_vp8_encode_loop
+from facefusion.common_helper import is_linux, is_macos, is_windows
+from facefusion.hash_helper import create_hash
+
+
+def _clear_deque(deque_ref : deque, return_value : object, *args) -> object:
+	deque_ref.clear()
+	return return_value
+
+
+def _countdown_clear(deque_ref : deque, counter : list, *args) -> None:
+	counter[0] -= 1
+	if counter[0] <= 0:
+		deque_ref.clear()
+	return None
+
+
+async def _collect_stream_frames(events : list) -> list:
+	return [ item async for item in receive_stream_frames(_make_websocket(events)) ]
+
+
+async def _collect_vision_frames(events : list) -> list:
+	return [ item async for item in receive_vision_frames(_make_websocket(events)) ]
+
+
+def _make_websocket(events : list) -> MagicMock:
+	mock = MagicMock()
+	mock.receive = AsyncMock(side_effect = events)
+	return mock
+
+
+def _make_handler_websocket(events : list) -> MagicMock:
+	mock = MagicMock()
+	mock.scope = {}
+	mock.client_state = WebSocketState.CONNECTED
+	mock.accept = AsyncMock()
+	mock.send_text = AsyncMock()
+	mock.close = AsyncMock()
+	mock.receive = AsyncMock(side_effect = events)
+	return mock
+
+
+def _make_video_packet(frame : numpy.ndarray) -> bytes:
+	_, encoded = cv2.imencode('.jpg', frame)
+	return b'\x01' + encoded.tobytes()
+
+
+def _make_audio_packet(samples : numpy.ndarray) -> bytes:
+	return b'\x02' + samples.tobytes()
+
+
+def test_receive_stream_frames() -> None:
+	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	video_packet = _make_video_packet(frame)
+	audio_packet = _make_audio_packet(numpy.zeros(1920, dtype = numpy.float32))
+
+	result = asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.disconnect'} ]))
+	assert len(result) == 1
+	assert result[0][0] == 1
+
+	if is_linux() or is_windows():
+		assert create_hash(result[0][1]) == '8ba34289'
+
+	if is_macos():
+		pytest.skip()
+
+	result = asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': audio_packet}, {'type': 'websocket.disconnect'} ]))
+	assert len(result) == 1
+	assert result[0][0] == 2
+
+	assert asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': b'\x01'}, {'type': 'websocket.receive', 'bytes': b''}, {'type': 'websocket.receive', 'bytes': None}, {'type': 'websocket.disconnect'} ])) == []
+
+	assert len(asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.disconnect'}, {'type': 'websocket.receive', 'bytes': video_packet} ]))) == 1
+
+
+def test_receive_vision_frames() -> None:
+	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	_, encoded = cv2.imencode('.jpg', frame)
+
+	result = asyncio.run(_collect_vision_frames([ {'type': 'websocket.receive', 'bytes': encoded.tobytes()}, {'type': 'websocket.disconnect'} ]))
+	assert len(result) == 1
+
+	if is_linux() or is_windows():
+		assert create_hash(result[0].tobytes()) == 'df269b74'
+
+	if is_macos():
+		assert create_hash(result[0].tobytes()) == 'df269b74'
+
+	assert asyncio.run(_collect_vision_frames([ {'type': 'websocket.receive', 'bytes': b'not_an_image'}, {'type': 'websocket.disconnect'} ])) == []
+
+
+def test_run_vp8_encode_loop() -> None:
+	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
+
+	vision_frame_deque : deque = deque([ frame ], maxlen = 1)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
+		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_clear_deque, vision_frame_deque, b'encoded')), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		mock_rtc.send_video_to_peers.assert_called_once()
+
+	vision_frame_deque = deque([ small_frame ], maxlen = 1)
+	counter = [ 2 ]
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
+		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()) as mock_create, \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_countdown_clear, vision_frame_deque, counter)), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc_store'), \
+		patch('facefusion.apis.stream_helper.rtc'):
+		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		assert mock_create.call_count == 2
+		assert mock_destroy.call_count == 2
+
+	vision_frame_deque = deque([ frame ], maxlen = 1)
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
+		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_clear_deque, vision_frame_deque, b'')), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
+		patch('facefusion.apis.stream_helper.rtc_store'), \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		mock_rtc.send_video_to_peers.assert_not_called()
+
+	vision_frame_deque = deque([ frame ], maxlen = 1)
+	mock_encoder = MagicMock()
+	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
+		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = mock_encoder), \
+		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_clear_deque, vision_frame_deque, None)), \
+		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
+		patch('facefusion.apis.stream_helper.rtc_store'), \
+		patch('facefusion.apis.stream_helper.rtc'):
+		run_vp8_encode_loop(vision_frame_deque, 'session-1', (64, 64), 30)
+		mock_destroy.assert_called_with(mock_encoder)
+
+
+def test_handle_video_stream() -> None:
+	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
+	video_packet = _make_video_packet(frame)
+	audio_packet = _make_audio_packet(numpy.zeros(1920, dtype = numpy.float32))
+
+	websocket = _make_handler_websocket([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.disconnect'} ])
+	with patch('facefusion.apis.stream_helper.get_sec_websocket_protocol', return_value = 'proto'), \
+		patch('facefusion.apis.stream_helper.extract_access_token', return_value = 'token'), \
+		patch('facefusion.apis.stream_helper.session_manager.find_session_id', return_value = 'session-1'), \
+		patch('facefusion.apis.stream_helper.session_context.set_session_id'), \
+		patch('facefusion.apis.stream_helper.state_manager.get_item', return_value = 30), \
+		patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
+		patch('facefusion.apis.stream_helper.run_aom_encode_loop') as mock_loop, \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc:
+		asyncio.run(handle_video_stream(websocket))
+		websocket.accept.assert_called_once_with(subprotocol = 'proto')
+		websocket.send_text.assert_called_once_with('ready')
+		websocket.close.assert_called_once()
+		mock_rtc.create_rtc_peers.assert_called_once_with('session-1')
+		mock_rtc.destroy_rtc_peers.assert_called_once_with('session-1')
+		_, loop_session_id, loop_resolution, _ = mock_loop.call_args[0]
+		assert loop_session_id == 'session-1'
+		assert loop_resolution == (64, 64)
+
+	websocket = _make_handler_websocket([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.disconnect'} ])
+	with patch('facefusion.apis.stream_helper.get_sec_websocket_protocol', return_value = 'proto'), \
+		patch('facefusion.apis.stream_helper.extract_access_token', return_value = 'token'), \
+		patch('facefusion.apis.stream_helper.session_manager.find_session_id', return_value = None), \
+		patch('facefusion.apis.stream_helper.session_context.set_session_id'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc:
+		asyncio.run(handle_video_stream(websocket))
+		websocket.accept.assert_called_once()
+		websocket.send_text.assert_not_called()
+		mock_rtc.create_rtc_peers.assert_not_called()
+
+	websocket = _make_handler_websocket([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.receive', 'bytes': audio_packet}, {'type': 'websocket.disconnect'} ])
+	with patch('facefusion.apis.stream_helper.get_sec_websocket_protocol', return_value = 'proto'), \
+		patch('facefusion.apis.stream_helper.extract_access_token', return_value = 'token'), \
+		patch('facefusion.apis.stream_helper.session_manager.find_session_id', return_value = 'session-1'), \
+		patch('facefusion.apis.stream_helper.session_context.set_session_id'), \
+		patch('facefusion.apis.stream_helper.state_manager.get_item', return_value = 30), \
+		patch('facefusion.apis.stream_helper.create_opus_encoder', return_value = MagicMock()), \
+		patch('facefusion.apis.stream_helper.encode_opus_buffer', return_value = b'opus') as mock_encode, \
+		patch('facefusion.apis.stream_helper.destroy_opus_encoder'), \
+		patch('facefusion.apis.stream_helper.run_aom_encode_loop'), \
+		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
+		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
+		asyncio.run(handle_video_stream(websocket))
+		assert create_hash(mock_encode.call_args[0][1]) == '6d72f0fc'
+		mock_rtc.send_audio_to_peers.assert_called_once()

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,10 +1,12 @@
 import asyncio
 from collections import deque
 from functools import partial
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import cv2
 import numpy
+from numpy.typing import NDArray
 import pytest
 from starlette.websockets import WebSocketState
 
@@ -13,33 +15,32 @@ from facefusion.common_helper import is_linux, is_macos, is_windows
 from facefusion.hash_helper import create_hash
 
 
-def _clear_deque(deque_ref : deque, return_value : object, *args) -> object:
+def _clear_deque(deque_ref : deque[Any], return_value : Any, *args : Any) -> Any:
 	deque_ref.clear()
 	return return_value
 
 
-def _countdown_clear(deque_ref : deque, counter : list, *args) -> None:
+def _countdown_clear(deque_ref : deque[Any], counter : list[int], *args : Any) -> None:
 	counter[0] -= 1
 	if counter[0] <= 0:
 		deque_ref.clear()
-	return None
 
 
-async def _collect_stream_frames(events : list) -> list:
+async def _collect_stream_frames(events : list[Any]) -> list[tuple[int, bytes]]:
 	return [ item async for item in receive_stream_frames(_make_websocket(events)) ]
 
 
-async def _collect_vision_frames(events : list) -> list:
+async def _collect_vision_frames(events : list[Any]) -> list[NDArray[Any]]:
 	return [ item async for item in receive_vision_frames(_make_websocket(events)) ]
 
 
-def _make_websocket(events : list) -> MagicMock:
+def _make_websocket(events : list[Any]) -> MagicMock:
 	mock = MagicMock()
 	mock.receive = AsyncMock(side_effect = events)
 	return mock
 
 
-def _make_handler_websocket(events : list) -> MagicMock:
+def _make_handler_websocket(events : list[Any]) -> MagicMock:
 	mock = MagicMock()
 	mock.scope = {}
 	mock.client_state = WebSocketState.CONNECTED
@@ -50,12 +51,12 @@ def _make_handler_websocket(events : list) -> MagicMock:
 	return mock
 
 
-def _make_video_packet(frame : numpy.ndarray) -> bytes:
+def _make_video_packet(frame : NDArray[Any]) -> bytes:
 	_, encoded = cv2.imencode('.jpg', frame)
 	return b'\x01' + encoded.tobytes()
 
 
-def _make_audio_packet(samples : numpy.ndarray) -> bytes:
+def _make_audio_packet(samples : NDArray[Any]) -> bytes:
 	return b'\x02' + samples.tobytes()
 
 
@@ -104,7 +105,7 @@ def test_run_vp8_encode_loop() -> None:
 	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
 
-	vision_frame_deque : deque = deque([ frame ], maxlen = 1)
+	vision_frame_deque : deque[NDArray[Any]] = deque([ frame ], maxlen = 1)
 	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
 		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
 		patch('facefusion.apis.stream_helper.encode_vpx_buffer', side_effect = partial(_clear_deque, vision_frame_deque, b'encoded')), \

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -9,30 +9,11 @@ import pytest
 from numpy.typing import NDArray
 from starlette.websockets import WebSocketState
 
-from facefusion.apis.stream_helper import handle_video_stream, receive_stream_frames, receive_vision_frames, run_aom_encode_loop, run_opus_encode_loop, run_vp8_encode_loop
-from facefusion.common_helper import is_linux, is_macos, is_windows
+from facefusion.apis.stream_helper import handle_video_stream, run_aom_encode_loop, run_opus_encode_loop, run_vp8_encode_loop
 from facefusion.hash_helper import create_hash
 from facefusion.types import VisionFrame
 
 
-# TODO: inline or move to helper
-async def _collect_stream_frames(events : list[Any]) -> list[tuple[int, bytes]]:
-	return [ item async for item in receive_stream_frames(_make_websocket(events)) ]
-
-
-# TODO: inline or move to helper
-async def _collect_vision_frames(events : list[Any]) -> list[NDArray[Any]]:
-	return [ item async for item in receive_vision_frames(_make_websocket(events)) ]
-
-
-# TODO: inline or move to helper
-def _make_websocket(events : list[Any]) -> MagicMock:
-	mock = MagicMock()
-	mock.receive = AsyncMock(side_effect = events)
-	return mock
-
-
-# TODO: inline or move to helper
 def _make_handler_websocket(events : list[Any]) -> MagicMock:
 	mock = MagicMock()
 	mock.scope = {}
@@ -44,153 +25,94 @@ def _make_handler_websocket(events : list[Any]) -> MagicMock:
 	return mock
 
 
-# TODO: inline or move to helper
 def _make_video_packet(frame : NDArray[Any]) -> bytes:
 	_, encoded = cv2.imencode('.jpg', frame)
 	return b'\x01' + encoded.tobytes()
 
 
-# TODO: inline or move to helper
 def _make_audio_packet(samples : NDArray[Any]) -> bytes:
 	return b'\x02' + samples.tobytes()
 
 
-# TODO: refine test
-def test_receive_stream_frames() -> None:
-	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
-	video_packet = _make_video_packet(frame)
-	audio_packet = _make_audio_packet(numpy.zeros(1920, dtype = numpy.float32))
-
-	result = asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.disconnect'} ]))
-	assert len(result) == 1
-	assert result[0][0] == 1
-
-	if is_linux() or is_windows():
-		assert create_hash(result[0][1]) == '8ba34289'
-
-	if is_macos():
-		pytest.skip()
-
-	result = asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': audio_packet}, {'type': 'websocket.disconnect'} ]))
-	assert len(result) == 1
-	assert result[0][0] == 2
-
-	assert asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': b'\x01'}, {'type': 'websocket.receive', 'bytes': b''}, {'type': 'websocket.receive', 'bytes': None}, {'type': 'websocket.disconnect'} ])) == []
-
-	assert len(asyncio.run(_collect_stream_frames([ {'type': 'websocket.receive', 'bytes': video_packet}, {'type': 'websocket.disconnect'}, {'type': 'websocket.receive', 'bytes': video_packet} ]))) == 1
-
-
-# TODO: refine test
-def test_receive_vision_frames() -> None:
-	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
-	_, encoded = cv2.imencode('.jpg', frame)
-
-	result = asyncio.run(_collect_vision_frames([ {'type': 'websocket.receive', 'bytes': encoded.tobytes()}, {'type': 'websocket.disconnect'} ]))
-	assert len(result) == 1
-
-	if is_linux() or is_windows():
-		assert create_hash(result[0].tobytes()) == 'df269b74'
-
-	if is_macos():
-		assert create_hash(result[0].tobytes()) == 'df269b74'
-
-	assert asyncio.run(_collect_vision_frames([ {'type': 'websocket.receive', 'bytes': b'not_an_image'}, {'type': 'websocket.disconnect'} ])) == []
-
-
-# TODO: refine test
-def test_run_vp8_encode_loop() -> None:
+@pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
+def test_run_video_encode_loop(video_codec : str) -> None:
 	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
 	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
 	black_frame = numpy.zeros((64, 64, 3), dtype = numpy.uint8)
+	prefix = 'facefusion.apis.stream_helper.'
+
+	create_name = prefix + 'create_aom_encoder'
+	encode_name = prefix + 'encode_aom_buffer'
+	destroy_name = prefix + 'destroy_aom_encoder'
+	run_loop = run_aom_encode_loop
+
+	if video_codec == 'vp8':
+		create_name = prefix + 'create_vpx_encoder'
+		encode_name = prefix + 'encode_vpx_buffer'
+		destroy_name = prefix + 'destroy_vpx_encoder'
+		run_loop = run_vp8_encode_loop
 
 	vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
 	vision_frame_queue.put(frame)
 	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
-		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b'encoded'), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
-		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+	with patch(prefix + 'process_vision_frame', return_value = frame), \
+		patch(create_name, return_value = MagicMock()), \
+		patch(encode_name, return_value = b'encoded'), \
+		patch(destroy_name), \
+		patch(prefix + 'rtc_store') as mock_rtc_store, \
+		patch(prefix + 'rtc') as mock_rtc:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		run_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_rtc.send_video_to_peers.assert_called_once()
 
 	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(small_frame)
-	vision_frame_queue.put(small_frame)
-	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
-		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()) as mock_create, \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = None), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
-		patch('facefusion.apis.stream_helper.rtc_store'), \
-		patch('facefusion.apis.stream_helper.rtc'):
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		assert mock_create.call_count == 2
-		assert mock_destroy.call_count == 2
-
-	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(frame)
-	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
-		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b''), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
-		patch('facefusion.apis.stream_helper.rtc_store'), \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		mock_rtc.send_video_to_peers.assert_not_called()
-
-	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(frame)
-	vision_frame_queue.put(None)
-	mock_encoder = MagicMock()
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
-		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = mock_encoder), \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = None), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
-		patch('facefusion.apis.stream_helper.rtc_store'), \
-		patch('facefusion.apis.stream_helper.rtc'):
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		mock_destroy.assert_called_with(mock_encoder)
-
-	vision_frame_queue = queue.Queue()
 	vision_frame_queue.put(frame)
 	vision_frame_queue.put(frame)
 	vision_frame_queue.put(frame)
 	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
-		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b'encoded'), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder'), \
-		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+	with patch(prefix + 'process_vision_frame', return_value = frame), \
+		patch(create_name, return_value = MagicMock()), \
+		patch(encode_name, return_value = b'encoded'), \
+		patch(destroy_name), \
+		patch(prefix + 'rtc_store') as mock_rtc_store, \
+		patch(prefix + 'rtc') as mock_rtc:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		run_loop(vision_frame_queue, 'session-1', (64, 64))
 		assert mock_rtc.send_video_to_peers.call_count == 3
 
 	vision_frame_queue = queue.Queue()
 	vision_frame_queue.put(black_frame)
-	with patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+	with patch(create_name, return_value = MagicMock()), \
+		patch(destroy_name) as mock_destroy, \
+		patch(prefix + 'rtc') as mock_rtc:
+		run_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_rtc.send_video_to_peers.assert_not_called()
 		mock_destroy.assert_called_once()
 
 	vision_frame_queue = queue.Queue()
+	vision_frame_queue.put(frame)
+	vision_frame_queue.put(None)
+	with patch(prefix + 'process_vision_frame', return_value = frame), \
+		patch(create_name, return_value = MagicMock()), \
+		patch(encode_name, return_value = b''), \
+		patch(destroy_name), \
+		patch(prefix + 'rtc_store'), \
+		patch(prefix + 'rtc') as mock_rtc:
+		run_loop(vision_frame_queue, 'session-1', (64, 64))
+		mock_rtc.send_video_to_peers.assert_not_called()
+
+	vision_frame_queue = queue.Queue()
 	vision_frame_queue.put(small_frame)
 	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
-		patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = MagicMock()) as mock_create, \
-		patch('facefusion.apis.stream_helper.encode_vpx_buffer', return_value = b'encoded'), \
-		patch('facefusion.apis.stream_helper.destroy_vpx_encoder') as mock_destroy, \
-		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
+	with patch(prefix + 'process_vision_frame', return_value = large_frame), \
+		patch(create_name, return_value = MagicMock()) as mock_create, \
+		patch(encode_name, return_value = b'encoded'), \
+		patch(destroy_name) as mock_destroy, \
+		patch(prefix + 'rtc_store') as mock_rtc_store, \
+		patch(prefix + 'rtc') as mock_rtc:
 		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+		run_loop(vision_frame_queue, 'session-1', (64, 64))
 		assert mock_create.call_count == 2
 		assert mock_destroy.call_count == 2
 		mock_rtc.send_video_to_peers.assert_called_once()
@@ -198,9 +120,9 @@ def test_run_vp8_encode_loop() -> None:
 	vision_frame_queue = queue.Queue()
 	vision_frame_queue.put(frame)
 	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.create_vpx_encoder', return_value = None), \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_vp8_encode_loop(vision_frame_queue, 'session-1', (64, 64))
+	with patch(create_name, return_value = None), \
+		patch(prefix + 'rtc') as mock_rtc:
+		run_loop(vision_frame_queue, 'session-1', (64, 64))
 		mock_rtc.send_video_to_peers.assert_not_called()
 
 
@@ -266,74 +188,6 @@ def test_run_opus_encode_loop() -> None:
 		run_opus_encode_loop(audio_chunk_queue, 'session-1')
 		mock_rtc.send_audio_to_peers.assert_not_called()
 		mock_destroy.assert_called_once()
-
-
-# TODO: refine test
-def test_run_aom_encode_loop() -> None:
-	frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
-	small_frame = numpy.full((64, 64, 3), 128, dtype = numpy.uint8)
-	large_frame = numpy.full((128, 128, 3), 128, dtype = numpy.uint8)
-	black_frame = numpy.zeros((64, 64, 3), dtype = numpy.uint8)
-
-	vision_frame_queue : queue.Queue[Optional[VisionFrame]] = queue.Queue()
-	vision_frame_queue.put(frame)
-	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
-		patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_aom_buffer', return_value = b'encoded'), \
-		patch('facefusion.apis.stream_helper.destroy_aom_encoder'), \
-		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		mock_rtc.send_video_to_peers.assert_called_once()
-
-	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(frame)
-	vision_frame_queue.put(frame)
-	vision_frame_queue.put(frame)
-	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = frame), \
-		patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.encode_aom_buffer', return_value = b'encoded'), \
-		patch('facefusion.apis.stream_helper.destroy_aom_encoder'), \
-		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		assert mock_rtc.send_video_to_peers.call_count == 3
-
-	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(black_frame)
-	with patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()), \
-		patch('facefusion.apis.stream_helper.destroy_aom_encoder') as mock_destroy, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		mock_rtc.send_video_to_peers.assert_not_called()
-		mock_destroy.assert_called_once()
-
-	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(small_frame)
-	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.process_vision_frame', return_value = large_frame), \
-		patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = MagicMock()) as mock_create, \
-		patch('facefusion.apis.stream_helper.encode_aom_buffer', return_value = b'encoded'), \
-		patch('facefusion.apis.stream_helper.destroy_aom_encoder') as mock_destroy, \
-		patch('facefusion.apis.stream_helper.rtc_store') as mock_rtc_store, \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		mock_rtc_store.get_rtc_peers.return_value = [ MagicMock() ]
-		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		assert mock_create.call_count == 2
-		assert mock_destroy.call_count == 2
-		mock_rtc.send_video_to_peers.assert_called_once()
-
-	vision_frame_queue = queue.Queue()
-	vision_frame_queue.put(frame)
-	vision_frame_queue.put(None)
-	with patch('facefusion.apis.stream_helper.create_aom_encoder', return_value = None), \
-		patch('facefusion.apis.stream_helper.rtc') as mock_rtc:
-		run_aom_encode_loop(vision_frame_queue, 'session-1', (64, 64))
-		mock_rtc.send_video_to_peers.assert_not_called()
 
 
 # TODO: refine test


### PR DESCRIPTION
 Replaces the asymmetric deque+inline-audio pattern with queue. Queue for both video and audio encode loops, making the two paths structurally identical. 

Each loop now runs in its own executor thread, communicates via None-sentinel queues, and manages its own encoder lifecycle. 

Dead code (keyframe_interval), try/except blocks, and while True breaks are removed. 

Adds test_stream_helper.py covering single frames, multiple frames, black frames, resolution changes, and encoder init failures for both VP8 and AOM loops.
