### PR TITLE
Implement REMB adaptive bitrate

### DIFF
--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -14,7 +14,7 @@ from facefusion import rtc, rtc_store, state_manager, streamer
 from facefusion.audio import create_empty_audio_frame
 from facefusion.codecs import aom_decoder, aom_encoder, opus_decoder, opus_encoder, vpx_decoder, vpx_encoder
 from facefusion.libraries import datachannel as datachannel_module
-from facefusion.types import AomDecoder, AomEncoder, AudioCodec, AudioFrame, PeerConnection, Resolution, RtcPeer, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame, VpxDecoder, VpxEncoder
+from facefusion.types import AomDecoder, AomEncoder, AudioCodec, AudioFrame, BitRate, PeerConnection, Resolution, RtcPeer, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame, VpxDecoder, VpxEncoder
 
 
 async def process_image(websocket : WebSocket) -> None:
@@ -43,7 +43,8 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 	if video_payload_type:
 		peer_connection : PeerConnection = rtc.create_peer_connection()
 		video_receiver_track = rtc.add_video_track(peer_connection, 'recvonly', video_codec, video_payload_type)
-		video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', video_codec, video_payload_type)
+		remb_bitrate = ctypes.c_uint(0)
+		video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', video_codec, video_payload_type, remb_bitrate)
 
 		audio_codec : AudioCodec = 'opus'
 		audio_payload_type = rtc.get_payload_type(sdp_offer, audio_codec)
@@ -66,7 +67,8 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 					'sender_track': video_sender_track,
 					'receiver_track': video_receiver_track,
 					'codec': video_codec
-				}
+				},
+			'remb_bitrate': remb_bitrate
 			}
 
 			if audio_receiver_track and audio_sender_track:
@@ -126,7 +128,8 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	if numpy.any(temp_vision_frame):
 		audio_frame = create_empty_audio_frame()
 		temp_resolution : Resolution = (temp_vision_frame.shape[1], temp_vision_frame.shape[0])
-		video_encoder = create_video_encoder(video_codec, temp_resolution)
+		bitrate : BitRate = 4000
+		video_encoder = create_video_encoder(video_codec, temp_resolution, bitrate)
 		audio_encoder = opus_encoder.create(48000, 2)
 		frame_index = 0
 
@@ -145,9 +148,15 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 			else:
 				destroy_video_encoder(video_codec, video_encoder)  # TODO: remove unconditional destroy methods, which have no impact on control flow
 				temp_resolution = output_resolution
-				video_encoder = create_video_encoder(video_codec, temp_resolution)
+				video_encoder = create_video_encoder(video_codec, temp_resolution, bitrate)
 				frame_index = 0
 				output_video_buffer = encode_video_frame(video_codec, video_encoder, output_vision_buffer, temp_resolution, frame_index)
+
+			remb_bitrate = rtc_peer.get('remb_bitrate').value
+
+			if remb_bitrate and abs(remb_bitrate - bitrate) > max(200, bitrate * 0.1):
+				bitrate = min(remb_bitrate, 8000)
+				video_encoder = update_video_encoder(video_codec, video_encoder, temp_resolution, bitrate)
 
 			if output_video_buffer:
 				rtc.send_video(rtc_peer, output_video_buffer, int(send_timestamp * 90000))
@@ -161,6 +170,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 			frame_index += 1
 			temp_vision_frame = video_queue.get()
 
+		rtc_peer.get('remb_bitrate').value = 0
 		destroy_video_encoder(video_codec, video_encoder)  # TODO: remove unconditional destroy methods, which have no impact on control flow
 		opus_encoder.destroy(audio_encoder)
 
