### PR TITLE
Refine stream helper: queue-based loops, AV1/WHIP support, endpoint separation

### DIFF
--- a/facefusion/apis/endpoints/stream.py
+++ b/facefusion/apis/endpoints/stream.py
@@ -1,15 +1,25 @@
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_404_NOT_FOUND
-from starlette.websockets import WebSocket
+from starlette.websockets import WebSocket, WebSocketState
 
 from facefusion import session_context, session_manager
+from facefusion.apis.api_helper import get_sec_websocket_protocol
 from facefusion.apis.session_helper import extract_access_token
 from facefusion.apis.stream_helper import destroy_stream, process_image, process_video
 
 
 async def websocket_stream(websocket : WebSocket) -> None:
-	return await process_image(websocket)
+	subprotocol = get_sec_websocket_protocol(websocket.scope)
+	access_token = extract_access_token(websocket.scope)
+	session_id = session_manager.find_session_id(access_token)
+	session_context.set_session_id(session_id)
+
+	await websocket.accept(subprotocol = subprotocol)
+	await process_image(websocket)
+
+	if websocket.client_state == WebSocketState.CONNECTED:
+		await websocket.close()
 
 
 async def post_stream(request : Request) -> Response:

--- a/facefusion/apis/endpoints/stream.py
+++ b/facefusion/apis/endpoints/stream.py
@@ -9,6 +9,7 @@ from facefusion.apis.session_helper import extract_access_token
 from facefusion.apis.stream_helper import destroy_stream, process_image, process_video
 
 
+# TODO: can we avoid passing websocket? just the data if doable
 async def websocket_stream(websocket : WebSocket) -> None:
 	subprotocol = get_sec_websocket_protocol(websocket.scope)
 	access_token = extract_access_token(websocket.scope)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -150,7 +150,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 		frame_index = 0
 
 		while numpy.any(vision_frame):
-			if not audio_queue.empty():
+			with contextlib.suppress(queue.Empty):
 				audio_frame = audio_queue.get_nowait()
 
 			output_vision_frame = streamer.process_frame(audio_frame, vision_frame)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -55,52 +55,52 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 
 	video_payload_type = rtc.get_payload_type(sdp_offer, video_codec)
 
-	if not video_payload_type:
-		return None
+	if video_payload_type:
+		peer_connection : PeerConnection = rtc.create_peer_connection()
+		video_receiver_track = rtc.add_video_track(peer_connection, 'recvonly', video_codec, video_payload_type)
+		video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', video_codec, video_payload_type)
 
-	peer_connection : PeerConnection = rtc.create_peer_connection()
-	video_receiver_track = rtc.add_video_track(peer_connection, 'recvonly', video_codec, video_payload_type)
-	video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', video_codec, video_payload_type)
+		audio_codec : AudioCodec = 'opus'
+		audio_payload_type = rtc.get_payload_type(sdp_offer, audio_codec)
+		audio_receiver_track = None
+		audio_sender_track = None
 
-	audio_codec : AudioCodec = 'opus'
-	audio_payload_type = rtc.get_payload_type(sdp_offer, audio_codec)
-	audio_receiver_track = None
-	audio_sender_track = None
+		if audio_payload_type:
+			audio_receiver_track = rtc.add_audio_track(peer_connection, 'recvonly', audio_codec, audio_payload_type)
+			audio_sender_track = rtc.add_audio_track(peer_connection, 'sendonly', audio_codec, audio_payload_type)
 
-	if audio_payload_type:
-		audio_receiver_track = rtc.add_audio_track(peer_connection, 'recvonly', audio_codec, audio_payload_type)
-		audio_sender_track = rtc.add_audio_track(peer_connection, 'sendonly', audio_codec, audio_payload_type)
+		rtc.set_remote_description(peer_connection, sdp_offer)
+		local_sdp = rtc.create_sdp_answer(peer_connection)
 
-	rtc.set_remote_description(peer_connection, sdp_offer)
-	local_sdp = rtc.create_sdp_answer(peer_connection)
-
-	if local_sdp:
-		rtc_peer : RtcPeer =\
-		{
-			'peer_connection': peer_connection,
-			'video':
+		if local_sdp:
+			rtc_peer : RtcPeer =\
 			{
-				'sender_track': video_sender_track,
-				'receiver_track': video_receiver_track,
-				'codec': video_codec
-			}
-		}
-
-		if audio_receiver_track and audio_sender_track:
-			rtc_peer['audio'] =\
-			{
-				'sender_track': audio_sender_track,
-				'receiver_track': audio_receiver_track,
-				'codec': audio_codec
+				'peer_connection': peer_connection,
+				'video':
+				{
+					'sender_track': video_sender_track,
+					'receiver_track': video_receiver_track,
+					'codec': video_codec
+				}
 			}
 
-		rtc_store.init_peers(session_id)
-		rtc_store.get_peers(session_id).append(rtc_peer)
+			if audio_receiver_track and audio_sender_track:
+				rtc_peer['audio'] =\
+				{
+					'sender_track': audio_sender_track,
+					'receiver_track': audio_receiver_track,
+					'codec': audio_codec
+				}
 
-		event_loop = asyncio.get_event_loop()
-		event_loop.run_in_executor(None, run_peer_loop, session_id, rtc_peer)
+			rtc_store.init_peers(session_id)
+			rtc_store.get_peers(session_id).append(rtc_peer)
 
-	return local_sdp
+			event_loop = asyncio.get_event_loop()
+			event_loop.run_in_executor(None, run_peer_loop, session_id, rtc_peer)
+
+		return local_sdp
+
+	return None
 
 
 #TODO: needs review
@@ -120,16 +120,16 @@ async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFr
 #TODO: needs review
 def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	video_codec = rtc_peer.get('video').get('codec')
-	video_receiver_track = rtc_peer.get('video').get('receiver_track')
+	video_track = rtc_peer.get('video').get('receiver_track')
 	stop_event = threading.Event()
 	video_queue : queue.Queue = queue.Queue(maxsize = 1)
 	audio_queue : queue.Queue = queue.Queue(maxsize = 4)
-	receiver_threads = [ threading.Thread(target = receive_video_into_deque, args = (video_receiver_track, video_codec, video_queue, stop_event), daemon = True) ]
+	receiver_threads = [threading.Thread(target = pump_video_frames, args = (video_track, video_codec, video_queue, stop_event), daemon = True)]
 
 	if rtc_peer.get('audio'):
 		audio_codec = rtc_peer.get('audio').get('codec')
-		audio_receiver_track = rtc_peer.get('audio').get('receiver_track')
-		receiver_threads.append(threading.Thread(target = receive_audio_into_deque, args = (audio_receiver_track, audio_codec, audio_queue, stop_event), daemon = True))
+		audio_track = rtc_peer.get('audio').get('receiver_track')
+		receiver_threads.append(threading.Thread(target = pump_audio_frames, args = (audio_track, audio_codec, audio_queue, stop_event), daemon = True))
 
 	for receiver_thread in receiver_threads:
 		receiver_thread.start()
