### PR TITLE
 feat(rtc): 2-way REMB with in-place encoder bitrate update

### DIFF
--- a/facefusion/apis/stream_helper.py
+++ b/facefusion/apis/stream_helper.py
@@ -44,8 +44,10 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 		peer_connection : PeerConnection = rtc.create_peer_connection()
 		video_receiver_track = rtc.add_video_track(peer_connection, 'recvonly', video_codec, video_payload_type)
 		video_sender_track = rtc.add_video_track(peer_connection, 'sendonly', video_codec, video_payload_type)
-		bitrate = ctypes.c_uint(0)
-		rtc.wire_remb(video_sender_track, bitrate)
+		sender_bitrate = ctypes.c_uint(0)
+		rtc.wire_remb(video_sender_track, sender_bitrate)
+		receiver_bitrate = ctypes.c_uint(0)
+		rtc.wire_remb(video_receiver_track, receiver_bitrate)
 
 		audio_codec : AudioCodec = 'opus'
 		audio_payload_type = rtc.get_payload_type(sdp_offer, audio_codec)
@@ -69,7 +71,8 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 					'receiver_track': video_receiver_track,
 					'codec': video_codec
 				},
-				'bitrate': bitrate
+				'sender_bitrate': sender_bitrate,
+				'receiver_bitrate': receiver_bitrate
 			}
 
 			if audio_receiver_track and audio_sender_track:
@@ -145,7 +148,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 
 			send_timestamp = time.monotonic()
 
-			peer_bitrate = rtc_peer.get('bitrate').value
+			peer_bitrate = rtc_peer.get('sender_bitrate').value
 
 			if output_resolution != temp_resolution: # TODO avoid != in condition
 				destroy_video_encoder(video_codec, video_encoder)

--- a/facefusion/rtc.py
+++ b/facefusion/rtc.py
@@ -228,7 +228,7 @@ def wire_remb(video_track : RtcVideoTrack, bitrate : ctypes.c_uint) -> None:
 
 
 def clear_remb(rtc_peer : RtcPeer) -> None:
-	rtc_peer.get('bitrate').value = 0
+	rtc_peer.get('sender_bitrate').value = 0
 
 
 def get_payload_type(sdp_offer : SdpOffer, codec : AudioCodec | VideoCodec) -> int:

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -314,7 +314,8 @@ RtcPeer = TypedDict('RtcPeer',
 	'peer_connection': PeerConnection,
 	'audio': NotRequired[RtcPeerAudio],
 	'video': RtcPeerVideo,
-	'bitrate': ctypes.c_uint
+	'sender_bitrate': ctypes.c_uint,
+	'receiver_bitrate': ctypes.c_uint
 })
 RtcStore : TypeAlias = Dict[SessionId, List[RtcPeer]]
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -79,7 +79,8 @@ def test_send_video() -> None:
 			'receiver_track': video_track,
 			'codec': 'vp8'
 		},
-		'bitrate': ctypes.c_uint(0)
+		'sender_bitrate': ctypes.c_uint(0),
+		'receiver_bitrate': ctypes.c_uint(0)
 	}
 
 	send_video(rtc_peer, bytes(1024), 0)
@@ -106,7 +107,8 @@ def test_send_audio() -> None:
 			'receiver_track': audio_track,
 			'codec': 'opus'
 		},
-		'bitrate': ctypes.c_uint(0)
+		'sender_bitrate': ctypes.c_uint(0),
+		'receiver_bitrate': ctypes.c_uint(0)
 	}
 
 	send_audio(rtc_peer, bytes(960), 0)
@@ -127,7 +129,8 @@ def test_delete_peers() -> None:
 				'receiver_track': 0,
 				'codec': 'vp8'
 			},
-			'bitrate': ctypes.c_uint(0)
+			'sender_bitrate': ctypes.c_uint(0),
+			'receiver_bitrate': ctypes.c_uint(0)
 		}
 	]
 