@@ -262,14 +272,19 @@ def create_video_decoder(video_codec : VideoCodec) -> Optional[VpxDecoder | AomD
 	return None
 
 
-def create_video_encoder(video_codec : VideoCodec, resolution : Resolution) -> Optional[VpxEncoder | AomEncoder]:
+def create_video_encoder(video_codec : VideoCodec, resolution : Resolution, bitrate : BitRate) -> Optional[VpxEncoder | AomEncoder]:
 	if video_codec == 'av1':
-		return aom_encoder.create(resolution, 8000, 8, 10)
+		return aom_encoder.create(resolution, bitrate, 8, 10)
 
 	if video_codec == 'vp8':
-		return vpx_encoder.create(resolution, 8000, 8, 10)
+		return vpx_encoder.create(resolution, bitrate, 8, 10)
 
 	return None
+
+
+def update_video_encoder(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, resolution : Resolution, bitrate : BitRate) -> Optional[VpxEncoder | AomEncoder]:
+	destroy_video_encoder(video_codec, video_encoder)
+	return create_video_encoder(video_codec, resolution, bitrate)
 
 
 def destroy_video_decoder(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder) -> None:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -154,11 +154,11 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 				frame_index = 0
 				output_video_buffer = encode_video_frame(video_codec, video_encoder, output_vision_buffer, temp_resolution, frame_index)
 
-			remb_bitrate = rtc_peer.get('remb_bitrate').value
+			remb = rtc_peer.get('remb_bitrate')
 
-			if remb_bitrate:
-				smoothed_remb = smoothed_remb or remb_bitrate
-				smoothed_remb = int(0.2 * remb_bitrate + 0.8 * smoothed_remb)
+			if remb and remb.value:
+				smoothed_remb = smoothed_remb or remb.value
+				smoothed_remb = int(0.2 * remb.value + 0.8 * smoothed_remb)
 
 			if smoothed_remb and abs(smoothed_remb - bitrate) > max(200, bitrate * 0.1):
 				bitrate = max(500, min(smoothed_remb, 8000))
@@ -176,7 +176,10 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 			frame_index += 1
 			temp_vision_frame = video_queue.get()
 
-		rtc_peer.get('remb_bitrate').value = 0
+		remb = rtc_peer.get('remb_bitrate')
+
+		if remb:
+			remb.value = 0
 		destroy_video_encoder(video_codec, video_encoder)  # TODO: remove unconditional destroy methods, which have no impact on control flow
 		opus_encoder.destroy(audio_encoder)
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -44,7 +44,8 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 		peer_connection : PeerConnection = rtc.create_peer_connection()
 		video_receiver_track = rtc.add_video_track(peer_connection, 'recvonly', video_codec, video_payload_type)
 		remb_bitrate = ctypes.c_uint(0)
-		video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', video_codec, video_payload_type, remb_bitrate)
+		video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', video_codec, video_payload_type)
+		rtc.wire_remb(video_sender_track, remb_bitrate)
 
 		audio_codec : AudioCodec = 'opus'
 		audio_payload_type = rtc.get_payload_type(sdp_offer, audio_codec)

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -133,7 +133,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 		video_encoder = create_video_encoder(video_codec, temp_resolution, bitrate)
 		audio_encoder = opus_encoder.create(48000, 2)
 		frame_index = 0
-		smoothed_remb : BitRate = 0
+		smooth_remb : BitRate = 0
 
 		while numpy.any(temp_vision_frame):
 			with contextlib.suppress(queue.Empty):
@@ -157,11 +157,11 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 			remb = rtc_peer.get('remb_bitrate')
 
 			if remb and remb.value:
-				smoothed_remb = smoothed_remb or remb.value
-				smoothed_remb = int(0.2 * remb.value + 0.8 * smoothed_remb)
+				smooth_remb = smooth_remb or remb.value
+				smooth_remb = int(0.2 * remb.value + 0.8 * smooth_remb)
 
-			if smoothed_remb and abs(smoothed_remb - bitrate) > max(200, bitrate * 0.1):
-				bitrate = max(500, min(smoothed_remb, 8000))
+			if smooth_remb and abs(smooth_remb - bitrate) > max(200, bitrate * 0.1):
+				bitrate = max(500, min(smooth_remb, 8000))
 				video_encoder = update_video_encoder(video_codec, video_encoder, temp_resolution, bitrate)
 
 			if output_video_buffer:

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -288,7 +288,14 @@ def create_video_encoder(video_codec : VideoCodec, resolution : Resolution, bitr
 
 
 def update_video_encoder(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, resolution : Resolution, bitrate : BitRate) -> Optional[VpxEncoder | AomEncoder]:
-	destroy_video_encoder(video_codec, video_encoder)
+	if video_codec == 'av1':
+		if aom_encoder.update_bitrate(video_encoder, resolution, bitrate):
+			return video_encoder
+
+	if video_codec == 'vp8':
+		if vpx_encoder.update_bitrate(video_encoder, resolution, bitrate):
+			return video_encoder
+
 	return create_video_encoder(video_codec, resolution, bitrate)
 
 

--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -128,10 +128,11 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	if numpy.any(temp_vision_frame):
 		audio_frame = create_empty_audio_frame()
 		temp_resolution : Resolution = (temp_vision_frame.shape[1], temp_vision_frame.shape[0])
-		bitrate : BitRate = 4000
+		bitrate : BitRate = 1500
 		video_encoder = create_video_encoder(video_codec, temp_resolution, bitrate)
 		audio_encoder = opus_encoder.create(48000, 2)
 		frame_index = 0
+		smoothed_remb : BitRate = 0
 
 		while numpy.any(temp_vision_frame):
 			with contextlib.suppress(queue.Empty):
@@ -154,8 +155,12 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 
 			remb_bitrate = rtc_peer.get('remb_bitrate').value
 
-			if remb_bitrate and abs(remb_bitrate - bitrate) > max(200, bitrate * 0.1):
-				bitrate = min(remb_bitrate, 8000)
+			if remb_bitrate:
+				smoothed_remb = smoothed_remb or remb_bitrate
+				smoothed_remb = int(0.2 * remb_bitrate + 0.8 * smoothed_remb)
+
+			if smoothed_remb and abs(smoothed_remb - bitrate) > max(200, bitrate * 0.1):
+				bitrate = max(500, min(smoothed_remb, 8000))
 				video_encoder = update_video_encoder(video_codec, video_encoder, temp_resolution, bitrate)
 
 			if output_video_buffer:

--- a/facefusion/codecs/aom_encoder.py
+++ b/facefusion/codecs/aom_encoder.py
@@ -65,6 +65,23 @@ def collect(aom_encoder : AomEncoder) -> bytes:
 	return bytes().join(output_parts)
 
 
+def update_bitrate(aom_encoder : AomEncoder, frame_resolution : Resolution, bitrate : BitRate) -> bool:
+	aom_library = aom_module.create_static_library()
+
+	if aom_library:
+		aom_codec = ctypes.c_void_p.in_dll(aom_library, 'aom_codec_av1_cx_algo')
+		config_buffer = ctypes.create_string_buffer(1024)
+
+		if aom_library.aom_codec_enc_config_default(ctypes.byref(aom_codec), config_buffer, 1) == 0:
+			struct.pack_into('I', config_buffer, 12, frame_resolution[0])
+			struct.pack_into('I', config_buffer, 16, frame_resolution[1])
+			struct.pack_into('I', config_buffer, 136, bitrate)
+			struct.pack_into('I', config_buffer, 192, 30)
+			return aom_library.aom_codec_enc_config_set(aom_encoder, config_buffer) == 0
+
+	return False
+
+
 def destroy(aom_encoder : AomEncoder) -> None:
 	aom_library = aom_module.create_static_library()
 

--- a/facefusion/codecs/vpx_encoder.py
+++ b/facefusion/codecs/vpx_encoder.py
@@ -69,6 +69,22 @@ def collect(vpx_encoder : VpxEncoder) -> bytes:
 	return bytes().join(output_parts)
 
 
+def update_bitrate(vpx_encoder : VpxEncoder, frame_resolution : Resolution, bitrate : BitRate) -> bool:
+	vpx_library = vpx_module.create_static_library()
+
+	if vpx_library:
+		vp8_codec = ctypes.c_void_p.in_dll(vpx_library, 'vpx_codec_vp8_cx_algo')
+		config_buffer = ctypes.create_string_buffer(512)
+
+		if vpx_library.vpx_codec_enc_config_default(ctypes.byref(vp8_codec), config_buffer, 0) == 0:
+			struct.pack_into('I', config_buffer, 12, frame_resolution[0])
+			struct.pack_into('I', config_buffer, 16, frame_resolution[1])
+			struct.pack_into('I', config_buffer, 112, bitrate)
+			return vpx_library.vpx_codec_enc_config_set(vpx_encoder, config_buffer) == 0
+
+	return False
+
+
 def destroy(vpx_encoder : VpxEncoder) -> None:
 	vpx_library = vpx_module.create_static_library()
 

--- a/facefusion/libraries/aom.py
+++ b/facefusion/libraries/aom.py
@@ -101,6 +101,9 @@ def init_ctypes(library : ctypes.CDLL) -> ctypes.CDLL:
 	library.aom_codec_enc_config_default.argtypes = [ ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint ]
 	library.aom_codec_enc_config_default.restype = ctypes.c_int
 
+	library.aom_codec_enc_config_set.argtypes = [ ctypes.c_void_p, ctypes.c_void_p ]
+	library.aom_codec_enc_config_set.restype = ctypes.c_int
+
 	library.aom_codec_enc_init_ver.argtypes = [ ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_long, ctypes.c_int ]
 	library.aom_codec_enc_init_ver.restype = ctypes.c_int
 

--- a/facefusion/libraries/vpx.py
+++ b/facefusion/libraries/vpx.py
@@ -101,6 +101,9 @@ def init_ctypes(library : ctypes.CDLL) -> ctypes.CDLL:
 	library.vpx_codec_enc_config_default.argtypes = [ ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint ]
 	library.vpx_codec_enc_config_default.restype = ctypes.c_int
 
+	library.vpx_codec_enc_config_set.argtypes = [ ctypes.c_void_p, ctypes.c_void_p ]
+	library.vpx_codec_enc_config_set.restype = ctypes.c_int
+
 	library.vpx_codec_enc_init_ver.argtypes = [ ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_long, ctypes.c_int ]
 	library.vpx_codec_enc_init_ver.restype = ctypes.c_int
 

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -131,7 +131,7 @@ def add_audio_track(peer_connection : PeerConnection, media_direction : MediaDir
 	return audio_track
 
 
-def add_video_track(peer_connection : PeerConnection, media_direction : MediaDirection, video_codec : VideoCodec, payload_type : int, remb_bitrate : Optional[ctypes.c_uint] = None) -> RtcVideoTrack:
+def add_video_track(peer_connection : PeerConnection, media_direction : MediaDirection, video_codec : VideoCodec, payload_type : int) -> RtcVideoTrack:
 	datachannel_library = datachannel_module.create_static_library()
 	video_track_init = create_video_track_init(media_direction, video_codec, payload_type)
 	video_track = datachannel_library.rtcAddTrackEx(peer_connection, video_track_init)
@@ -151,10 +151,8 @@ def add_video_track(peer_connection : PeerConnection, media_direction : MediaDir
 		if video_codec == 'vp8':
 			datachannel_library.rtcSetVP8Packetizer(video_track, ctypes.byref(video_packetizer))
 
-		datachannel_library.rtcSetUserPointer(video_track, ctypes.cast(ctypes.byref(remb_bitrate), ctypes.c_void_p))
 		datachannel_library.rtcChainRtcpSrReporter(video_track)
 		datachannel_library.rtcChainRtcpNackResponder(video_track, 512)
-		datachannel_library.rtcChainRembHandler(video_track, create_static_remb_callback())
 
 	if media_direction == 'recvonly':
 		if video_codec == 'av1':
@@ -171,6 +169,12 @@ def add_video_track(peer_connection : PeerConnection, media_direction : MediaDir
 		datachannel_library.rtcChainRtcpReceivingSession(video_track)
 
 	return video_track
+
+
+def wire_remb(video_track : RtcVideoTrack, remb_bitrate : ctypes.c_uint) -> None:
+	datachannel_library = datachannel_module.create_static_library()
+	datachannel_library.rtcSetUserPointer(video_track, ctypes.cast(ctypes.byref(remb_bitrate), ctypes.c_void_p))
+	datachannel_library.rtcChainRembHandler(video_track, create_static_remb_callback())
 
 
 def create_audio_track_init(media_direction : MediaDirection, audio_codec : AudioCodec, payload_type : int) -> RtcTrackInit:

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 from typing import List, Optional
 
 from facefusion.libraries import datachannel as datachannel_module
-from facefusion.types import AudioCodec, MediaDirection, PeerConnection, RtcAudioTrack, RtcPeer, RtcTrackInit, RtcVideoTrack, SdpAnswer, SdpOffer, VideoCodec
+from facefusion.types import AudioCodec, MediaDirection, PeerConnection, RtcAudioTrack, RtcCallback, RtcPeer, RtcTrackInit, RtcVideoTrack, SdpAnswer, SdpOffer, VideoCodec
 
 
 def handle_remb(_ : int, bitrate : int, ptr : int) -> None:
@@ -11,7 +11,7 @@ def handle_remb(_ : int, bitrate : int, ptr : int) -> None:
 
 
 @lru_cache
-def create_static_remb_callback() -> ctypes.CFUNCTYPE:
+def create_static_remb_callback() -> RtcCallback:
 	return ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_uint, ctypes.c_void_p)(handle_remb)
 
 

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -1,8 +1,18 @@
 import ctypes
+from functools import lru_cache
 from typing import List, Optional
 
 from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import AudioCodec, MediaDirection, PeerConnection, RtcAudioTrack, RtcPeer, RtcTrackInit, RtcVideoTrack, SdpAnswer, SdpOffer, VideoCodec
+
+
+def handle_remb(_ : int, bitrate : int, ptr : int) -> None:
+	ctypes.cast(ptr, ctypes.POINTER(ctypes.c_uint)).contents.value = bitrate // 1000
+
+
+@lru_cache
+def create_static_remb_callback() -> ctypes.CFUNCTYPE:
+	return ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_uint, ctypes.c_void_p)(handle_remb)
 
 
 def create_peer_connection() -> PeerConnection:
@@ -121,7 +131,7 @@ def add_audio_track(peer_connection : PeerConnection, media_direction : MediaDir
 	return audio_track
 
 
-def add_video_track(peer_connection : PeerConnection, media_direction : MediaDirection, video_codec : VideoCodec, payload_type : int) -> RtcVideoTrack:
+def add_video_track(peer_connection : PeerConnection, media_direction : MediaDirection, video_codec : VideoCodec, payload_type : int, remb_bitrate : Optional[ctypes.c_uint] = None) -> RtcVideoTrack:
 	datachannel_library = datachannel_module.create_static_library()
 	video_track_init = create_video_track_init(media_direction, video_codec, payload_type)
 	video_track = datachannel_library.rtcAddTrackEx(peer_connection, video_track_init)
@@ -141,8 +151,10 @@ def add_video_track(peer_connection : PeerConnection, media_direction : MediaDir
 		if video_codec == 'vp8':
 			datachannel_library.rtcSetVP8Packetizer(video_track, ctypes.byref(video_packetizer))
 
+		datachannel_library.rtcSetUserPointer(video_track, ctypes.cast(ctypes.byref(remb_bitrate), ctypes.c_void_p))
 		datachannel_library.rtcChainRtcpSrReporter(video_track)
 		datachannel_library.rtcChainRtcpNackResponder(video_track, 512)
+		datachannel_library.rtcChainRembHandler(video_track, create_static_remb_callback())
 
 	if media_direction == 'recvonly':
 		if video_codec == 'av1':

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -6,15 +6,6 @@ from facefusion.libraries import datachannel as datachannel_module
 from facefusion.types import AudioCodec, MediaDirection, PeerConnection, RtcAudioTrack, RtcCallback, RtcPeer, RtcTrackInit, RtcVideoTrack, SdpAnswer, SdpOffer, VideoCodec
 
 
-def handle_remb(_ : int, bitrate : int, ptr : int) -> None:
-	ctypes.cast(ptr, ctypes.POINTER(ctypes.c_uint)).contents.value = bitrate // 1000
-
-
-@lru_cache
-def create_static_remb_callback() -> RtcCallback:
-	return ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_uint, ctypes.c_void_p)(handle_remb)
-
-
 def create_peer_connection() -> PeerConnection:
 	datachannel_library = datachannel_module.create_static_library()
 	rtc_configuration = datachannel_module.define_rtc_configuration()
@@ -241,3 +232,12 @@ def get_payload_type(sdp_offer : SdpOffer, codec : AudioCodec | VideoCodec) -> i
 		return payload_type_buffer[0]
 
 	return 0
+
+
+def handle_remb(track : int, bitrate : int, pointer : int) -> None:
+	ctypes.cast(pointer, ctypes.POINTER(ctypes.c_uint)).contents.value = bitrate // 1000
+
+
+@lru_cache
+def create_static_remb_callback() -> RtcCallback:
+	return ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_uint, ctypes.c_void_p)(handle_remb)

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -64,10 +64,10 @@ def send_video(rtc_peer : RtcPeer, video_buffer : bytes, video_timestamp : int) 
 		video_track = rtc_peer.get('video').get('sender_track')
 
 		if datachannel_library.rtcIsOpen(video_track):
-			send_buffer = ctypes.create_string_buffer(video_buffer)
+			send_pointer = ctypes.cast(ctypes.c_char_p(video_buffer), ctypes.c_void_p)
 			send_total = len(video_buffer)
 			datachannel_library.rtcSetTrackRtpTimestamp(video_track, video_timestamp)
-			datachannel_library.rtcSendMessage(video_track, send_buffer, send_total)
+			datachannel_library.rtcSendMessage(video_track, send_pointer, send_total)
 
 	return None
 
@@ -79,10 +79,10 @@ def send_audio(rtc_peer : RtcPeer, audio_buffer : bytes, audio_timestamp : int) 
 		audio_track = rtc_peer.get('audio').get('sender_track')
 
 		if datachannel_library.rtcIsOpen(audio_track):
-			send_buffer = ctypes.create_string_buffer(audio_buffer)
+			send_pointer = ctypes.cast(ctypes.c_char_p(audio_buffer), ctypes.c_void_p)
 			send_total = len(audio_buffer)
 			datachannel_library.rtcSetTrackRtpTimestamp(audio_track, audio_timestamp)
-			datachannel_library.rtcSendMessage(audio_track, send_buffer, send_total)
+			datachannel_library.rtcSendMessage(audio_track, send_pointer, send_total)
 
 	return None
 

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -314,6 +314,7 @@ RtcPeer = TypedDict('RtcPeer',
 	'peer_connection': PeerConnection,
 	'audio': NotRequired[RtcPeerAudio],
 	'video': RtcPeerVideo,
+	'remb_bitrate': ctypes.c_uint,
 })
 RtcStore : TypeAlias = Dict[SessionId, List[RtcPeer]]
 

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -291,6 +291,7 @@ SdpAnswer : TypeAlias = str
 MediaDirection : TypeAlias = Literal['sendonly', 'recvonly', 'sendrecv']
 
 RtcTrackInit : TypeAlias = Any
+RtcCallback : TypeAlias = Any
 
 RtcVideoTrack : TypeAlias = int
 RtcAudioTrack : TypeAlias = int
@@ -314,7 +315,7 @@ RtcPeer = TypedDict('RtcPeer',
 	'peer_connection': PeerConnection,
 	'audio': NotRequired[RtcPeerAudio],
 	'video': RtcPeerVideo,
-	'remb_bitrate': ctypes.c_uint,
+	'remb_bitrate': NotRequired[ctypes.c_uint],
 })
 RtcStore : TypeAlias = Dict[SessionId, List[RtcPeer]]
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -1,10 +1,11 @@
+import ctypes
 from typing import List
 
 import pytest
 
 from facefusion import state_manager
 from facefusion.libraries import datachannel as datachannel_module, opus as opus_module, vpx as vpx_module
-from facefusion.rtc import add_audio_track, add_video_track, create_peer_connection, create_sdp_answer, create_sdp_offer, delete_peers, get_payload_type, send_audio, send_video, set_remote_description
+from facefusion.rtc import add_audio_track, add_video_track, create_peer_connection, create_sdp_answer, create_sdp_offer, delete_peers, get_payload_type, send_audio, send_video, set_remote_description, wire_remb
 from facefusion.types import RtcPeer
 
 
@@ -143,3 +144,16 @@ def test_get_payload_type() -> None:
 	assert get_payload_type(sdp_offer, 'av1') == 0
 
 	datachannel_module.create_static_library().rtcDeletePeerConnection(peer_connection)
+
+
+def test_wire_remb() -> None:
+	datachannel_library = datachannel_module.create_static_library()
+	peer_connection = create_peer_connection()
+	video_track = add_video_track(peer_connection, 'sendonly', 'vp8', 96)
+	remb_bitrate = ctypes.c_uint(0)
+
+	wire_remb(video_track, remb_bitrate)
+
+	assert remb_bitrate.value == 0
+
+	datachannel_library.rtcDeletePeerConnection(peer_connection)


### PR DESCRIPTION
Improves the WebRTC stream path to reduce unnecessary work per frame and make the encoder respond to network conditions without disrupting playback quality.
The send path no longer copies frame data on every call. The encoder now adjusts to receiver bandwidth feedback smoothly rather than resetting on each change.