@@ -184,17 +184,17 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	rtc_store.delete_peers(session_id)
 
 
-def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_queue : queue.Queue, stop_event : threading.Event) -> None:
+def pump_video_frames(video_track : int, video_codec : VideoCodec, video_queue : queue.Queue, stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	video_decoder = create_video_decoder(video_codec)
 	receive_buffer = ctypes.create_string_buffer(512 * 1024)
-	idle_duration = 0.0
+	last_frame_time = time.monotonic()
 
-	while not stop_event.is_set() and idle_duration < 30.0:
+	while not stop_event.is_set() and time.monotonic() - last_frame_time < 30: # TODO: use positive while condition and remove last_frame_time
 		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
 
 		if frame_buffer:
-			idle_duration = 0.0
+			last_frame_time = time.monotonic()
 			vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
 
 			if numpy.any(vision_frame):
@@ -203,7 +203,6 @@ def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_
 				video_queue.put_nowait(vision_frame)
 		else:
 			stop_event.wait(timeout = 0.001)
-			idle_duration += 0.001
 
 	video_queue.put(numpy.empty(0))
 
@@ -213,12 +212,12 @@ def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_
 		vpx_decoder.destroy(video_decoder)
 
 
-def receive_audio_into_deque(audio_track : int, audio_codec : AudioCodec, audio_queue : queue.Queue, stop_event : threading.Event) -> None:
+def pump_audio_frames(audio_track : int, audio_codec : AudioCodec, audio_queue : queue.Queue, stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	audio_decoder = opus_decoder.create(48000, 2)
 	receive_buffer = ctypes.create_string_buffer(8 * 1024)
 
-	while not stop_event.is_set():
+	while not stop_event.is_set(): # TODO: use positive while condition
 		audio_frame = receive_audio_frame(datachannel_library, audio_track, audio_decoder, receive_buffer)
 
 		if audio_frame.dtype == numpy.float32:
@@ -227,14 +226,6 @@ def receive_audio_into_deque(audio_track : int, audio_codec : AudioCodec, audio_
 			stop_event.wait(timeout = 0.001)
 
 	opus_decoder.destroy(audio_decoder)
-
-
-def stop_receiver_threads(stop_event : threading.Event, video_receiver : threading.Thread, audio_receiver : Optional[threading.Thread]) -> None:
-	stop_event.set()
-	video_receiver.join()
-
-	if audio_receiver:
-		audio_receiver.join()
 
 
 #TODO: needs review
@@ -266,10 +257,11 @@ def destroy_video_encoder(video_codec : VideoCodec, video_encoder : Optional[Vpx
 
 
 def destroy_stream(session_id : SessionId) -> bool:
-	if rtc_store.get_peers(session_id) is None:
-		return False
-	rtc_store.delete_peers(session_id)
-	return True
+	if rtc_store.get_peers(session_id):
+		rtc_store.delete_peers(session_id)
+		return True
+
+	return False
 
 
 #TODO: needs review
@@ -290,12 +282,15 @@ def receive_audio_frame(datachannel_library : ctypes.CDLL, audio_track : int, au
 def decode_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, frame_buffer : bytes) -> Optional[VisionFrame]:
 	if video_codec == 'av1':
 		aom_pointer = aom_decoder.decode(video_decoder, frame_buffer)
+
 		if aom_pointer:
 			frame_width, frame_height = aom_pointer.get('resolution')
 			yuv_frame = numpy.frombuffer(aom_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
 			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
+
 	if video_codec == 'vp8':
 		vpx_pointer = vpx_decoder.decode(video_decoder, frame_buffer)
+
 		if vpx_pointer:
 			frame_width, frame_height = vpx_pointer.get('resolution')
 			yuv_frame = numpy.frombuffer(vpx_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -133,24 +133,21 @@ def wait_for_frame(video_deque : deque, video_event : threading.Event, timeout :
 
 #TODO: needs review
 def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
-	datachannel_library = datachannel_module.create_static_library()
-	video_info = rtc_peer.get('video')
-	video_codec = video_info.get('codec')
-	video_receiver_track = video_info.get('receiver_track')
-	video_receive_buffer = ctypes.create_string_buffer(512 * 1024)
-	audio_receive_buffer = ctypes.create_string_buffer(8 * 1024)
+	video_codec = rtc_peer.get('video').get('codec')
+	video_receiver_track = rtc_peer.get('video').get('receiver_track')
 	stop_event = threading.Event()
 	video_deque : deque = deque(maxlen = 1)
 	video_event = threading.Event()
 	audio_deque : deque = deque(maxlen = 4)
-	audio_receiver = None
-
-	video_receiver = threading.Thread(target = receive_video_into_deque, args = (datachannel_library, video_receiver_track, video_receive_buffer, video_codec, video_deque, video_event, stop_event), daemon = True)
-	video_receiver.start()
+	receiver_threads = [threading.Thread(target = receive_video_into_deque, args = (video_receiver_track, video_codec, video_deque, video_event, stop_event), daemon = True)]
 
 	if rtc_peer.get('audio'):
-		audio_receiver = threading.Thread(target = receive_audio_into_deque, args = (datachannel_library, rtc_peer.get('audio').get('receiver_track'), audio_receive_buffer, audio_deque, stop_event), daemon = True)
-		audio_receiver.start()
+		audio_codec = rtc_peer.get('audio').get('codec')
+		audio_receiver_track = rtc_peer.get('audio').get('receiver_track')
+		receiver_threads.append(threading.Thread(target = receive_audio_into_deque, args = (audio_receiver_track, audio_codec, audio_deque, stop_event), daemon = True))
+
+	for receiver_thread in receiver_threads:
+		receiver_thread.start()
 
 	vision_frame = wait_for_frame(video_deque, video_event, 30.0)
 
@@ -196,14 +193,17 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 		opus_encoder.destroy(audio_encoder)
 
 	stop_event.set()
-	video_receiver.join()
-	if audio_receiver:
-		audio_receiver.join()
+
+	for receiver_thread in receiver_threads:
+		receiver_thread.join()
+
 	rtc_store.delete_peers(session_id)
 
 
-def receive_video_into_deque(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char], video_codec : VideoCodec, video_deque : deque, video_event : threading.Event, stop_event : threading.Event) -> None:
+def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_deque : deque, video_event : threading.Event, stop_event : threading.Event) -> None:
+	datachannel_library = datachannel_module.create_static_library()
 	video_decoder = create_video_decoder(video_codec)
+	receive_buffer = ctypes.create_string_buffer(512 * 1024)
 
 	while not stop_event.is_set():
 		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
@@ -223,8 +223,10 @@ def receive_video_into_deque(datachannel_library : ctypes.CDLL, video_track : in
 		vpx_decoder.destroy(video_decoder)
 
 
-def receive_audio_into_deque(datachannel_library : ctypes.CDLL, audio_track : int, receive_buffer : ctypes.Array[ctypes.c_char], audio_deque : deque, stop_event : threading.Event) -> None:
+def receive_audio_into_deque(audio_track : int, audio_codec : AudioCodec, audio_deque : deque, stop_event : threading.Event) -> None:
+	datachannel_library = datachannel_module.create_static_library()
 	audio_decoder = opus_decoder.create(48000, 2)
+	receive_buffer = ctypes.create_string_buffer(8 * 1024)
 
 	while not stop_event.is_set():
 		audio_frame = receive_audio_frame(datachannel_library, audio_track, audio_decoder, receive_buffer)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -134,45 +134,44 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	for receiver_thread in receiver_threads:
 		receiver_thread.start()
 
-	vision_frame = video_queue.get()
+	temp_vision_frame = video_queue.get()
 
-	if numpy.any(vision_frame):
+	if numpy.any(temp_vision_frame):
 		audio_frame = create_empty_audio_frame()
-		temp_resolution : Resolution = (vision_frame.shape[1], vision_frame.shape[0])
+		temp_resolution : Resolution = (temp_vision_frame.shape[1], temp_vision_frame.shape[0])
 		video_encoder = create_video_encoder(video_codec, temp_resolution)
 		audio_encoder = opus_encoder.create(48000, 2)
 		frame_index = 0
 
-		while numpy.any(vision_frame):
+		while numpy.any(temp_vision_frame):
 			with contextlib.suppress(queue.Empty):
 				audio_frame = audio_queue.get_nowait()
 
-			output_vision_frame = streamer.process_frame(audio_frame, vision_frame)
+			output_vision_frame = streamer.process_frame(audio_frame, temp_vision_frame)
 			output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
-
-			raw_vision_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+			output_vision_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 
 			if output_resolution == temp_resolution:
-				output_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_buffer, temp_resolution, frame_index)
+				output_video_buffer = encode_video_frame(video_codec, video_encoder, output_vision_buffer, temp_resolution, frame_index)
 			else:
 				destroy_video_encoder(video_codec, video_encoder)
 				temp_resolution = output_resolution
 				video_encoder = create_video_encoder(video_codec, temp_resolution)
-				output_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_buffer, temp_resolution, frame_index)
+				output_video_buffer = encode_video_frame(video_codec, video_encoder, output_vision_buffer, temp_resolution, frame_index)
 
-			now = time.monotonic()
+			send_timestamp = time.monotonic()
 
 			if output_video_buffer:
-				rtc.send_video(rtc_peer, output_video_buffer, int(now * 90000))
+				rtc.send_video(rtc_peer, output_video_buffer, int(send_timestamp * 90000))
 
 			if audio_encoder and audio_frame.dtype == numpy.float32:
 				output_audio_buffer = opus_encoder.encode(audio_encoder, audio_frame.tobytes(), 960)
 
 				if output_audio_buffer:
-					rtc.send_audio(rtc_peer, output_audio_buffer, int(now * 48000))
+					rtc.send_audio(rtc_peer, output_audio_buffer, int(send_timestamp * 48000))
 
 			frame_index += 1
-			vision_frame = video_queue.get()
+			temp_vision_frame = video_queue.get()
 
 		destroy_video_encoder(video_codec, video_encoder)
 		opus_encoder.destroy(audio_encoder)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -121,9 +121,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	video_info = rtc_peer.get('video')
 	video_codec = video_info.get('codec')
 	video_receiver_track = video_info.get('receiver_track')
-	video_decoder = create_video_decoder(video_codec)
 	audio_info = rtc_peer.get('audio')
-	audio_decoder = opus_decoder.create(48000, 2) if audio_info else None
 	video_receive_buffer = ctypes.create_string_buffer(512 * 1024)
 	audio_receive_buffer = ctypes.create_string_buffer(8 * 1024)
 	stop_event = threading.Event()
@@ -132,11 +130,11 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	audio_deque : deque = deque(maxlen = 4)
 	audio_receiver = None
 
-	video_receiver = threading.Thread(target = receive_video_into_deque, args = (datachannel_library, video_receiver_track, video_receive_buffer, video_codec, video_decoder, video_deque, video_event, stop_event), daemon = True)
+	video_receiver = threading.Thread(target = receive_video_into_deque, args = (datachannel_library, video_receiver_track, video_receive_buffer, video_codec, video_deque, video_event, stop_event), daemon = True)
 	video_receiver.start()
 
-	if audio_info and audio_decoder:
-		audio_receiver = threading.Thread(target = receive_audio_into_deque, args = (datachannel_library, audio_info.get('receiver_track'), audio_decoder, audio_receive_buffer, audio_deque, stop_event), daemon = True)
+	if audio_info:
+		audio_receiver = threading.Thread(target = receive_audio_into_deque, args = (datachannel_library, audio_info.get('receiver_track'), audio_receive_buffer, audio_deque, stop_event), daemon = True)
 		audio_receiver.start()
 
 	video_event.clear()
@@ -144,14 +142,14 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	if not video_deque:
 		if not video_event.wait(timeout = 30.0):
 			stop_receiver_threads(stop_event, video_receiver, audio_receiver)
-			cleanup_peer(session_id, rtc_peer, video_codec, video_decoder, audio_decoder)
+			cleanup_peer(session_id)
 			return
 
 	vision_frame = video_deque.popleft() if video_deque else None
 
 	if vision_frame is None:
 		stop_receiver_threads(stop_event, video_receiver, audio_receiver)
-		cleanup_peer(session_id, rtc_peer, video_codec, video_decoder, audio_decoder)
+		cleanup_peer(session_id)
 		return
 
 	audio_frame = create_empty_audio_frame()
@@ -215,10 +213,12 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	stop_receiver_threads(stop_event, video_receiver, audio_receiver)
 	destroy_video_encoder(video_codec, video_encoder)
 	opus_encoder.destroy(audio_encoder)
-	cleanup_peer(session_id, rtc_peer, video_codec, video_decoder, audio_decoder)
+	cleanup_peer(session_id)
 
 
-def receive_video_into_deque(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char], video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_deque : deque, video_event : threading.Event, stop_event : threading.Event) -> None:
+def receive_video_into_deque(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char], video_codec : VideoCodec, video_deque : deque, video_event : threading.Event, stop_event : threading.Event) -> None:
+	video_decoder = create_video_decoder(video_codec)
+
 	while not stop_event.is_set():
 		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
 
@@ -231,8 +231,15 @@ def receive_video_into_deque(datachannel_library : ctypes.CDLL, video_track : in
 		else:
 			stop_event.wait(timeout = 0.001)
 
+	if video_codec == 'av1':
+		aom_decoder.destroy(video_decoder)
+	if video_codec == 'vp8':
+		vpx_decoder.destroy(video_decoder)
 
-def receive_audio_into_deque(datachannel_library : ctypes.CDLL, audio_track : int, audio_decoder : OpusDecoder, receive_buffer : ctypes.Array[ctypes.c_char], audio_deque : deque, stop_event : threading.Event) -> None:
+
+def receive_audio_into_deque(datachannel_library : ctypes.CDLL, audio_track : int, receive_buffer : ctypes.Array[ctypes.c_char], audio_deque : deque, stop_event : threading.Event) -> None:
+	audio_decoder = opus_decoder.create(48000, 2)
+
 	while not stop_event.is_set():
 		audio_frame = receive_audio_frame(datachannel_library, audio_track, audio_decoder, receive_buffer)
 
@@ -240,6 +247,8 @@ def receive_audio_into_deque(datachannel_library : ctypes.CDLL, audio_track : in
 			audio_deque.append(audio_frame)
 		else:
 			stop_event.wait(timeout = 0.001)
+
+	opus_decoder.destroy(audio_decoder)
 
 
 def stop_receiver_threads(stop_event : threading.Event, video_receiver : threading.Thread, audio_receiver : Optional[threading.Thread]) -> None:
@@ -278,17 +287,7 @@ def destroy_video_encoder(video_codec : VideoCodec, video_encoder : Optional[Vpx
 		vpx_encoder.destroy(video_encoder)
 
 
-#TODO: needs review
-def cleanup_peer(session_id : SessionId, rtc_peer : RtcPeer, video_codec : VideoCodec, video_decoder : Optional[VpxDecoder | AomDecoder], audio_decoder : Optional[OpusDecoder]) -> None:
-	if video_decoder:
-		if video_codec == 'av1':
-			aom_decoder.destroy(video_decoder)
-		if video_codec == 'vp8':
-			vpx_decoder.destroy(video_decoder)
-
-	if audio_decoder:
-		opus_decoder.destroy(audio_decoder)
-
+def cleanup_peer(session_id : SessionId) -> None:
 	rtc_store.delete_peers(session_id)
 
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -116,13 +116,27 @@ async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFr
 		websocket_event = await websocket.receive()
 
 
+def wait_for_frame(video_deque : deque, video_event : threading.Event, timeout : float) -> VisionFrame:
+	if video_deque:
+		return video_deque.popleft()
+
+	video_event.clear()
+
+	if video_deque:
+		return video_deque.popleft()
+	video_event.wait(timeout = timeout)
+
+	if video_deque:
+		return video_deque.popleft()
+	return numpy.empty(0)
+
+
 #TODO: needs review
 def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	video_info = rtc_peer.get('video')
 	video_codec = video_info.get('codec')
 	video_receiver_track = video_info.get('receiver_track')
-	audio_info = rtc_peer.get('audio')
 	video_receive_buffer = ctypes.create_string_buffer(512 * 1024)
 	audio_receive_buffer = ctypes.create_string_buffer(8 * 1024)
 	stop_event = threading.Event()
@@ -134,86 +148,57 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	video_receiver = threading.Thread(target = receive_video_into_deque, args = (datachannel_library, video_receiver_track, video_receive_buffer, video_codec, video_deque, video_event, stop_event), daemon = True)
 	video_receiver.start()
 
-	if audio_info:
-		audio_receiver = threading.Thread(target = receive_audio_into_deque, args = (datachannel_library, audio_info.get('receiver_track'), audio_receive_buffer, audio_deque, stop_event), daemon = True)
+	if rtc_peer.get('audio'):
+		audio_receiver = threading.Thread(target = receive_audio_into_deque, args = (datachannel_library, rtc_peer.get('audio').get('receiver_track'), audio_receive_buffer, audio_deque, stop_event), daemon = True)
 		audio_receiver.start()
 
-	video_event.clear()
+	vision_frame = wait_for_frame(video_deque, video_event, 30.0)
 
-	if not video_deque:
-		if not video_event.wait(timeout = 30.0):
-			stop_receiver_threads(stop_event, video_receiver, audio_receiver)
-			rtc_store.delete_peers(session_id)
-			return
+	if numpy.any(vision_frame):
+		audio_frame = create_empty_audio_frame()
+		temp_resolution : Resolution = (vision_frame.shape[1], vision_frame.shape[0])
+		video_encoder = create_video_encoder(video_codec, temp_resolution)
+		audio_encoder = opus_encoder.create(48000, 2)
+		frame_index = 0
 
-	vision_frame = video_deque.popleft() if video_deque else None
+		while numpy.any(vision_frame):
+			if audio_deque:
+				audio_frame = audio_deque.popleft()
 
-	if vision_frame is None:
-		stop_receiver_threads(stop_event, video_receiver, audio_receiver)
-		rtc_store.delete_peers(session_id)
-		return
+			output_vision_frame = streamer.process_frame(audio_frame, vision_frame)
+			output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 
-	audio_frame = create_empty_audio_frame()
-	resolution : Resolution = (vision_frame.shape[1], vision_frame.shape[0])
-	video_encoder = create_video_encoder(video_codec, resolution)
-	audio_encoder = opus_encoder.create(48000, 2)
-	frame_index = 0
+			raw_vision_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
 
-	while True:
-		if audio_deque:
-			audio_frame = audio_deque.popleft()
+			if output_resolution == temp_resolution:
+				encoded_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_frame.tobytes(), temp_resolution, frame_index)
+			else:
+				destroy_video_encoder(video_codec, video_encoder)
+				temp_resolution = output_resolution
+				video_encoder = create_video_encoder(video_codec, temp_resolution)
+				encoded_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_frame.tobytes(), temp_resolution, frame_index)
 
-		output_vision_frame = streamer.process_frame(audio_frame, vision_frame)
-		output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
+			now = time.monotonic()
 
-		if output_resolution != resolution:
-			resolution = output_resolution
-			destroy_video_encoder(video_codec, video_encoder)
-			video_encoder = create_video_encoder(video_codec, resolution)
+			if encoded_video_buffer:
+				rtc.send_video(rtc_peer, encoded_video_buffer, int(now * 90000))
 
-		raw_vision_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
-		encoded_video_buffer = bytes()
+			if audio_encoder and audio_frame.dtype == numpy.float32:
+				encoded_audio_buffer = opus_encoder.encode(audio_encoder, audio_frame.tobytes(), 960)
 
-		if video_codec == 'av1':
-			encoded_video_buffer = aom_encoder.encode(video_encoder, raw_vision_frame.tobytes(), resolution, frame_index)
-		if video_codec == 'vp8':
-			encoded_video_buffer = vpx_encoder.encode(video_encoder, raw_vision_frame.tobytes(), resolution, frame_index)
+				if encoded_audio_buffer:
+					rtc.send_audio(rtc_peer, encoded_audio_buffer, int(now * 48000))
 
-		now = time.monotonic()
+			frame_index += 1
+			vision_frame = wait_for_frame(video_deque, video_event, 30.0)
 
-		if encoded_video_buffer:
-			rtc.send_video(rtc_peer, encoded_video_buffer, int(now * 90000))
+		destroy_video_encoder(video_codec, video_encoder)
+		opus_encoder.destroy(audio_encoder)
 
-		if audio_encoder and audio_frame.dtype == numpy.float32:
-			encoded_audio_buffer = opus_encoder.encode(audio_encoder, audio_frame.tobytes(), 960)
-
-			if encoded_audio_buffer:
-				rtc.send_audio(rtc_peer, encoded_audio_buffer, int(now * 48000))
-
-		frame_index += 1
-
-		next_frame = video_deque.popleft() if video_deque else None
-
-		if next_frame is not None:
-			vision_frame = next_frame
-			continue
-
-		video_event.clear()
-
-		if not video_deque:
-			if not video_event.wait(timeout = 30.0):
-				break
-
-		next_frame = video_deque.popleft() if video_deque else None
-
-		if next_frame is None:
-			break
-
-		vision_frame = next_frame
-
-	stop_receiver_threads(stop_event, video_receiver, audio_receiver)
-	destroy_video_encoder(video_codec, video_encoder)
-	opus_encoder.destroy(audio_encoder)
+	stop_event.set()
+	video_receiver.join()
+	if audio_receiver:
+		audio_receiver.join()
 	rtc_store.delete_peers(session_id)
 
 
@@ -325,6 +310,14 @@ def decode_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | Ao
 			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
 
 	return None
+
+
+def encode_video_frame(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, raw_frame_bytes : bytes, resolution : Resolution, frame_index : int) -> bytes:
+	if video_codec == 'av1':
+		return aom_encoder.encode(video_encoder, raw_frame_bytes, resolution, frame_index)
+	if video_codec == 'vp8':
+		return vpx_encoder.encode(video_encoder, raw_frame_bytes, resolution, frame_index)
+	return bytes()
 
 
 def receive_video_buffer(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[bytes]:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -111,12 +111,12 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	stop_event = threading.Event()
 	video_queue : queue.Queue[VisionFrame] = queue.Queue(maxsize = 1)
 	audio_queue : queue.Queue[AudioFrame] = queue.Queue(maxsize = 4)
-	receiver_threads = [threading.Thread(target = pump_video_frames, args = (video_track, video_codec, video_queue, stop_event), daemon = True)]
+	receiver_threads = [threading.Thread(target = receive_video_frames, args = (video_track, video_codec, video_queue, stop_event), daemon = True)]
 
 	if rtc_peer.get('audio'):
 		audio_codec = rtc_peer.get('audio').get('codec')
 		audio_track = rtc_peer.get('audio').get('receiver_track')
-		receiver_threads.append(threading.Thread(target = pump_audio_frames, args = (audio_track, audio_codec, audio_queue, stop_event), daemon = True))
+		receiver_threads.append(threading.Thread(target = receive_audio_frames, args = (audio_track, audio_codec, audio_queue, stop_event), daemon = True))
 
 	for receiver_thread in receiver_threads:
 		receiver_thread.start()
@@ -171,17 +171,17 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	rtc_store.delete_peers(session_id)
 
 
-def pump_video_frames(video_track : int, video_codec : VideoCodec, video_queue : queue.Queue[VisionFrame], stop_event : threading.Event) -> None:
+def receive_video_frames(video_track : int, video_codec : VideoCodec, video_queue : queue.Queue[VisionFrame], stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	video_decoder = create_video_decoder(video_codec)
 	receive_buffer = ctypes.create_string_buffer(512 * 1024)
-	last_frame_time = time.monotonic()
+	last_time = time.monotonic()
 
-	while not stop_event.is_set() and time.monotonic() - last_frame_time < 30: # TODO: use positive while condition and remove last_frame_time
+	while not stop_event.is_set() and time.monotonic() - last_time < 30: # TODO: use positive while condition and remove last_frame_time
 		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
 
 		if frame_buffer:
-			last_frame_time = time.monotonic()
+			last_time = time.monotonic()
 			vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
 
 			if numpy.any(vision_frame):
@@ -199,7 +199,7 @@ def pump_video_frames(video_track : int, video_codec : VideoCodec, video_queue :
 		vpx_decoder.destroy(video_decoder)
 
 
-def pump_audio_frames(audio_track : int, audio_codec : AudioCodec, audio_queue : queue.Queue[AudioFrame], stop_event : threading.Event) -> None:
+def receive_audio_frames(audio_track : int, audio_codec : AudioCodec, audio_queue : queue.Queue[AudioFrame], stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	audio_decoder = opus_decoder.create(48000, 2)
 	receive_buffer = ctypes.create_string_buffer(8 * 1024)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -117,12 +117,6 @@ async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFr
 		websocket_event = await websocket.receive()
 
 
-def wait_for_frame(video_queue : queue.Queue, timeout : float) -> VisionFrame:
-	with contextlib.suppress(queue.Empty):
-		return video_queue.get(timeout = timeout)
-	return numpy.empty(0)
-
-
 #TODO: needs review
 def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	video_codec = rtc_peer.get('video').get('codec')
@@ -140,7 +134,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	for receiver_thread in receiver_threads:
 		receiver_thread.start()
 
-	vision_frame = wait_for_frame(video_queue, 30.0)
+	vision_frame = video_queue.get()
 
 	if numpy.any(vision_frame):
 		audio_frame = create_empty_audio_frame()
@@ -178,7 +172,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 					rtc.send_audio(rtc_peer, output_audio_buffer, int(now * 48000))
 
 			frame_index += 1
-			vision_frame = wait_for_frame(video_queue, 30.0)
+			vision_frame = video_queue.get()
 
 		destroy_video_encoder(video_codec, video_encoder)
 		opus_encoder.destroy(audio_encoder)
@@ -195,11 +189,13 @@ def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_
 	datachannel_library = datachannel_module.create_static_library()
 	video_decoder = create_video_decoder(video_codec)
 	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+	idle_duration = 0.0
 
-	while not stop_event.is_set():
+	while not stop_event.is_set() and idle_duration < 30.0:
 		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
 
 		if frame_buffer:
+			idle_duration = 0.0
 			vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
 
 			if numpy.any(vision_frame):
@@ -208,6 +204,9 @@ def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_
 				video_queue.put_nowait(vision_frame)
 		else:
 			stop_event.wait(timeout = 0.001)
+			idle_duration += 0.001
+
+	video_queue.put(numpy.empty(0))
 
 	if video_codec == 'av1':
 		aom_decoder.destroy(video_decoder)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -42,20 +42,6 @@ async def process_image(websocket : WebSocket) -> None:
 
 
 #TODO: needs review
-async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFrame]:
-	websocket_event = await websocket.receive()
-
-	while websocket_event.get('type') == 'websocket.receive':
-		frame_buffer = websocket_event.get('bytes') or bytes()
-		vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
-
-		if numpy.any(vision_frame):
-			yield vision_frame
-
-		websocket_event = await websocket.receive()
-
-
-#TODO: needs review
 def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpAnswer]:
 	video_codec : VideoCodec = 'vp8'
 	av1_payload_type = rtc.get_payload_type(sdp_offer, 'av1')
@@ -111,6 +97,20 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 		event_loop.run_in_executor(None, run_peer_loop, session_id, rtc_peer)
 
 	return local_sdp
+
+
+#TODO: needs review
+async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFrame]:
+	websocket_event = await websocket.receive()
+
+	while websocket_event.get('type') == 'websocket.receive':
+		frame_buffer = websocket_event.get('bytes') or bytes()
+		vision_frame = cv2.imdecode(numpy.frombuffer(frame_buffer, numpy.uint8), cv2.IMREAD_COLOR)
+
+		if numpy.any(vision_frame):
+			yield vision_frame
+
+		websocket_event = await websocket.receive()
 
 
 #TODO: needs review
@@ -193,20 +193,6 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 
 
 #TODO: needs review
-def cleanup_peer(session_id : SessionId, rtc_peer : RtcPeer, video_codec : VideoCodec, video_decoder : Optional[VpxDecoder | AomDecoder], audio_decoder : Optional[OpusDecoder]) -> None:
-	if video_decoder:
-		if video_codec == 'av1':
-			aom_decoder.destroy(video_decoder)
-		if video_codec == 'vp8':
-			vpx_decoder.destroy(video_decoder)
-
-	if audio_decoder:
-		opus_decoder.destroy(audio_decoder)
-
-	rtc_store.delete_peers(session_id)
-
-
-#TODO: needs review
 def create_video_decoder(video_codec : VideoCodec) -> Optional[VpxDecoder | AomDecoder]:
 	if video_codec == 'av1':
 		return aom_decoder.create(8)
@@ -234,46 +220,18 @@ def destroy_video_encoder(video_codec : VideoCodec, video_encoder : Optional[Vpx
 		vpx_encoder.destroy(video_encoder)
 
 
-def decode_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, frame_buffer : bytes) -> Optional[VisionFrame]:
-	if video_codec == 'av1':
-		aom_pointer = aom_decoder.decode(video_decoder, frame_buffer)
-		if aom_pointer:
-			frame_width, frame_height = aom_pointer.get('resolution')
-			yuv_frame = numpy.frombuffer(aom_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
-			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
-	if video_codec == 'vp8':
-		vpx_pointer = vpx_decoder.decode(video_decoder, frame_buffer)
-		if vpx_pointer:
-			frame_width, frame_height = vpx_pointer.get('resolution')
-			yuv_frame = numpy.frombuffer(vpx_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
-			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
-
-	return None
-
-
 #TODO: needs review
-def receive_audio_frame(datachannel_library : ctypes.CDLL, audio_track : int, audio_decoder : OpusDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> AudioFrame:
-	buffer_size = ctypes.c_int(8 * 1024)
-	receive_output = datachannel_library.rtcReceiveMessage(audio_track, receive_buffer, ctypes.byref(buffer_size))
+def cleanup_peer(session_id : SessionId, rtc_peer : RtcPeer, video_codec : VideoCodec, video_decoder : Optional[VpxDecoder | AomDecoder], audio_decoder : Optional[OpusDecoder]) -> None:
+	if video_decoder:
+		if video_codec == 'av1':
+			aom_decoder.destroy(video_decoder)
+		if video_codec == 'vp8':
+			vpx_decoder.destroy(video_decoder)
 
-	if receive_output == 0 and buffer_size.value > 0:
-		opus_buffer = receive_buffer.raw[:buffer_size.value]
-		output_buffer = opus_decoder.decode(audio_decoder, opus_buffer, 960, 2)
+	if audio_decoder:
+		opus_decoder.destroy(audio_decoder)
 
-		if output_buffer:
-			return numpy.frombuffer(output_buffer, dtype = numpy.float32)
-
-	return create_empty_audio_frame()
-
-
-def receive_video_buffer(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[bytes]:
-	buffer_size = ctypes.c_int(512 * 1024)
-	receive_output = datachannel_library.rtcReceiveMessage(video_track, receive_buffer, ctypes.byref(buffer_size))
-
-	if receive_output == 0 and buffer_size.value > 0:
-		return receive_buffer.raw[:buffer_size.value]
-
-	return None
+	rtc_store.delete_peers(session_id)
 
 
 def poll_for_buffer(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char], timeout : float) -> Optional[bytes]:
@@ -306,16 +264,6 @@ def poll_for_frame(datachannel_library : ctypes.CDLL, video_track : int, video_c
 
 
 #TODO: needs review
-def try_receive_frame(datachannel_library : ctypes.CDLL, video_track : int, video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[VisionFrame]:
-	frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
-
-	if frame_buffer:
-		return decode_video_frame(video_codec, video_decoder, frame_buffer)
-
-	return None
-
-
-#TODO: needs review
 def drain_to_latest_frame(datachannel_library : ctypes.CDLL, video_track : int, video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[VisionFrame]:
 	last_vision_frame = numpy.empty(0)
 	buffer_size = ctypes.c_int(512 * 1024)
@@ -334,5 +282,57 @@ def drain_to_latest_frame(datachannel_library : ctypes.CDLL, video_track : int, 
 
 	if numpy.any(last_vision_frame):
 		return last_vision_frame
+
+	return None
+
+
+#TODO: needs review
+def receive_audio_frame(datachannel_library : ctypes.CDLL, audio_track : int, audio_decoder : OpusDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> AudioFrame:
+	buffer_size = ctypes.c_int(8 * 1024)
+	receive_output = datachannel_library.rtcReceiveMessage(audio_track, receive_buffer, ctypes.byref(buffer_size))
+
+	if receive_output == 0 and buffer_size.value > 0:
+		opus_buffer = receive_buffer.raw[:buffer_size.value]
+		output_buffer = opus_decoder.decode(audio_decoder, opus_buffer, 960, 2)
+
+		if output_buffer:
+			return numpy.frombuffer(output_buffer, dtype = numpy.float32)
+
+	return create_empty_audio_frame()
+
+
+#TODO: needs review
+def try_receive_frame(datachannel_library : ctypes.CDLL, video_track : int, video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[VisionFrame]:
+	frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
+
+	if frame_buffer:
+		return decode_video_frame(video_codec, video_decoder, frame_buffer)
+
+	return None
+
+
+def decode_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, frame_buffer : bytes) -> Optional[VisionFrame]:
+	if video_codec == 'av1':
+		aom_pointer = aom_decoder.decode(video_decoder, frame_buffer)
+		if aom_pointer:
+			frame_width, frame_height = aom_pointer.get('resolution')
+			yuv_frame = numpy.frombuffer(aom_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
+			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
+	if video_codec == 'vp8':
+		vpx_pointer = vpx_decoder.decode(video_decoder, frame_buffer)
+		if vpx_pointer:
+			frame_width, frame_height = vpx_pointer.get('resolution')
+			yuv_frame = numpy.frombuffer(vpx_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
+			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
+
+	return None
+
+
+def receive_video_buffer(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[bytes]:
+	buffer_size = ctypes.c_int(512 * 1024)
+	receive_output = datachannel_library.rtcReceiveMessage(video_track, receive_buffer, ctypes.byref(buffer_size))
+
+	if receive_output == 0 and buffer_size.value > 0:
+		return receive_buffer.raw[:buffer_size.value]
 
 	return None

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -288,8 +288,11 @@ def destroy_video_encoder(video_codec : VideoCodec, video_encoder : Optional[Vpx
 		vpx_encoder.destroy(video_encoder)
 
 
-def cleanup_peer(session_id : SessionId) -> None:
+def destroy_stream(session_id : SessionId) -> bool:
+	if rtc_store.get_peers(session_id) is None:
+		return False
 	rtc_store.delete_peers(session_id)
+	return True
 
 
 #TODO: needs review

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -9,27 +9,17 @@ from typing import Optional
 
 import cv2
 import numpy
-from starlette.websockets import WebSocket, WebSocketState
+from starlette.websockets import WebSocket
 
-from facefusion import rtc, rtc_store, session_context, session_manager, state_manager, streamer
-from facefusion.apis.api_helper import get_sec_websocket_protocol
-from facefusion.apis.session_helper import extract_access_token
+from facefusion import rtc, rtc_store, state_manager, streamer
 from facefusion.audio import create_empty_audio_frame
 from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import AomDecoder, AomEncoder, AudioCodec, AudioFrame, OpusDecoder, PeerConnection, Resolution, RtcPeer, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame, VpxDecoder, VpxEncoder
 
 
-#TODO: needs review
 async def process_image(websocket : WebSocket) -> None:
-	#TODO: all the websocket handling belongs to the endpoint, these are connection concerns
-	subprotocol = get_sec_websocket_protocol(websocket.scope)
-	access_token = extract_access_token(websocket.scope)
-	session_id = session_manager.find_session_id(access_token)
-	session_context.set_session_id(session_id)
 	source_paths = state_manager.get_item('source_paths')
-
-	await websocket.accept(subprotocol = subprotocol)
 
 	if source_paths:
 		capture_vision_frame = await anext(receive_vision_frames(websocket), None)
@@ -40,9 +30,6 @@ async def process_image(websocket : WebSocket) -> None:
 
 			if is_success:
 				await websocket.send_bytes(output_frame_buffer.tobytes())
-
-	if websocket.client_state == WebSocketState.CONNECTED:
-		await websocket.close()
 
 
 #TODO: needs review
@@ -302,8 +289,10 @@ def decode_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | Ao
 def encode_video_frame(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, raw_frame_bytes : bytes, resolution : Resolution, frame_index : int) -> bytes:
 	if video_codec == 'av1':
 		return aom_encoder.encode(video_encoder, raw_frame_bytes, resolution, frame_index)
+
 	if video_codec == 'vp8':
 		return vpx_encoder.encode(video_encoder, raw_frame_bytes, resolution, frame_index)
+
 	return bytes()
 
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -156,26 +156,26 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 			output_vision_frame = streamer.process_frame(audio_frame, vision_frame)
 			output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 
-			raw_vision_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
+			raw_vision_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 
 			if output_resolution == temp_resolution:
-				encoded_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_frame.tobytes(), temp_resolution, frame_index)
+				output_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_buffer, temp_resolution, frame_index)
 			else:
 				destroy_video_encoder(video_codec, video_encoder)
 				temp_resolution = output_resolution
 				video_encoder = create_video_encoder(video_codec, temp_resolution)
-				encoded_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_frame.tobytes(), temp_resolution, frame_index)
+				output_video_buffer = encode_video_frame(video_codec, video_encoder, raw_vision_buffer, temp_resolution, frame_index)
 
 			now = time.monotonic()
 
-			if encoded_video_buffer:
-				rtc.send_video(rtc_peer, encoded_video_buffer, int(now * 90000))
+			if output_video_buffer:
+				rtc.send_video(rtc_peer, output_video_buffer, int(now * 90000))
 
 			if audio_encoder and audio_frame.dtype == numpy.float32:
-				encoded_audio_buffer = opus_encoder.encode(audio_encoder, audio_frame.tobytes(), 960)
+				output_audio_buffer = opus_encoder.encode(audio_encoder, audio_frame.tobytes(), 960)
 
-				if encoded_audio_buffer:
-					rtc.send_audio(rtc_peer, encoded_audio_buffer, int(now * 48000))
+				if output_audio_buffer:
+					rtc.send_audio(rtc_peer, output_audio_buffer, int(now * 48000))
 
 			frame_index += 1
 			vision_frame = wait_for_frame(video_queue, 30.0)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -142,14 +142,14 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	if not video_deque:
 		if not video_event.wait(timeout = 30.0):
 			stop_receiver_threads(stop_event, video_receiver, audio_receiver)
-			cleanup_peer(session_id)
+			rtc_store.delete_peers(session_id)
 			return
 
 	vision_frame = video_deque.popleft() if video_deque else None
 
 	if vision_frame is None:
 		stop_receiver_threads(stop_event, video_receiver, audio_receiver)
-		cleanup_peer(session_id)
+		rtc_store.delete_peers(session_id)
 		return
 
 	audio_frame = create_empty_audio_frame()
@@ -213,7 +213,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	stop_receiver_threads(stop_event, video_receiver, audio_receiver)
 	destroy_video_encoder(video_codec, video_encoder)
 	opus_encoder.destroy(audio_encoder)
-	cleanup_peer(session_id)
+	rtc_store.delete_peers(session_id)
 
 
 def receive_video_into_deque(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char], video_codec : VideoCodec, video_deque : deque, video_event : threading.Event, stop_event : threading.Event) -> None:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -187,7 +187,7 @@ def receive_video_frames(video_track : int, video_codec : VideoCodec, video_queu
 					video_queue.get_nowait()
 				video_queue.put_nowait(vision_frame)
 		else:
-			stop_event.wait(timeout = 0.001)
+			stop_event.wait(timeout = 0.001) # TODO: remove this timeout
 
 	video_queue.put(numpy.empty(0))
 
@@ -208,7 +208,7 @@ def receive_audio_frames(audio_track : int, audio_codec : AudioCodec, audio_queu
 		if audio_frame.dtype == numpy.float32:
 			audio_queue.put(audio_frame)
 		else:
-			stop_event.wait(timeout = 0.001)
+			stop_event.wait(timeout = 0.001) # TODO: remove this timeout
 
 	opus_decoder.destroy(audio_decoder)
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,6 +1,8 @@
 import asyncio
 import ctypes
+import threading
 import time
+from collections import deque
 from collections.abc import AsyncIterator
 from typing import Optional
 
@@ -118,21 +120,37 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	video_info = rtc_peer.get('video')
 	video_codec = video_info.get('codec')
+	video_receiver_track = video_info.get('receiver_track')
 	video_decoder = create_video_decoder(video_codec)
 	audio_info = rtc_peer.get('audio')
 	audio_decoder = opus_decoder.create(48000, 2) if audio_info else None
 	video_receive_buffer = ctypes.create_string_buffer(512 * 1024)
 	audio_receive_buffer = ctypes.create_string_buffer(8 * 1024)
+	stop_event = threading.Event()
+	video_deque : deque = deque(maxlen = 1)
+	video_event = threading.Event()
+	audio_deque : deque = deque(maxlen = 4)
+	audio_receiver = None
 
-	frame_buffer = poll_for_buffer(datachannel_library, video_info.get('receiver_track'), video_receive_buffer, 30.0)
+	video_receiver = threading.Thread(target = receive_video_into_deque, args = (datachannel_library, video_receiver_track, video_receive_buffer, video_codec, video_decoder, video_deque, video_event, stop_event), daemon = True)
+	video_receiver.start()
 
-	if frame_buffer is None:
-		cleanup_peer(session_id, rtc_peer, video_codec, video_decoder, audio_decoder)
-		return
+	if audio_info and audio_decoder:
+		audio_receiver = threading.Thread(target = receive_audio_into_deque, args = (datachannel_library, audio_info.get('receiver_track'), audio_decoder, audio_receive_buffer, audio_deque, stop_event), daemon = True)
+		audio_receiver.start()
 
-	vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
+	video_event.clear()
+
+	if not video_deque:
+		if not video_event.wait(timeout = 30.0):
+			stop_receiver_threads(stop_event, video_receiver, audio_receiver)
+			cleanup_peer(session_id, rtc_peer, video_codec, video_decoder, audio_decoder)
+			return
+
+	vision_frame = video_deque.popleft() if video_deque else None
 
 	if vision_frame is None:
+		stop_receiver_threads(stop_event, video_receiver, audio_receiver)
 		cleanup_peer(session_id, rtc_peer, video_codec, video_decoder, audio_decoder)
 		return
 
@@ -143,8 +161,8 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	frame_index = 0
 
 	while True:
-		if audio_info and audio_decoder:
-			audio_frame = receive_audio_frame(datachannel_library, audio_info.get('receiver_track'), audio_decoder, audio_receive_buffer)
+		if audio_deque:
+			audio_frame = audio_deque.popleft()
 
 		output_vision_frame = streamer.process_frame(audio_frame, vision_frame)
 		output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
@@ -155,41 +173,81 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 			video_encoder = create_video_encoder(video_codec, resolution)
 
 		raw_vision_frame = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420)
+		encoded_video_buffer = bytes()
 
 		if video_codec == 'av1':
 			encoded_video_buffer = aom_encoder.encode(video_encoder, raw_vision_frame.tobytes(), resolution, frame_index)
 		if video_codec == 'vp8':
 			encoded_video_buffer = vpx_encoder.encode(video_encoder, raw_vision_frame.tobytes(), resolution, frame_index)
 
-		if encoded_video_buffer:
-			video_timestamp = int(time.monotonic() * 90000)
-			rtc.send_video(rtc_peer, encoded_video_buffer, video_timestamp)
+		now = time.monotonic()
 
-		if audio_encoder and audio_frame is not None and audio_frame.size > 0:
+		if encoded_video_buffer:
+			rtc.send_video(rtc_peer, encoded_video_buffer, int(now * 90000))
+
+		if audio_encoder and audio_frame.dtype == numpy.float32:
 			encoded_audio_buffer = opus_encoder.encode(audio_encoder, audio_frame.tobytes(), 960)
 
 			if encoded_audio_buffer:
-				audio_timestamp = int(time.monotonic() * 48000)
-				rtc.send_audio(rtc_peer, encoded_audio_buffer, audio_timestamp)
+				rtc.send_audio(rtc_peer, encoded_audio_buffer, int(now * 48000))
 
 		frame_index += 1
 
-		next_frame = drain_to_latest_frame(datachannel_library, video_info.get('receiver_track'), video_codec, video_decoder, video_receive_buffer)
+		next_frame = video_deque.popleft() if video_deque else None
 
 		if next_frame is not None:
 			vision_frame = next_frame
 			continue
 
-		next_frame = poll_for_frame(datachannel_library, video_info.get('receiver_track'), video_codec, video_decoder, video_receive_buffer, 30.0)
+		video_event.clear()
+
+		if not video_deque:
+			if not video_event.wait(timeout = 30.0):
+				break
+
+		next_frame = video_deque.popleft() if video_deque else None
 
 		if next_frame is None:
 			break
 
 		vision_frame = next_frame
 
+	stop_receiver_threads(stop_event, video_receiver, audio_receiver)
 	destroy_video_encoder(video_codec, video_encoder)
 	opus_encoder.destroy(audio_encoder)
 	cleanup_peer(session_id, rtc_peer, video_codec, video_decoder, audio_decoder)
+
+
+def receive_video_into_deque(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char], video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_deque : deque, video_event : threading.Event, stop_event : threading.Event) -> None:
+	while not stop_event.is_set():
+		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
+
+		if frame_buffer:
+			vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
+
+			if vision_frame is not None:
+				video_deque.append(vision_frame)
+				video_event.set()
+		else:
+			stop_event.wait(timeout = 0.001)
+
+
+def receive_audio_into_deque(datachannel_library : ctypes.CDLL, audio_track : int, audio_decoder : OpusDecoder, receive_buffer : ctypes.Array[ctypes.c_char], audio_deque : deque, stop_event : threading.Event) -> None:
+	while not stop_event.is_set():
+		audio_frame = receive_audio_frame(datachannel_library, audio_track, audio_decoder, receive_buffer)
+
+		if audio_frame.dtype == numpy.float32:
+			audio_deque.append(audio_frame)
+		else:
+			stop_event.wait(timeout = 0.001)
+
+
+def stop_receiver_threads(stop_event : threading.Event, video_receiver : threading.Thread, audio_receiver : Optional[threading.Thread]) -> None:
+	stop_event.set()
+	video_receiver.join()
+
+	if audio_receiver:
+		audio_receiver.join()
 
 
 #TODO: needs review
@@ -234,58 +292,6 @@ def cleanup_peer(session_id : SessionId, rtc_peer : RtcPeer, video_codec : Video
 	rtc_store.delete_peers(session_id)
 
 
-def poll_for_buffer(datachannel_library : ctypes.CDLL, video_track : int, receive_buffer : ctypes.Array[ctypes.c_char], timeout : float) -> Optional[bytes]:
-	deadline = time.monotonic() + timeout
-
-	while time.monotonic() < deadline:
-		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
-
-		if frame_buffer is not None:
-			return frame_buffer
-
-		time.sleep(0.001)
-
-	return None
-
-
-#TODO: needs review
-def poll_for_frame(datachannel_library : ctypes.CDLL, video_track : int, video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, receive_buffer : ctypes.Array[ctypes.c_char], timeout : float) -> Optional[VisionFrame]:
-	deadline = time.monotonic() + timeout
-
-	while time.monotonic() < deadline:
-		vision_frame = try_receive_frame(datachannel_library, video_track, video_codec, video_decoder, receive_buffer)
-
-		if vision_frame is not None:
-			return vision_frame
-
-		time.sleep(0.001)
-
-	return None
-
-
-#TODO: needs review
-def drain_to_latest_frame(datachannel_library : ctypes.CDLL, video_track : int, video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[VisionFrame]:
-	last_vision_frame = numpy.empty(0)
-	buffer_size = ctypes.c_int(512 * 1024)
-	receive_output = 0
-
-	while receive_output == 0 and buffer_size.value > 0:
-		buffer_size.value = 512 * 1024
-		receive_output = datachannel_library.rtcReceiveMessage(video_track, receive_buffer, ctypes.byref(buffer_size))
-
-		if receive_output == 0 and buffer_size.value > 0:
-			frame_buffer = receive_buffer.raw[:buffer_size.value]
-			vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
-
-			if numpy.any(vision_frame):
-				last_vision_frame = vision_frame
-
-	if numpy.any(last_vision_frame):
-		return last_vision_frame
-
-	return None
-
-
 #TODO: needs review
 def receive_audio_frame(datachannel_library : ctypes.CDLL, audio_track : int, audio_decoder : OpusDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> AudioFrame:
 	buffer_size = ctypes.c_int(8 * 1024)
@@ -299,16 +305,6 @@ def receive_audio_frame(datachannel_library : ctypes.CDLL, audio_track : int, au
 			return numpy.frombuffer(output_buffer, dtype = numpy.float32)
 
 	return create_empty_audio_frame()
-
-
-#TODO: needs review
-def try_receive_frame(datachannel_library : ctypes.CDLL, video_track : int, video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, receive_buffer : ctypes.Array[ctypes.c_char]) -> Optional[VisionFrame]:
-	frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
-
-	if frame_buffer:
-		return decode_video_frame(video_codec, video_decoder, frame_buffer)
-
-	return None
 
 
 def decode_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, frame_buffer : bytes) -> Optional[VisionFrame]:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -109,8 +109,8 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	video_codec = rtc_peer.get('video').get('codec')
 	video_track = rtc_peer.get('video').get('receiver_track')
 	stop_event = threading.Event()
-	video_queue : queue.Queue = queue.Queue(maxsize = 1)
-	audio_queue : queue.Queue = queue.Queue(maxsize = 4)
+	video_queue : queue.Queue[VisionFrame] = queue.Queue(maxsize = 1)
+	audio_queue : queue.Queue[AudioFrame] = queue.Queue(maxsize = 4)
 	receiver_threads = [threading.Thread(target = pump_video_frames, args = (video_track, video_codec, video_queue, stop_event), daemon = True)]
 
 	if rtc_peer.get('audio'):
@@ -171,7 +171,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	rtc_store.delete_peers(session_id)
 
 
-def pump_video_frames(video_track : int, video_codec : VideoCodec, video_queue : queue.Queue, stop_event : threading.Event) -> None:
+def pump_video_frames(video_track : int, video_codec : VideoCodec, video_queue : queue.Queue[VisionFrame], stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	video_decoder = create_video_decoder(video_codec)
 	receive_buffer = ctypes.create_string_buffer(512 * 1024)
@@ -199,7 +199,7 @@ def pump_video_frames(video_track : int, video_codec : VideoCodec, video_queue :
 		vpx_decoder.destroy(video_decoder)
 
 
-def pump_audio_frames(audio_track : int, audio_codec : AudioCodec, audio_queue : queue.Queue, stop_event : threading.Event) -> None:
+def pump_audio_frames(audio_track : int, audio_codec : AudioCodec, audio_queue : queue.Queue[AudioFrame], stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	audio_decoder = opus_decoder.create(48000, 2)
 	receive_buffer = ctypes.create_string_buffer(8 * 1024)
@@ -272,16 +272,16 @@ def decode_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | Ao
 
 		if aom_pointer:
 			frame_width, frame_height = aom_pointer.get('resolution')
-			yuv_frame = numpy.frombuffer(aom_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
-			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
+			vision_frame = numpy.frombuffer(aom_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
+			return cv2.cvtColor(vision_frame, cv2.COLOR_YUV2BGR_I420)
 
 	if video_codec == 'vp8':
 		vpx_pointer = vpx_decoder.decode(video_decoder, frame_buffer)
 
 		if vpx_pointer:
 			frame_width, frame_height = vpx_pointer.get('resolution')
-			yuv_frame = numpy.frombuffer(vpx_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
-			return cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
+			vision_frame = numpy.frombuffer(vpx_pointer.get('buffer'), dtype = numpy.uint8).reshape((frame_height * 3 // 2, frame_width))
+			return cv2.cvtColor(vision_frame, cv2.COLOR_YUV2BGR_I420)
 
 	return None
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -175,13 +175,11 @@ def receive_video_frames(video_track : int, video_codec : VideoCodec, video_queu
 	datachannel_library = datachannel_module.create_static_library()
 	video_decoder = create_video_decoder(video_codec)
 	receive_buffer = ctypes.create_string_buffer(512 * 1024)
-	last_time = time.monotonic()
 
-	while not stop_event.is_set() and time.monotonic() - last_time < 30: # TODO: use positive while condition and remove last_frame_time
+	while not stop_event.is_set(): # TODO: use positive while condition
 		frame_buffer = receive_video_buffer(datachannel_library, video_track, receive_buffer)
 
 		if frame_buffer:
-			last_time = time.monotonic()
 			vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
 
 			if numpy.any(vision_frame):

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -1,8 +1,9 @@
 import asyncio
+import contextlib
 import ctypes
+import queue
 import threading
 import time
-from collections import deque
 from collections.abc import AsyncIterator
 from typing import Optional
 
@@ -116,18 +117,9 @@ async def receive_vision_frames(websocket : WebSocket) -> AsyncIterator[VisionFr
 		websocket_event = await websocket.receive()
 
 
-def wait_for_frame(video_deque : deque, video_event : threading.Event, timeout : float) -> VisionFrame:
-	if video_deque:
-		return video_deque.popleft()
-
-	video_event.clear()
-
-	if video_deque:
-		return video_deque.popleft()
-	video_event.wait(timeout = timeout)
-
-	if video_deque:
-		return video_deque.popleft()
+def wait_for_frame(video_queue : queue.Queue, timeout : float) -> VisionFrame:
+	with contextlib.suppress(queue.Empty):
+		return video_queue.get(timeout = timeout)
 	return numpy.empty(0)
 
 
@@ -136,20 +128,19 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	video_codec = rtc_peer.get('video').get('codec')
 	video_receiver_track = rtc_peer.get('video').get('receiver_track')
 	stop_event = threading.Event()
-	video_deque : deque = deque(maxlen = 1)
-	video_event = threading.Event()
-	audio_deque : deque = deque(maxlen = 4)
-	receiver_threads = [threading.Thread(target = receive_video_into_deque, args = (video_receiver_track, video_codec, video_deque, video_event, stop_event), daemon = True)]
+	video_queue : queue.Queue = queue.Queue(maxsize = 1)
+	audio_queue : queue.Queue = queue.Queue(maxsize = 4)
+	receiver_threads = [ threading.Thread(target = receive_video_into_deque, args = (video_receiver_track, video_codec, video_queue, stop_event), daemon = True) ]
 
 	if rtc_peer.get('audio'):
 		audio_codec = rtc_peer.get('audio').get('codec')
 		audio_receiver_track = rtc_peer.get('audio').get('receiver_track')
-		receiver_threads.append(threading.Thread(target = receive_audio_into_deque, args = (audio_receiver_track, audio_codec, audio_deque, stop_event), daemon = True))
+		receiver_threads.append(threading.Thread(target = receive_audio_into_deque, args = (audio_receiver_track, audio_codec, audio_queue, stop_event), daemon = True))
 
 	for receiver_thread in receiver_threads:
 		receiver_thread.start()
 
-	vision_frame = wait_for_frame(video_deque, video_event, 30.0)
+	vision_frame = wait_for_frame(video_queue, 30.0)
 
 	if numpy.any(vision_frame):
 		audio_frame = create_empty_audio_frame()
@@ -159,8 +150,8 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 		frame_index = 0
 
 		while numpy.any(vision_frame):
-			if audio_deque:
-				audio_frame = audio_deque.popleft()
+			if not audio_queue.empty():
+				audio_frame = audio_queue.get_nowait()
 
 			output_vision_frame = streamer.process_frame(audio_frame, vision_frame)
 			output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
@@ -187,7 +178,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 					rtc.send_audio(rtc_peer, encoded_audio_buffer, int(now * 48000))
 
 			frame_index += 1
-			vision_frame = wait_for_frame(video_deque, video_event, 30.0)
+			vision_frame = wait_for_frame(video_queue, 30.0)
 
 		destroy_video_encoder(video_codec, video_encoder)
 		opus_encoder.destroy(audio_encoder)
@@ -200,7 +191,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	rtc_store.delete_peers(session_id)
 
 
-def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_deque : deque, video_event : threading.Event, stop_event : threading.Event) -> None:
+def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_queue : queue.Queue, stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	video_decoder = create_video_decoder(video_codec)
 	receive_buffer = ctypes.create_string_buffer(512 * 1024)
@@ -211,9 +202,10 @@ def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_
 		if frame_buffer:
 			vision_frame = decode_video_frame(video_codec, video_decoder, frame_buffer)
 
-			if vision_frame is not None:
-				video_deque.append(vision_frame)
-				video_event.set()
+			if numpy.any(vision_frame):
+				with contextlib.suppress(queue.Empty):
+					video_queue.get_nowait()
+				video_queue.put_nowait(vision_frame)
 		else:
 			stop_event.wait(timeout = 0.001)
 
@@ -223,7 +215,7 @@ def receive_video_into_deque(video_track : int, video_codec : VideoCodec, video_
 		vpx_decoder.destroy(video_decoder)
 
 
-def receive_audio_into_deque(audio_track : int, audio_codec : AudioCodec, audio_deque : deque, stop_event : threading.Event) -> None:
+def receive_audio_into_deque(audio_track : int, audio_codec : AudioCodec, audio_queue : queue.Queue, stop_event : threading.Event) -> None:
 	datachannel_library = datachannel_module.create_static_library()
 	audio_decoder = opus_decoder.create(48000, 2)
 	receive_buffer = ctypes.create_string_buffer(8 * 1024)
@@ -232,7 +224,7 @@ def receive_audio_into_deque(audio_track : int, audio_codec : AudioCodec, audio_
 		audio_frame = receive_audio_frame(datachannel_library, audio_track, audio_decoder, receive_buffer)
 
 		if audio_frame.dtype == numpy.float32:
-			audio_deque.append(audio_frame)
+			audio_queue.put(audio_frame)
 		else:
 			stop_event.wait(timeout = 0.001)
 

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -11,7 +11,7 @@ from starlette.websockets import WebSocketState
 from tests.assert_helper import get_test_example_file, get_test_examples_directory
 
 from facefusion import rtc, rtc_store, state_manager
-from facefusion.apis.stream_helper import cleanup_peer, decode_video_frame, process_image, process_video, receive_audio_frame, receive_audio_into_deque, receive_video_buffer, receive_video_into_deque, receive_vision_frames, run_peer_loop
+from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, receive_audio_frame, receive_audio_into_deque, receive_video_buffer, receive_video_into_deque, receive_vision_frames, run_peer_loop
 from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
@@ -72,28 +72,6 @@ def before_all() -> None:
 @pytest.fixture(scope = 'function', autouse = True)
 def before_each() -> None:
 	rtc_store.clear()
-
-
-def test_cleanup_peer() -> None:
-	session_id = 'test-cleanup-peer'
-	peer_connection = rtc.create_peer_connection()
-	rtc_peer : RtcPeer =\
-	{
-		'peer_connection': peer_connection,
-		'video':
-		{
-			'sender_track': 0,
-			'receiver_track': 0,
-			'codec': 'vp8'
-		}
-	}
-
-	rtc_store.init_peers(session_id)
-	rtc_store.get_peers(session_id).append(rtc_peer)
-	cleanup_peer(session_id)
-
-	assert rtc_store.get_peers(session_id) is None
-	assert datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection) == -1
 
 
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -12,7 +12,7 @@ from tests.assert_helper import get_test_example_file, get_test_examples_directo
 from facefusion import rtc, rtc_store, state_manager
 import queue
 
-from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, receive_audio_frame, receive_audio_into_deque, receive_video_buffer, receive_video_into_deque, receive_vision_frames, run_peer_loop
+from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, receive_audio_frame, pump_audio_frames, receive_video_buffer, pump_video_frames, receive_vision_frames, run_peer_loop
 from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
@@ -150,7 +150,7 @@ def test_receive_video_into_deque_delivers_frame() -> None:
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event, 30.0), daemon = True)
+		receiver = threading.Thread(target = pump_video_frames, args = (0, 'vp8', video_queue, stop_event), daemon = True)
 		receiver.start()
 		vision_frame = video_queue.get(timeout = 2.0)
 		stop_event.set()
@@ -172,7 +172,7 @@ def test_receive_video_into_deque_keeps_latest_when_full() -> None:
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event, 30.0), daemon = True)
+		receiver = threading.Thread(target = pump_video_frames, args = (0, 'vp8', video_queue, stop_event), daemon = True)
 		receiver.start()
 		receiver.join(timeout = 2.0)
 		stop_event.set()
@@ -190,7 +190,7 @@ def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_queue, stop_event), daemon = True)
+		receiver = threading.Thread(target = pump_audio_frames, args = (0, 'opus', audio_queue, stop_event), daemon = True)
 		receiver.start()
 		audio_frame = audio_queue.get(timeout = 2.0)
 		stop_event.set()
@@ -207,7 +207,7 @@ def test_receive_audio_into_deque_skips_empty_frames() -> None:
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_queue, stop_event), daemon = True)
+		receiver = threading.Thread(target = pump_audio_frames, args = (0, 'opus', audio_queue, stop_event), daemon = True)
 		receiver.start()
 		threading.Event().wait(timeout = 0.05)
 		stop_event.set()

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,0 +1,305 @@
+import ctypes
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import cv2
+import numpy
+import pytest
+from starlette.websockets import WebSocketState
+from tests.assert_helper import get_test_example_file, get_test_examples_directory
+
+from facefusion import rtc, rtc_store, state_manager
+from facefusion.apis.stream_helper import cleanup_peer, decode_video_frame, drain_to_latest_frame, poll_for_buffer, poll_for_frame, process_image, process_video, receive_audio_frame, receive_video_buffer, receive_vision_frames, try_receive_frame
+from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, vpx_decoder, vpx_encoder
+from facefusion.download import conditional_download
+from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
+from facefusion.types import VideoCodec
+from facefusion.vision import read_video_frame
+
+
+@pytest.fixture(scope = 'module', autouse = True)
+def before_all() -> None:
+	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+	state_manager.init_item('processors', [])
+
+	conditional_download(get_test_examples_directory(),
+	[
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4',
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg'
+	])
+
+	aom_module.pre_check()
+	vpx_module.pre_check()
+	opus_module.pre_check()
+	datachannel_module.pre_check()
+
+
+@pytest.fixture(scope = 'function', autouse = True)
+def before_each() -> None:
+	rtc_store.clear()
+
+
+@pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
+def test_cleanup_peer(video_codec : VideoCodec) -> None:
+	session_id = 'test-cleanup-peer'
+	rtc_store.init_peers(session_id)
+	audio_dec = opus_decoder.create(48000, 2)
+
+	if video_codec == 'av1':
+		video_decoder = aom_decoder.create(8)
+
+		with patch('facefusion.apis.stream_helper.aom_decoder.destroy') as mock_video_destroy, \
+			patch('facefusion.apis.stream_helper.opus_decoder.destroy') as mock_audio_destroy, \
+			patch('facefusion.apis.stream_helper.rtc_store.delete_peers') as mock_delete:
+			cleanup_peer(session_id, None, video_codec, video_decoder, audio_dec)
+			mock_video_destroy.assert_called_once_with(video_decoder)
+			mock_audio_destroy.assert_called_once_with(audio_dec)
+			mock_delete.assert_called_once_with(session_id)
+
+	if video_codec == 'vp8':
+		video_decoder = vpx_decoder.create(8)
+
+		with patch('facefusion.apis.stream_helper.vpx_decoder.destroy') as mock_video_destroy, \
+			patch('facefusion.apis.stream_helper.opus_decoder.destroy') as mock_audio_destroy, \
+			patch('facefusion.apis.stream_helper.rtc_store.delete_peers') as mock_delete:
+			cleanup_peer(session_id, None, video_codec, video_decoder, audio_dec)
+			mock_video_destroy.assert_called_once_with(video_decoder)
+			mock_audio_destroy.assert_called_once_with(audio_dec)
+			mock_delete.assert_called_once_with(session_id)
+
+
+@pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
+def test_decode_video_frame(video_codec : VideoCodec) -> None:
+	vision_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
+	video_resolution = (vision_frame.shape[1], vision_frame.shape[0])
+	yuv_buffer = cv2.cvtColor(vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+
+	if video_codec == 'av1':
+		video_encoder = aom_encoder.create(video_resolution, 1000, 1, 0)
+		encoded_buffer = aom_encoder.encode(video_encoder, yuv_buffer, video_resolution, 0)
+		decoded_frame = decode_video_frame(video_codec, aom_decoder.create(8), encoded_buffer)
+
+		assert decoded_frame is not None
+		assert decoded_frame.shape[1] >= video_resolution[0]
+		assert decoded_frame.shape[0] >= video_resolution[1]
+		assert decoded_frame.ndim == 3
+
+	if video_codec == 'vp8':
+		video_encoder = vpx_encoder.create(video_resolution, 1000, 1, 0)
+		encoded_buffer = vpx_encoder.encode(video_encoder, yuv_buffer, video_resolution, 0)
+		decoded_frame = decode_video_frame(video_codec, vpx_decoder.create(8), encoded_buffer)
+
+		assert decoded_frame is not None
+		assert decoded_frame.shape[1] == video_resolution[0]
+		assert decoded_frame.shape[0] == video_resolution[1]
+		assert decoded_frame.ndim == 3
+
+
+def test_decode_video_frame_empty_buffer() -> None:
+	assert decode_video_frame('vp8', vpx_decoder.create(8), bytes()) is None
+	assert decode_video_frame('av1', aom_decoder.create(8), bytes()) is None
+
+
+def test_receive_video_buffer_failure() -> None:
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = -1
+	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+
+	assert receive_video_buffer(mock_lib, 0, receive_buffer) is None
+
+
+def test_receive_video_buffer_success() -> None:
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = 0
+	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+
+	assert isinstance(receive_video_buffer(mock_lib, 0, receive_buffer), bytes)
+
+
+def test_poll_for_buffer_timeout() -> None:
+	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+
+	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = None):
+		assert poll_for_buffer(MagicMock(), 0, receive_buffer, 0.01) is None
+
+
+def test_poll_for_buffer_success() -> None:
+	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+	test_data = b'\x01\x02\x03\x04'
+
+	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = test_data):
+		assert poll_for_buffer(MagicMock(), 0, receive_buffer, 1.0) == test_data
+
+
+def test_receive_audio_frame_failure() -> None:
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = -1
+	result = receive_audio_frame(mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024))
+
+	assert result.dtype == numpy.int16
+
+
+def test_receive_audio_frame_success() -> None:
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = 0
+	audio_bytes = numpy.zeros(960 * 2, dtype = numpy.float32).tobytes()
+
+	with patch('facefusion.apis.stream_helper.opus_decoder.decode', return_value = audio_bytes):
+		result = receive_audio_frame(mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024))
+
+	assert result.dtype == numpy.float32
+	assert result.size == 960 * 2
+
+
+def test_try_receive_frame_no_data() -> None:
+	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+
+	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = None):
+		assert try_receive_frame(MagicMock(), 0, 'vp8', vpx_decoder.create(8), receive_buffer) is None
+
+
+def test_try_receive_frame_valid_data() -> None:
+	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
+	video_resolution = (source_frame.shape[1], source_frame.shape[0])
+	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
+	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+
+	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = encoded_buffer):
+		vision_frame = try_receive_frame(MagicMock(), 0, 'vp8', vpx_decoder.create(8), receive_buffer)
+
+	assert vision_frame is not None
+	assert vision_frame.shape[1] == video_resolution[0]
+	assert vision_frame.shape[0] == video_resolution[1]
+
+
+def test_drain_to_latest_frame_no_data() -> None:
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = -1
+
+	assert drain_to_latest_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024)) is None
+
+
+def test_drain_to_latest_frame_returns_last_frame() -> None:
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.side_effect = [0, 0, -1]
+	dummy_frame = numpy.full((240, 320, 3), 128, dtype = numpy.uint8)
+
+	with patch('facefusion.apis.stream_helper.decode_video_frame', return_value = dummy_frame):
+		last_frame = drain_to_latest_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024))
+
+	assert numpy.array_equal(last_frame, dummy_frame)
+
+
+def test_poll_for_frame_timeout() -> None:
+	video_decoder = vpx_decoder.create(8)
+
+	with patch('facefusion.apis.stream_helper.try_receive_frame', return_value = None):
+		assert poll_for_frame(MagicMock(), 0, 'vp8', video_decoder, ctypes.create_string_buffer(512 * 1024), 0.01) is None
+
+
+def test_poll_for_frame_success() -> None:
+	video_decoder = vpx_decoder.create(8)
+	dummy_frame = numpy.full((240, 320, 3), 128, dtype = numpy.uint8)
+
+	with patch('facefusion.apis.stream_helper.try_receive_frame', return_value = dummy_frame):
+		assert numpy.array_equal(poll_for_frame(MagicMock(), 0, 'vp8', video_decoder, ctypes.create_string_buffer(512 * 1024), 1.0), dummy_frame)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+	return 'asyncio'
+
+
+@pytest.mark.anyio
+async def test_receive_vision_frames_yields_decoded_frames() -> None:
+	vision_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
+	_, jpeg_buffer = cv2.imencode('.jpg', vision_frame)
+	jpeg_bytes = jpeg_buffer.tobytes()
+	mock_ws = AsyncMock()
+	mock_ws.receive.side_effect =\
+	[
+		{'type': 'websocket.receive', 'bytes': jpeg_bytes},
+		{'type': 'websocket.receive', 'bytes': jpeg_bytes},
+		{'type': 'websocket.disconnect'}
+	]
+
+	frames = []
+
+	async for frame in receive_vision_frames(mock_ws):
+		frames.append(frame)
+
+	assert len(frames) == 2
+	assert frames[0].shape == vision_frame.shape
+
+
+@pytest.mark.anyio
+async def test_receive_vision_frames_skips_invalid_bytes() -> None:
+	mock_ws = AsyncMock()
+	mock_ws.receive.side_effect =\
+	[
+		{'type': 'websocket.receive', 'bytes': b'not_a_jpeg'},
+		{'type': 'websocket.disconnect'}
+	]
+
+	frames = []
+
+	async for frame in receive_vision_frames(mock_ws):
+		frames.append(frame)
+
+	assert len(frames) == 0
+
+
+@pytest.mark.anyio
+async def test_process_image_sends_processed_frame() -> None:
+	vision_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
+	_, jpeg_buffer = cv2.imencode('.jpg', vision_frame)
+	mock_ws = AsyncMock()
+	mock_ws.scope = {'type': 'websocket', 'headers': []}
+	mock_ws.client_state = WebSocketState.CONNECTED
+	mock_ws.receive.side_effect = [{'type': 'websocket.receive', 'bytes': jpeg_buffer.tobytes()}]
+
+	state_manager.init_item('source_paths', [get_test_example_file('source.jpg')])
+
+	await process_image(mock_ws)
+
+	mock_ws.accept.assert_called_once()
+	mock_ws.send_bytes.assert_called_once()
+	assert mock_ws.send_bytes.call_args[0][0][:3] == b'\xff\xd8\xff'
+
+
+@pytest.mark.anyio
+async def test_process_image_without_source_closes_cleanly() -> None:
+	mock_ws = AsyncMock()
+	mock_ws.scope = {'type': 'websocket', 'headers': []}
+	mock_ws.client_state = WebSocketState.CONNECTED
+
+	state_manager.init_item('source_paths', None)
+
+	await process_image(mock_ws)
+
+	mock_ws.accept.assert_called_once()
+	mock_ws.send_bytes.assert_not_called()
+	mock_ws.close.assert_called_once()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
+async def test_process_video_returns_sdp_answer(video_codec : VideoCodec) -> None:
+	sender_connection = rtc.create_peer_connection()
+
+	if video_codec == 'av1':
+		rtc.add_video_track(sender_connection, 'sendrecv', video_codec, 35)
+	if video_codec == 'vp8':
+		rtc.add_video_track(sender_connection, 'sendrecv', video_codec, 96)
+
+	rtc.add_audio_track(sender_connection, 'sendrecv', 'opus', 111)
+	sdp_offer = rtc.create_sdp_offer(sender_connection)
+	datachannel_module.create_static_library().rtcDeletePeerConnection(sender_connection)
+
+	with patch('facefusion.apis.stream_helper.run_peer_loop'):
+		sdp_answer = process_video('test-process-video-' + video_codec, sdp_offer)
+
+	assert sdp_answer is not None
+	assert 'm=video' in sdp_answer
+	assert 'a=recvonly' in sdp_answer
+	assert 'a=sendonly' in sdp_answer

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,7 +1,6 @@
 import ctypes
 import queue
 import threading
-from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import cv2
@@ -12,45 +11,12 @@ from tests.assert_helper import get_test_example_file, get_test_examples_directo
 
 from facefusion import rtc, rtc_store, state_manager
 from facefusion.apis.endpoints.stream import websocket_stream
-from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, pump_audio_frames, pump_video_frames, receive_vision_frames, run_peer_loop
+from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, receive_audio_frames, receive_video_frames, receive_vision_frames, run_peer_loop
 from facefusion.codecs import aom_decoder, aom_encoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
 from facefusion.types import AudioFrame, RtcPeer, VideoCodec, VisionFrame
 from facefusion.vision import read_video_frame
-
-
-def rtc_receive_data(data : bytes, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
-	ctypes.memmove(buffer, data, len(data))
-	ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(data)
-	return 0
-
-
-def rtc_receive_once(data : bytes, state : list[bool], track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
-	if state[0]:
-		return -1
-	ctypes.memmove(buffer, data, len(data))
-	ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(data)
-	state[0] = True
-	return 0
-
-
-def rtc_receive_two(first : bytes, second : bytes, state : list[int], track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
-	if state[0] == 0:
-		ctypes.memmove(buffer, first, len(first))
-		ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(first)
-		state[0] = 1
-		return 0
-	if state[0] == 1:
-		ctypes.memmove(buffer, second, len(second))
-		ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(second)
-		state[0] = 2
-		return 0
-	return -1
-
-
-def passthrough_process_frame(audio_frame : object, vision_frame : object) -> object:
-	return vision_frame
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -73,11 +39,6 @@ def before_all() -> None:
 @pytest.fixture(scope = 'function', autouse = True)
 def before_each() -> None:
 	rtc_store.clear()
-
-
-@pytest.fixture
-def anyio_backend() -> str:
-	return 'asyncio'
 
 
 # TODO: refine test
@@ -119,12 +80,22 @@ def test_pump_video_frames_keeps_latest_when_full() -> None:
 	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_two, encoded_buffer, encoded_buffer, [ 0 ])
+	state : list[int] = [ 0 ]
+
+	def receive_two(track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
+		if state[0] < 2:
+			ctypes.memmove(buffer, encoded_buffer, len(encoded_buffer))
+			ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(encoded_buffer)
+			state[0] += 1
+			return 0
+		return -1
+
+	mock_lib.rtcReceiveMessage.side_effect = receive_two
 	video_queue : queue.Queue[VisionFrame] = queue.Queue(maxsize = 1)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = pump_video_frames, args = (0, 'vp8', video_queue, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_video_frames, args = (0, 'vp8', video_queue, stop_event), daemon = True)
 		receiver.start()
 		receiver.join(timeout = 2.0)
 		stop_event.set()
@@ -138,12 +109,22 @@ def test_pump_audio_frames_delivers_decoded_frame() -> None:
 	audio_data = numpy.zeros(960 * 2, dtype = numpy.float32).tobytes()
 	encoded_opus = opus_encoder.encode(opus_encoder.create(48000, 2), audio_data, 960)
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_opus, [ False ])
+	state : list[bool] = [ False ]
+
+	def receive_once(track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
+		if state[0]:
+			return -1
+		ctypes.memmove(buffer, encoded_opus, len(encoded_opus))
+		ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(encoded_opus)
+		state[0] = True
+		return 0
+
+	mock_lib.rtcReceiveMessage.side_effect = receive_once
 	audio_queue : queue.Queue[AudioFrame] = queue.Queue(maxsize = 4)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = pump_audio_frames, args = (0, 'opus', audio_queue, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_audio_frames, args = (0, 'opus', audio_queue, stop_event), daemon = True)
 		receiver.start()
 		audio_frame = audio_queue.get(timeout = 2.0)
 		stop_event.set()
@@ -161,7 +142,7 @@ def test_pump_audio_frames_skips_empty_frames() -> None:
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = pump_audio_frames, args = (0, 'opus', audio_queue, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_audio_frames, args = (0, 'opus', audio_queue, stop_event), daemon = True)
 		receiver.start()
 		threading.Event().wait(timeout = 0.05)
 		stop_event.set()
@@ -196,10 +177,19 @@ def test_run_peer_loop_processes_and_sends_frame() -> None:
 	rtc_store.get_peers(session_id).append(rtc_peer)
 
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
+	state : list[bool] = [ False ]
+
+	def receive_once(track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
+		if state[0]:
+			return -1
+		ctypes.memmove(buffer, encoded_buffer, len(encoded_buffer))
+		ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(encoded_buffer)
+		state[0] = True
+		return 0
+
+	mock_lib.rtcReceiveMessage.side_effect = receive_once
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib), \
-		patch('facefusion.apis.stream_helper.streamer.process_frame', side_effect = passthrough_process_frame), \
 		patch('facefusion.apis.stream_helper.rtc.send_video') as mock_send_video:
 		thread = threading.Thread(target = run_peer_loop, args = (session_id, rtc_peer), daemon = True)
 		thread.start()

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -6,12 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import cv2
 import numpy
 import pytest
-from starlette.websockets import WebSocketState
 from tests.assert_helper import get_test_example_file, get_test_examples_directory
 
 from facefusion import rtc, rtc_store, state_manager
 import queue
 
+from starlette.websockets import WebSocketState
+from facefusion.apis.endpoints.stream import websocket_stream
 from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, receive_audio_frame, pump_audio_frames, receive_video_buffer, pump_video_frames, receive_vision_frames, run_peer_loop
 from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
@@ -303,31 +304,42 @@ async def test_process_image_sends_processed_frame() -> None:
 	vision_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
 	_, jpeg_buffer = cv2.imencode('.jpg', vision_frame)
 	mock_ws = AsyncMock()
-	mock_ws.scope = {'type': 'websocket', 'headers': []}
-	mock_ws.client_state = WebSocketState.CONNECTED
 	mock_ws.receive.side_effect = [{'type': 'websocket.receive', 'bytes': jpeg_buffer.tobytes()}]
 
 	state_manager.init_item('source_paths', [get_test_example_file('source.jpg')])
 
 	await process_image(mock_ws)
 
-	mock_ws.accept.assert_called_once()
 	mock_ws.send_bytes.assert_called_once()
 	assert mock_ws.send_bytes.call_args[0][0][:3] == b'\xff\xd8\xff'
 
 
 @pytest.mark.anyio
-async def test_process_image_without_source_closes_cleanly() -> None:
+async def test_process_image_without_source_skips_send() -> None:
+	mock_ws = AsyncMock()
+
+	state_manager.init_item('source_paths', None)
+
+	await process_image(mock_ws)
+
+	mock_ws.send_bytes.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_websocket_stream_accepts_and_closes() -> None:
 	mock_ws = AsyncMock()
 	mock_ws.scope = {'type': 'websocket', 'headers': []}
 	mock_ws.client_state = WebSocketState.CONNECTED
 
 	state_manager.init_item('source_paths', None)
 
-	await process_image(mock_ws)
+	with patch('facefusion.apis.endpoints.stream.get_sec_websocket_protocol', return_value = None), \
+		patch('facefusion.apis.endpoints.stream.extract_access_token', return_value = None), \
+		patch('facefusion.apis.endpoints.stream.session_manager.find_session_id', return_value = None), \
+		patch('facefusion.apis.endpoints.stream.session_context.set_session_id'):
+		await websocket_stream(mock_ws)
 
 	mock_ws.accept.assert_called_once()
-	mock_ws.send_bytes.assert_not_called()
 	mock_ws.close.assert_called_once()
 
 

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -74,9 +74,8 @@ def before_each() -> None:
 	rtc_store.clear()
 
 
-@pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
-def test_cleanup_peer(video_codec : VideoCodec) -> None:
-	session_id = 'test-cleanup-peer-' + video_codec
+def test_cleanup_peer() -> None:
+	session_id = 'test-cleanup-peer'
 	peer_connection = rtc.create_peer_connection()
 	rtc_peer : RtcPeer =\
 	{
@@ -85,17 +84,13 @@ def test_cleanup_peer(video_codec : VideoCodec) -> None:
 		{
 			'sender_track': 0,
 			'receiver_track': 0,
-			'codec': video_codec
+			'codec': 'vp8'
 		}
 	}
 
 	rtc_store.init_peers(session_id)
 	rtc_store.get_peers(session_id).append(rtc_peer)
-
-	if video_codec == 'av1':
-		cleanup_peer(session_id, rtc_peer, video_codec, aom_decoder.create(8), opus_decoder.create(48000, 2))
-	if video_codec == 'vp8':
-		cleanup_peer(session_id, rtc_peer, video_codec, vpx_decoder.create(8), opus_decoder.create(48000, 2))
+	cleanup_peer(session_id)
 
 	assert rtc_store.get_peers(session_id) is None
 	assert datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection) == -1
@@ -176,7 +171,7 @@ def test_receive_video_into_deque_delivers_frame() -> None:
 	video_event = threading.Event()
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', vpx_decoder.create(8), video_deque, video_event, stop_event), daemon = True)
+	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', video_deque, video_event, stop_event), daemon = True)
 	receiver.start()
 	video_event.wait(timeout = 2.0)
 	stop_event.set()
@@ -200,7 +195,7 @@ def test_receive_video_into_deque_keeps_latest_when_full() -> None:
 	video_event = threading.Event()
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', vpx_decoder.create(8), video_deque, video_event, stop_event), daemon = True)
+	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', video_deque, video_event, stop_event), daemon = True)
 	receiver.start()
 	receiver.join(timeout = 2.0)
 	stop_event.set()
@@ -217,7 +212,7 @@ def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
 	audio_deque : deque = deque(maxlen = 4)
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
+	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
 	receiver.start()
 	stop_event.wait(timeout = 2.0)
 	stop_event.set()
@@ -235,7 +230,7 @@ def test_receive_audio_into_deque_skips_empty_frames() -> None:
 	audio_deque : deque = deque(maxlen = 4)
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
+	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
 	receiver.start()
 	threading.Event().wait(timeout = 0.05)
 	stop_event.set()

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -150,7 +150,7 @@ def test_receive_video_into_deque_delivers_frame() -> None:
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event, 30.0), daemon = True)
 		receiver.start()
 		vision_frame = video_queue.get(timeout = 2.0)
 		stop_event.set()
@@ -172,7 +172,7 @@ def test_receive_video_into_deque_keeps_latest_when_full() -> None:
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event, 30.0), daemon = True)
 		receiver.start()
 		receiver.join(timeout = 2.0)
 		stop_event.set()

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,4 +1,5 @@
 import ctypes
+import queue
 import threading
 from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -6,28 +7,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import cv2
 import numpy
 import pytest
+from starlette.websockets import WebSocketState
 from tests.assert_helper import get_test_example_file, get_test_examples_directory
 
 from facefusion import rtc, rtc_store, state_manager
-import queue
-
-from starlette.websockets import WebSocketState
 from facefusion.apis.endpoints.stream import websocket_stream
-from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, receive_audio_frame, pump_audio_frames, receive_video_buffer, pump_video_frames, receive_vision_frames, run_peer_loop
-from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
+from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, pump_audio_frames, pump_video_frames, receive_vision_frames, run_peer_loop
+from facefusion.codecs import aom_decoder, aom_encoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
-from facefusion.types import RtcPeer, VideoCodec
+from facefusion.types import AudioFrame, RtcPeer, VideoCodec, VisionFrame
 from facefusion.vision import read_video_frame
 
 
-def rtc_receive_data(data : bytes, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : object) -> int:
+def rtc_receive_data(data : bytes, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
 	ctypes.memmove(buffer, data, len(data))
 	ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(data)
 	return 0
 
 
-def rtc_receive_once(data : bytes, state : list, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : object) -> int:
+def rtc_receive_once(data : bytes, state : list[bool], track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
 	if state[0]:
 		return -1
 	ctypes.memmove(buffer, data, len(data))
@@ -36,7 +35,7 @@ def rtc_receive_once(data : bytes, state : list, track : int, buffer : ctypes.Ar
 	return 0
 
 
-def rtc_receive_two(first : bytes, second : bytes, state : list, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : object) -> int:
+def rtc_receive_two(first : bytes, second : bytes, state : list[int], track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : ctypes.c_void_p) -> int:
 	if state[0] == 0:
 		ctypes.memmove(buffer, first, len(first))
 		ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(first)
@@ -76,6 +75,12 @@ def before_each() -> None:
 	rtc_store.clear()
 
 
+@pytest.fixture
+def anyio_backend() -> str:
+	return 'asyncio'
+
+
+# TODO: refine test
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
 def test_decode_video_frame(video_codec : VideoCodec) -> None:
 	vision_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
@@ -101,75 +106,21 @@ def test_decode_video_frame(video_codec : VideoCodec) -> None:
 		assert decoded_frame.ndim == 3
 
 
+# TODO: refine test
 def test_decode_video_frame_empty_buffer() -> None:
 	assert decode_video_frame('vp8', vpx_decoder.create(8), bytes()) is None
 	assert decode_video_frame('av1', aom_decoder.create(8), bytes()) is None
 
 
-def test_receive_video_buffer_failure() -> None:
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.return_value = -1
-
-	assert receive_video_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024)) is None
-
-
-def test_receive_video_buffer_success() -> None:
-	test_data = b'\x01\x02\x03\x04'
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, test_data)
-
-	assert receive_video_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024)) == test_data
-
-
-def test_receive_audio_frame_failure() -> None:
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.return_value = -1
-	result = receive_audio_frame(mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024))
-
-	assert result.dtype == numpy.int16
-
-
-def test_receive_audio_frame_success() -> None:
-	audio_data = numpy.zeros(960 * 2, dtype = numpy.float32).tobytes()
-	encoded_opus = opus_encoder.encode(opus_encoder.create(48000, 2), audio_data, 960)
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, encoded_opus)
-	result = receive_audio_frame(mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024))
-
-	assert result.dtype == numpy.float32
-	assert result.size == 960 * 2
-
-
-def test_receive_video_into_deque_delivers_frame() -> None:
-	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
-	video_resolution = (source_frame.shape[1], source_frame.shape[0])
-	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
-	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
-	video_queue : queue.Queue = queue.Queue(maxsize = 1)
-	stop_event = threading.Event()
-
-	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = pump_video_frames, args = (0, 'vp8', video_queue, stop_event), daemon = True)
-		receiver.start()
-		vision_frame = video_queue.get(timeout = 2.0)
-		stop_event.set()
-		receiver.join()
-
-	assert numpy.any(vision_frame)
-	assert vision_frame.shape[1] == video_resolution[0]
-	assert vision_frame.shape[0] == video_resolution[1]
-
-
-def test_receive_video_into_deque_keeps_latest_when_full() -> None:
+# TODO: refine test
+def test_pump_video_frames_keeps_latest_when_full() -> None:
 	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
 	video_resolution = (source_frame.shape[1], source_frame.shape[0])
 	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_two, encoded_buffer, encoded_buffer, [ 0 ])
-	video_queue : queue.Queue = queue.Queue(maxsize = 1)
+	video_queue : queue.Queue[VisionFrame] = queue.Queue(maxsize = 1)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
@@ -182,12 +133,13 @@ def test_receive_video_into_deque_keeps_latest_when_full() -> None:
 	assert video_queue.get_nowait().shape[1] == video_resolution[0]
 
 
-def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
+# TODO: refine test
+def test_pump_audio_frames_delivers_decoded_frame() -> None:
 	audio_data = numpy.zeros(960 * 2, dtype = numpy.float32).tobytes()
 	encoded_opus = opus_encoder.encode(opus_encoder.create(48000, 2), audio_data, 960)
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_opus, [ False ])
-	audio_queue : queue.Queue = queue.Queue(maxsize = 4)
+	audio_queue : queue.Queue[AudioFrame] = queue.Queue(maxsize = 4)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
@@ -201,10 +153,11 @@ def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
 	assert audio_frame.size == 960 * 2
 
 
-def test_receive_audio_into_deque_skips_empty_frames() -> None:
+# TODO: refine test
+def test_pump_audio_frames_skips_empty_frames() -> None:
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.return_value = -1
-	audio_queue : queue.Queue = queue.Queue(maxsize = 4)
+	audio_queue : queue.Queue[AudioFrame] = queue.Queue(maxsize = 4)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
@@ -217,6 +170,7 @@ def test_receive_audio_into_deque_skips_empty_frames() -> None:
 	assert audio_queue.empty()
 
 
+# TODO: refine test
 def test_run_peer_loop_processes_and_sends_frame() -> None:
 	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
 	video_resolution = (source_frame.shape[1], source_frame.shape[0])
@@ -255,11 +209,7 @@ def test_run_peer_loop_processes_and_sends_frame() -> None:
 	assert len(mock_send_video.call_args[0][1]) > 0
 
 
-@pytest.fixture
-def anyio_backend() -> str:
-	return 'asyncio'
-
-
+# TODO: refine test
 @pytest.mark.anyio
 async def test_receive_vision_frames_yields_decoded_frames() -> None:
 	vision_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
@@ -282,6 +232,7 @@ async def test_receive_vision_frames_yields_decoded_frames() -> None:
 	assert frames[0].shape == vision_frame.shape
 
 
+# TODO: refine test
 @pytest.mark.anyio
 async def test_receive_vision_frames_skips_invalid_bytes() -> None:
 	mock_ws = AsyncMock()
@@ -299,6 +250,7 @@ async def test_receive_vision_frames_skips_invalid_bytes() -> None:
 	assert len(frames) == 0
 
 
+# TODO: refine test
 @pytest.mark.anyio
 async def test_process_image_sends_processed_frame() -> None:
 	vision_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
@@ -314,6 +266,7 @@ async def test_process_image_sends_processed_frame() -> None:
 	assert mock_ws.send_bytes.call_args[0][0][:3] == b'\xff\xd8\xff'
 
 
+# TODO: refine test
 @pytest.mark.anyio
 async def test_process_image_without_source_skips_send() -> None:
 	mock_ws = AsyncMock()
@@ -325,6 +278,7 @@ async def test_process_image_without_source_skips_send() -> None:
 	mock_ws.send_bytes.assert_not_called()
 
 
+# TODO: refine test
 @pytest.mark.anyio
 async def test_websocket_stream_accepts_and_closes() -> None:
 	mock_ws = AsyncMock()
@@ -343,6 +297,7 @@ async def test_websocket_stream_accepts_and_closes() -> None:
 	mock_ws.close.assert_called_once()
 
 
+# TODO: refine test
 @pytest.mark.anyio
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
 async def test_process_video_returns_sdp_answer(video_codec : VideoCodec) -> None:

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,4 +1,5 @@
 import ctypes
+from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import cv2
@@ -9,11 +10,26 @@ from tests.assert_helper import get_test_example_file, get_test_examples_directo
 
 from facefusion import rtc, rtc_store, state_manager
 from facefusion.apis.stream_helper import cleanup_peer, decode_video_frame, drain_to_latest_frame, poll_for_buffer, poll_for_frame, process_image, process_video, receive_audio_frame, receive_video_buffer, receive_vision_frames, try_receive_frame
-from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, vpx_decoder, vpx_encoder
+from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
-from facefusion.types import VideoCodec
+from facefusion.types import RtcPeer, VideoCodec
 from facefusion.vision import read_video_frame
+
+
+def rtc_receive_data(data : bytes, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : object) -> int:
+	ctypes.memmove(buffer, data, len(data))
+	ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(data)
+	return 0
+
+
+def rtc_receive_once(data : bytes, state : list, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : object) -> int:
+	if state[0]:
+		return -1
+	ctypes.memmove(buffer, data, len(data))
+	ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(data)
+	state[0] = True
+	return 0
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -40,31 +56,29 @@ def before_each() -> None:
 
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
 def test_cleanup_peer(video_codec : VideoCodec) -> None:
-	session_id = 'test-cleanup-peer'
+	session_id = 'test-cleanup-peer-' + video_codec
+	peer_connection = rtc.create_peer_connection()
+	rtc_peer : RtcPeer =\
+	{
+		'peer_connection': peer_connection,
+		'video':
+		{
+			'sender_track': 0,
+			'receiver_track': 0,
+			'codec': video_codec
+		}
+	}
+
 	rtc_store.init_peers(session_id)
-	audio_dec = opus_decoder.create(48000, 2)
+	rtc_store.get_peers(session_id).append(rtc_peer)
 
 	if video_codec == 'av1':
-		video_decoder = aom_decoder.create(8)
-
-		with patch('facefusion.apis.stream_helper.aom_decoder.destroy') as mock_video_destroy, \
-			patch('facefusion.apis.stream_helper.opus_decoder.destroy') as mock_audio_destroy, \
-			patch('facefusion.apis.stream_helper.rtc_store.delete_peers') as mock_delete:
-			cleanup_peer(session_id, None, video_codec, video_decoder, audio_dec)
-			mock_video_destroy.assert_called_once_with(video_decoder)
-			mock_audio_destroy.assert_called_once_with(audio_dec)
-			mock_delete.assert_called_once_with(session_id)
-
+		cleanup_peer(session_id, rtc_peer, video_codec, aom_decoder.create(8), opus_decoder.create(48000, 2))
 	if video_codec == 'vp8':
-		video_decoder = vpx_decoder.create(8)
+		cleanup_peer(session_id, rtc_peer, video_codec, vpx_decoder.create(8), opus_decoder.create(48000, 2))
 
-		with patch('facefusion.apis.stream_helper.vpx_decoder.destroy') as mock_video_destroy, \
-			patch('facefusion.apis.stream_helper.opus_decoder.destroy') as mock_audio_destroy, \
-			patch('facefusion.apis.stream_helper.rtc_store.delete_peers') as mock_delete:
-			cleanup_peer(session_id, None, video_codec, video_decoder, audio_dec)
-			mock_video_destroy.assert_called_once_with(video_decoder)
-			mock_audio_destroy.assert_called_once_with(audio_dec)
-			mock_delete.assert_called_once_with(session_id)
+	assert rtc_store.get_peers(session_id) is None
+	assert datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection) == -1
 
 
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8' ])
@@ -108,26 +122,26 @@ def test_receive_video_buffer_failure() -> None:
 
 
 def test_receive_video_buffer_success() -> None:
+	test_data = b'\x01\x02\x03\x04'
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.return_value = 0
-	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, test_data)
 