@@ -150,16 +153,43 @@ def test_wire_remb(video_codec : VideoCodec, payload_type : int) -> None:
 			'receiver_track': video_sender_track,
 			'codec': video_codec
 		},
-		'bitrate': ctypes.c_uint(0)
+		'sender_bitrate': ctypes.c_uint(0),
+		'receiver_bitrate': ctypes.c_uint(0)
 	}
 
-	wire_remb(video_sender_track, rtc_peer.get('bitrate'))
+	wire_remb(video_sender_track, rtc_peer.get('sender_bitrate'))
 
-	assert rtc_peer.get('bitrate').value == 0
+	assert rtc_peer.get('sender_bitrate').value == 0
 
-	handle_remb(0, 6000000, ctypes.addressof(rtc_peer.get('bitrate')))
+	handle_remb(0, 6000000, ctypes.addressof(rtc_peer.get('sender_bitrate')))
 
-	assert rtc_peer.get('bitrate').value == 6000
+	assert rtc_peer.get('sender_bitrate').value == 6000
+
+	datachannel_library.rtcDeletePeerConnection(peer_connection)
+
+
+@pytest.mark.parametrize('video_codec, payload_type', [ ('av1', 35), ('vp8', 96) ])
+def test_wire_remb_receiver(video_codec : VideoCodec, payload_type : int) -> None:
+	datachannel_library = datachannel_module.create_static_library()
+	peer_connection = create_peer_connection()
+	video_receiver_track = add_video_track(peer_connection, 'recvonly', video_codec, payload_type)
+	rtc_peer : RtcPeer =\
+	{
+		'peer_connection': peer_connection,
+		'video':
+		{
+			'sender_track': video_receiver_track,
+			'receiver_track': video_receiver_track,
+			'codec': video_codec
+		},
+		'sender_bitrate': ctypes.c_uint(0),
+		'receiver_bitrate': ctypes.c_uint(0)
+	}
+
+	wire_remb(video_receiver_track, rtc_peer.get('receiver_bitrate'))
+	handle_remb(0, 6000000, ctypes.addressof(rtc_peer.get('receiver_bitrate')))
+
+	assert rtc_peer.get('receiver_bitrate').value == 6000
 
 	datachannel_library.rtcDeletePeerConnection(peer_connection)
 

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -298,3 +298,16 @@ def test_process_video(video_codec : VideoCodec, session_id : str) -> None:
 	assert 'm=video' in sdp_answer
 	assert 'a=recvonly' in sdp_answer
 	assert 'a=sendonly' in sdp_answer
+
+	for peer in rtc_store.get_peers(session_id):
+		sender_bitrate = peer.get('sender_bitrate')
+		receiver_bitrate = peer.get('receiver_bitrate')
+
+		assert sender_bitrate.value == 0
+		assert receiver_bitrate.value == 0
+
+		rtc.handle_remb(0, 6000000, ctypes.addressof(sender_bitrate))
+		assert sender_bitrate.value == 6000
+
+		rtc.handle_remb(0, 4000000, ctypes.addressof(receiver_bitrate))
+		assert receiver_bitrate.value == 4000

--- a/tests/test_stream_helper.py
+++ b/tests/test_stream_helper.py
@@ -178,7 +178,8 @@ def test_run_peer_loop() -> None:
 			'receiver_track': video_receiver_track,
 			'codec': 'vp8'
 		},
-		'bitrate': ctypes.c_uint(0)
+		'sender_bitrate': ctypes.c_uint(0),
+		'receiver_bitrate': ctypes.c_uint(0)
 	}
 
 	session_id = 'test-run-peer-loop'


### PR DESCRIPTION
Completes bidirectional REMB: facefusion now generates REMB feedback to the browser's sender (tier 2) in addition to receiving it from the browser (tier 1), so both encoders adapt to network conditions independently