-	assert isinstance(receive_video_buffer(mock_lib, 0, receive_buffer), bytes)
+	assert receive_video_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024)) == test_data
 
 
 def test_poll_for_buffer_timeout() -> None:
-	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = -1
 
-	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = None):
-		assert poll_for_buffer(MagicMock(), 0, receive_buffer, 0.01) is None
+	assert poll_for_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 0.01) is None
 
 
 def test_poll_for_buffer_success() -> None:
-	receive_buffer = ctypes.create_string_buffer(512 * 1024)
 	test_data = b'\x01\x02\x03\x04'
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, test_data)
 
-	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = test_data):
-		assert poll_for_buffer(MagicMock(), 0, receive_buffer, 1.0) == test_data
+	assert poll_for_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 1.0) == test_data
 
 
 def test_receive_audio_frame_failure() -> None:
@@ -139,22 +153,21 @@ def test_receive_audio_frame_failure() -> None:
 
 
 def test_receive_audio_frame_success() -> None:
+	audio_data = numpy.zeros(960 * 2, dtype = numpy.float32).tobytes()
+	encoded_opus = opus_encoder.encode(opus_encoder.create(48000, 2), audio_data, 960)
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.return_value = 0
-	audio_bytes = numpy.zeros(960 * 2, dtype = numpy.float32).tobytes()
-
-	with patch('facefusion.apis.stream_helper.opus_decoder.decode', return_value = audio_bytes):
-		result = receive_audio_frame(mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024))
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, encoded_opus)
+	result = receive_audio_frame(mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024))
 
 	assert result.dtype == numpy.float32
 	assert result.size == 960 * 2
 
 
 def test_try_receive_frame_no_data() -> None:
-	receive_buffer = ctypes.create_string_buffer(512 * 1024)
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = -1
 
-	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = None):
-		assert try_receive_frame(MagicMock(), 0, 'vp8', vpx_decoder.create(8), receive_buffer) is None
+	assert try_receive_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024)) is None
 
 
 def test_try_receive_frame_valid_data() -> None:
@@ -162,10 +175,9 @@ def test_try_receive_frame_valid_data() -> None:
 	video_resolution = (source_frame.shape[1], source_frame.shape[0])
 	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
-	receive_buffer = ctypes.create_string_buffer(512 * 1024)
-
-	with patch('facefusion.apis.stream_helper.receive_video_buffer', return_value = encoded_buffer):
-		vision_frame = try_receive_frame(MagicMock(), 0, 'vp8', vpx_decoder.create(8), receive_buffer)
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, encoded_buffer)
+	vision_frame = try_receive_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024))
 
 	assert vision_frame is not None
 	assert vision_frame.shape[1] == video_resolution[0]
@@ -180,29 +192,38 @@ def test_drain_to_latest_frame_no_data() -> None:
 
 
 def test_drain_to_latest_frame_returns_last_frame() -> None:
+	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
+	video_resolution = (source_frame.shape[1], source_frame.shape[0])
+	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = [0, 0, -1]
-	dummy_frame = numpy.full((240, 320, 3), 128, dtype = numpy.uint8)
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
+	last_frame = drain_to_latest_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024))
 
-	with patch('facefusion.apis.stream_helper.decode_video_frame', return_value = dummy_frame):
-		last_frame = drain_to_latest_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024))
-
-	assert numpy.array_equal(last_frame, dummy_frame)
+	assert last_frame is not None
+	assert last_frame.shape[1] == video_resolution[0]
+	assert last_frame.shape[0] == video_resolution[1]
 
 
 def test_poll_for_frame_timeout() -> None:
-	video_decoder = vpx_decoder.create(8)
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.return_value = -1
 
-	with patch('facefusion.apis.stream_helper.try_receive_frame', return_value = None):
-		assert poll_for_frame(MagicMock(), 0, 'vp8', video_decoder, ctypes.create_string_buffer(512 * 1024), 0.01) is None
+	assert poll_for_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024), 0.01) is None
 
 
 def test_poll_for_frame_success() -> None:
-	video_decoder = vpx_decoder.create(8)
-	dummy_frame = numpy.full((240, 320, 3), 128, dtype = numpy.uint8)
+	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
+	video_resolution = (source_frame.shape[1], source_frame.shape[0])
+	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
+	last_frame = poll_for_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024), 1.0)
 
-	with patch('facefusion.apis.stream_helper.try_receive_frame', return_value = dummy_frame):
-		assert numpy.array_equal(poll_for_frame(MagicMock(), 0, 'vp8', video_decoder, ctypes.create_string_buffer(512 * 1024), 1.0), dummy_frame)
+	assert last_frame is not None
+	assert last_frame.shape[1] == video_resolution[0]
+	assert last_frame.shape[0] == video_resolution[1]
 
 
 @pytest.fixture

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -149,15 +149,16 @@ def test_receive_video_into_deque_delivers_frame() -> None:
 	video_event = threading.Event()
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', video_deque, video_event, stop_event), daemon = True)
-	receiver.start()
-	video_event.wait(timeout = 2.0)
-	stop_event.set()
-	receiver.join()
+	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
+		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_deque, video_event, stop_event), daemon = True)
+		receiver.start()
+		video_event.wait(timeout = 2.0)
+		stop_event.set()
+		receiver.join()
 
 	vision_frame = video_deque.popleft()
 
-	assert vision_frame is not None
+	assert numpy.any(vision_frame)
 	assert vision_frame.shape[1] == video_resolution[0]
 	assert vision_frame.shape[0] == video_resolution[1]
 
@@ -173,10 +174,11 @@ def test_receive_video_into_deque_keeps_latest_when_full() -> None:
 	video_event = threading.Event()
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', video_deque, video_event, stop_event), daemon = True)
-	receiver.start()
-	receiver.join(timeout = 2.0)
-	stop_event.set()
+	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
+		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_deque, video_event, stop_event), daemon = True)
+		receiver.start()
+		receiver.join(timeout = 2.0)
+		stop_event.set()
 
 	assert len(video_deque) == 1
 	assert video_deque.popleft().shape[1] == video_resolution[0]
@@ -190,11 +192,12 @@ def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
 	audio_deque : deque = deque(maxlen = 4)
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
-	receiver.start()
-	stop_event.wait(timeout = 2.0)
-	stop_event.set()
-	receiver.join()
+	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
+		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_deque, stop_event), daemon = True)
+		receiver.start()
+		stop_event.wait(timeout = 2.0)
+		stop_event.set()
+		receiver.join()
 
 	audio_frame = audio_deque.popleft()
 
@@ -208,11 +211,12 @@ def test_receive_audio_into_deque_skips_empty_frames() -> None:
 	audio_deque : deque = deque(maxlen = 4)
 	stop_event = threading.Event()
 
-	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
-	receiver.start()
-	threading.Event().wait(timeout = 0.05)
-	stop_event.set()
-	receiver.join()
+	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
+		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_deque, stop_event), daemon = True)
+		receiver.start()
+		threading.Event().wait(timeout = 0.05)
+		stop_event.set()
+		receiver.join()
 
 	assert len(audio_deque) == 0
 

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,4 +1,6 @@
 import ctypes
+import threading
+from collections import deque
 from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,7 +11,7 @@ from starlette.websockets import WebSocketState
 from tests.assert_helper import get_test_example_file, get_test_examples_directory
 
 from facefusion import rtc, rtc_store, state_manager
-from facefusion.apis.stream_helper import cleanup_peer, decode_video_frame, drain_to_latest_frame, poll_for_buffer, poll_for_frame, process_image, process_video, receive_audio_frame, receive_video_buffer, receive_vision_frames, try_receive_frame
+from facefusion.apis.stream_helper import cleanup_peer, decode_video_frame, process_image, process_video, receive_audio_frame, receive_audio_into_deque, receive_video_buffer, receive_video_into_deque, receive_vision_frames, run_peer_loop
 from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
@@ -30,6 +32,24 @@ def rtc_receive_once(data : bytes, state : list, track : int, buffer : ctypes.Ar
 	ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(data)
 	state[0] = True
 	return 0
+
+
+def rtc_receive_two(first : bytes, second : bytes, state : list, track : int, buffer : ctypes.Array[ctypes.c_char], size_byref : object) -> int:
+	if state[0] == 0:
+		ctypes.memmove(buffer, first, len(first))
+		ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(first)
+		state[0] = 1
+		return 0
+	if state[0] == 1:
+		ctypes.memmove(buffer, second, len(second))
+		ctypes.cast(size_byref, ctypes.POINTER(ctypes.c_int))[0] = len(second)
+		state[0] = 2
+		return 0
+	return -1
+
+
+def passthrough_process_frame(audio_frame : object, vision_frame : object) -> object:
+	return vision_frame
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -88,8 +108,7 @@ def test_decode_video_frame(video_codec : VideoCodec) -> None:
 	yuv_buffer = cv2.cvtColor(vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 
 	if video_codec == 'av1':
-		video_encoder = aom_encoder.create(video_resolution, 1000, 1, 0)
-		encoded_buffer = aom_encoder.encode(video_encoder, yuv_buffer, video_resolution, 0)
+		encoded_buffer = aom_encoder.encode(aom_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 		decoded_frame = decode_video_frame(video_codec, aom_decoder.create(8), encoded_buffer)
 
 		assert decoded_frame is not None
@@ -98,8 +117,7 @@ def test_decode_video_frame(video_codec : VideoCodec) -> None:
 		assert decoded_frame.ndim == 3
 
 	if video_codec == 'vp8':
-		video_encoder = vpx_encoder.create(video_resolution, 1000, 1, 0)
-		encoded_buffer = vpx_encoder.encode(video_encoder, yuv_buffer, video_resolution, 0)
+		encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 		decoded_frame = decode_video_frame(video_codec, vpx_decoder.create(8), encoded_buffer)
 
 		assert decoded_frame is not None
@@ -116,9 +134,8 @@ def test_decode_video_frame_empty_buffer() -> None:
 def test_receive_video_buffer_failure() -> None:
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.return_value = -1
-	receive_buffer = ctypes.create_string_buffer(512 * 1024)
 
-	assert receive_video_buffer(mock_lib, 0, receive_buffer) is None
+	assert receive_video_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024)) is None
 
 
 def test_receive_video_buffer_success() -> None:
@@ -127,21 +144,6 @@ def test_receive_video_buffer_success() -> None:
 	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, test_data)
 
 	assert receive_video_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024)) == test_data
-
-
-def test_poll_for_buffer_timeout() -> None:
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.return_value = -1
-
-	assert poll_for_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 0.01) is None
-
-
-def test_poll_for_buffer_success() -> None:
-	test_data = b'\x01\x02\x03\x04'
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, test_data)
-
-	assert poll_for_buffer(mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 1.0) == test_data
 
 
 def test_receive_audio_frame_failure() -> None:
@@ -163,67 +165,121 @@ def test_receive_audio_frame_success() -> None:
 	assert result.size == 960 * 2
 
 
-def test_try_receive_frame_no_data() -> None:
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.return_value = -1
-
-	assert try_receive_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024)) is None
-
-
-def test_try_receive_frame_valid_data() -> None:
+def test_receive_video_into_deque_delivers_frame() -> None:
 	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
 	video_resolution = (source_frame.shape[1], source_frame.shape[0])
 	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_data, encoded_buffer)
-	vision_frame = try_receive_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024))
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
+	video_deque : deque = deque(maxlen = 1)
+	video_event = threading.Event()
+	stop_event = threading.Event()
+
+	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', vpx_decoder.create(8), video_deque, video_event, stop_event), daemon = True)
+	receiver.start()
+	video_event.wait(timeout = 2.0)
+	stop_event.set()
+	receiver.join()
+
+	vision_frame = video_deque.popleft()
 
 	assert vision_frame is not None
 	assert vision_frame.shape[1] == video_resolution[0]
 	assert vision_frame.shape[0] == video_resolution[1]
 
 
-def test_drain_to_latest_frame_no_data() -> None:
-	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.return_value = -1
-
-	assert drain_to_latest_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024)) is None
-
-
-def test_drain_to_latest_frame_returns_last_frame() -> None:
+def test_receive_video_into_deque_keeps_latest_when_full() -> None:
 	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
 	video_resolution = (source_frame.shape[1], source_frame.shape[0])
 	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 	mock_lib = MagicMock()
-	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
-	last_frame = drain_to_latest_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024))
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_two, encoded_buffer, encoded_buffer, [ 0 ])
+	video_deque : deque = deque(maxlen = 1)
+	video_event = threading.Event()
+	stop_event = threading.Event()
 
-	assert last_frame is not None
-	assert last_frame.shape[1] == video_resolution[0]
-	assert last_frame.shape[0] == video_resolution[1]
+	receiver = threading.Thread(target = receive_video_into_deque, args = (mock_lib, 0, ctypes.create_string_buffer(512 * 1024), 'vp8', vpx_decoder.create(8), video_deque, video_event, stop_event), daemon = True)
+	receiver.start()
+	receiver.join(timeout = 2.0)
+	stop_event.set()
+
+	assert len(video_deque) == 1
+	assert video_deque.popleft().shape[1] == video_resolution[0]
 
 
-def test_poll_for_frame_timeout() -> None:
+def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
+	audio_data = numpy.zeros(960 * 2, dtype = numpy.float32).tobytes()
+	encoded_opus = opus_encoder.encode(opus_encoder.create(48000, 2), audio_data, 960)
+	mock_lib = MagicMock()
+	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_opus, [ False ])
+	audio_deque : deque = deque(maxlen = 4)
+	stop_event = threading.Event()
+
+	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
+	receiver.start()
+	stop_event.wait(timeout = 2.0)
+	stop_event.set()
+	receiver.join()
+
+	audio_frame = audio_deque.popleft()
+
+	assert audio_frame.dtype == numpy.float32
+	assert audio_frame.size == 960 * 2
+
+
+def test_receive_audio_into_deque_skips_empty_frames() -> None:
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.return_value = -1
+	audio_deque : deque = deque(maxlen = 4)
+	stop_event = threading.Event()
 
-	assert poll_for_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024), 0.01) is None
+	receiver = threading.Thread(target = receive_audio_into_deque, args = (mock_lib, 0, opus_decoder.create(48000, 2), ctypes.create_string_buffer(8 * 1024), audio_deque, stop_event), daemon = True)
+	receiver.start()
+	threading.Event().wait(timeout = 0.05)
+	stop_event.set()
+	receiver.join()
+
+	assert len(audio_deque) == 0
 
 
-def test_poll_for_frame_success() -> None:
+def test_run_peer_loop_processes_and_sends_frame() -> None:
 	source_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
 	video_resolution = (source_frame.shape[1], source_frame.shape[0])
 	yuv_buffer = cv2.cvtColor(source_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
+
+	peer_connection = rtc.create_peer_connection()
+	video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', 'vp8', 96)
+	video_receiver_track = rtc.add_video_track(peer_connection, 'recvonly', 'vp8', 96)
+	rtc_peer : RtcPeer =\
+	{
+		'peer_connection': peer_connection,
+		'video':
+		{
+			'sender_track': video_sender_track,
+			'receiver_track': video_receiver_track,
+			'codec': 'vp8'
+		}
+	}
+
+	session_id = 'test-run-peer-loop'
+	rtc_store.init_peers(session_id)
+	rtc_store.get_peers(session_id).append(rtc_peer)
+
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
-	last_frame = poll_for_frame(mock_lib, 0, 'vp8', vpx_decoder.create(8), ctypes.create_string_buffer(512 * 1024), 1.0)
 
-	assert last_frame is not None
-	assert last_frame.shape[1] == video_resolution[0]
-	assert last_frame.shape[0] == video_resolution[1]
+	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib), \
+		patch('facefusion.apis.stream_helper.streamer.process_frame', side_effect = passthrough_process_frame), \
+		patch('facefusion.apis.stream_helper.rtc.send_video') as mock_send_video:
+		thread = threading.Thread(target = run_peer_loop, args = (session_id, rtc_peer), daemon = True)
+		thread.start()
+		thread.join(timeout = 5.0)
+
+	assert mock_send_video.called
+	assert len(mock_send_video.call_args[0][1]) > 0
 
 
 @pytest.fixture

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -1,6 +1,5 @@
 import ctypes
 import threading
-from collections import deque
 from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,6 +10,8 @@ from starlette.websockets import WebSocketState
 from tests.assert_helper import get_test_example_file, get_test_examples_directory
 
 from facefusion import rtc, rtc_store, state_manager
+import queue
+
 from facefusion.apis.stream_helper import decode_video_frame, process_image, process_video, receive_audio_frame, receive_audio_into_deque, receive_video_buffer, receive_video_into_deque, receive_vision_frames, run_peer_loop
 from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.download import conditional_download
@@ -145,18 +146,15 @@ def test_receive_video_into_deque_delivers_frame() -> None:
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_buffer, [ False ])
-	video_deque : deque = deque(maxlen = 1)
-	video_event = threading.Event()
+	video_queue : queue.Queue = queue.Queue(maxsize = 1)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_deque, video_event, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event), daemon = True)
 		receiver.start()
-		video_event.wait(timeout = 2.0)
+		vision_frame = video_queue.get(timeout = 2.0)
 		stop_event.set()
 		receiver.join()
-
-	vision_frame = video_deque.popleft()
 
 	assert numpy.any(vision_frame)
 	assert vision_frame.shape[1] == video_resolution[0]
@@ -170,18 +168,17 @@ def test_receive_video_into_deque_keeps_latest_when_full() -> None:
 	encoded_buffer = vpx_encoder.encode(vpx_encoder.create(video_resolution, 1000, 1, 0), yuv_buffer, video_resolution, 0)
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_two, encoded_buffer, encoded_buffer, [ 0 ])
-	video_deque : deque = deque(maxlen = 1)
-	video_event = threading.Event()
+	video_queue : queue.Queue = queue.Queue(maxsize = 1)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_deque, video_event, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_video_into_deque, args = (0, 'vp8', video_queue, stop_event), daemon = True)
 		receiver.start()
 		receiver.join(timeout = 2.0)
 		stop_event.set()
 
-	assert len(video_deque) == 1
-	assert video_deque.popleft().shape[1] == video_resolution[0]
+	assert video_queue.qsize() == 1
+	assert video_queue.get_nowait().shape[1] == video_resolution[0]
 
 
 def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
@@ -189,17 +186,15 @@ def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
 	encoded_opus = opus_encoder.encode(opus_encoder.create(48000, 2), audio_data, 960)
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.side_effect = partial(rtc_receive_once, encoded_opus, [ False ])
-	audio_deque : deque = deque(maxlen = 4)
+	audio_queue : queue.Queue = queue.Queue(maxsize = 4)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_deque, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_queue, stop_event), daemon = True)
 		receiver.start()
-		stop_event.wait(timeout = 2.0)
+		audio_frame = audio_queue.get(timeout = 2.0)
 		stop_event.set()
 		receiver.join()
-
-	audio_frame = audio_deque.popleft()
 
 	assert audio_frame.dtype == numpy.float32
 	assert audio_frame.size == 960 * 2
@@ -208,17 +203,17 @@ def test_receive_audio_into_deque_delivers_decoded_frame() -> None:
 def test_receive_audio_into_deque_skips_empty_frames() -> None:
 	mock_lib = MagicMock()
 	mock_lib.rtcReceiveMessage.return_value = -1
-	audio_deque : deque = deque(maxlen = 4)
+	audio_queue : queue.Queue = queue.Queue(maxsize = 4)
 	stop_event = threading.Event()
 
 	with patch('facefusion.apis.stream_helper.datachannel_module.create_static_library', return_value = mock_lib):
-		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_deque, stop_event), daemon = True)
+		receiver = threading.Thread(target = receive_audio_into_deque, args = (0, 'opus', audio_queue, stop_event), daemon = True)
 		receiver.start()
 		threading.Event().wait(timeout = 0.05)
 		stop_event.set()
 		receiver.join()
 
-	assert len(audio_deque) == 0
+	assert audio_queue.empty()
 
 
 def test_run_peer_loop_processes_and_sends_frame() -> None:


### PR DESCRIPTION
  - Refactor run_peer_loop to use queue.Queue for video/audio frame delivery with a dedicated pump_video_frames / pump_audio_frames per track
  - Move websocket connection concerns (accept, close, auth/session setup) out of process_image into the websocket_stream endpoint
  - Add test_stream_helper.py with unit tests for codecs, pump loops, vision frame generator, and endpoint lifecycle
