### PR TITLE
Best performance to code ratio for stream

### DIFF
--- a/facefusion/apis/stream_audio.py
+++ b/facefusion/apis/stream_audio.py
@@ -12,6 +12,7 @@ from facefusion.codecs import opus_decoder, opus_encoder
 from facefusion.types import AudioCodec, AudioPack, OpusDecoder, RtcPeer, RtcPeerAudio
 
 
+# todo: why is this called encode_loop, is there a decode loop as well?
 def run_audio_encode_loop(rtc_peer : RtcPeer, audio_queue : Queue[AudioPack]) -> None:
 	temp_audio_frame, temp_audio_time = audio_queue.get()
 	audio_encoder = opus_encoder.create(48000, 2)

--- a/facefusion/apis/stream_audio.py
+++ b/facefusion/apis/stream_audio.py
@@ -36,8 +36,10 @@ def receive_audio_frames(rtc_peer_audio : RtcPeerAudio, audio_queue : Queue[Audi
 	audio_frame_handler = partial(handle_audio_frame, audio_codec, audio_decoder, audio_queue)
 	receive_event = create_receive_event(audio_track, audio_frame_handler)
 	receive_event.wait()
+
 	empty_audio_frame = numpy.empty(0)
 	audio_queue.put((empty_audio_frame, 0.0))
+	# todo: is this the correct place to destroy?
 	destroy_audio_decoder(audio_codec, audio_decoder)
 
 
@@ -58,6 +60,7 @@ def destroy_audio_decoder(audio_codec : AudioCodec, audio_decoder : OpusDecoder)
 		opus_decoder.destroy(audio_decoder)
 
 
+#todo: we can remove the dead args or pass audio buffer
 def handle_audio_frame(audio_codec : AudioCodec, audio_decoder : OpusDecoder, audio_queue : Queue[AudioPack], track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
 	audio_buffer = ctypes.string_at(data, size)
 	audio_frame = decode_audio_frame(audio_codec, audio_decoder, audio_buffer)

--- a/facefusion/apis/stream_audio.py
+++ b/facefusion/apis/stream_audio.py
@@ -39,7 +39,6 @@ def receive_audio_frames(rtc_peer_audio : RtcPeerAudio, audio_queue : Queue[Audi
 
 	empty_audio_frame = numpy.empty(0)
 	audio_queue.put((empty_audio_frame, 0.0))
-	# todo: is this the correct place to destroy?
 	destroy_audio_decoder(audio_codec, audio_decoder)
 
 

--- a/facefusion/apis/stream_audio.py
+++ b/facefusion/apis/stream_audio.py
@@ -2,19 +2,18 @@ import ctypes
 import time
 from functools import partial
 from queue import Queue
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy
 
 from facefusion import rtc
 from facefusion.apis.stream_event import create_receive_event
 from facefusion.codecs import opus_decoder, opus_encoder
-from facefusion.types import AudioCodec, AudioPack, OpusDecoder, RtcPeer, RtcPeerAudio
+from facefusion.types import AudioCodec, AudioFrame, OpusDecoder, RtcPeer, RtcPeerAudio
 
 
-# todo: why is this called encode_loop, is there a decode loop as well?
-def run_audio_encode_loop(rtc_peer : RtcPeer, audio_queue : Queue[AudioPack]) -> None:
-	temp_audio_frame, temp_audio_time = audio_queue.get()
+def run_audio_encode_loop(rtc_peer : RtcPeer, audio_queue : Queue[Tuple[float, AudioFrame]]) -> None:
+	temp_audio_time, temp_audio_frame = audio_queue.get()
 	audio_encoder = opus_encoder.create(48000, 2)
 
 	while numpy.any(temp_audio_frame):
@@ -24,12 +23,12 @@ def run_audio_encode_loop(rtc_peer : RtcPeer, audio_queue : Queue[AudioPack]) ->
 			audio_timestamp = int(temp_audio_time * 48000)
 			rtc.send_audio(rtc_peer, output_audio_buffer, audio_timestamp)
 
-		temp_audio_frame, temp_audio_time = audio_queue.get()
+		temp_audio_time, temp_audio_frame = audio_queue.get()
 
 	opus_encoder.destroy(audio_encoder)
 
 
-def receive_audio_frames(rtc_peer_audio : RtcPeerAudio, audio_queue : Queue[AudioPack]) -> None:
+def receive_audio_frames(rtc_peer_audio : RtcPeerAudio, audio_queue : Queue[Tuple[float, AudioFrame]]) -> None:
 	audio_track = rtc_peer_audio.get('receiver_track')
 	audio_codec = rtc_peer_audio.get('codec')
 	audio_decoder = create_audio_decoder(audio_codec)
@@ -39,7 +38,7 @@ def receive_audio_frames(rtc_peer_audio : RtcPeerAudio, audio_queue : Queue[Audi
 	receive_event.wait()
 
 	empty_audio_frame = numpy.empty(0)
-	audio_queue.put((empty_audio_frame, 0.0))
+	audio_queue.put((0.0, empty_audio_frame))
 	destroy_audio_decoder(audio_codec, audio_decoder)
 
 
@@ -60,11 +59,11 @@ def destroy_audio_decoder(audio_codec : AudioCodec, audio_decoder : OpusDecoder)
 		opus_decoder.destroy(audio_decoder)
 
 
-#todo: we can remove the dead args or pass audio buffer
-def handle_audio_frame(audio_codec : AudioCodec, audio_decoder : OpusDecoder, audio_queue : Queue[AudioPack], track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
+#todo: Alias Time for float
+def handle_audio_frame(audio_codec : AudioCodec, audio_decoder : OpusDecoder, audio_queue : Queue[Tuple[float, AudioFrame]], track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
 	audio_buffer = ctypes.string_at(data, size)
 	audio_frame = decode_audio_frame(audio_codec, audio_decoder, audio_buffer)
 
 	if audio_frame:
 		temp_audio_frame = numpy.frombuffer(audio_frame, dtype = numpy.float32)
-		audio_queue.put((temp_audio_frame, time.monotonic()))
+		audio_queue.put((time.monotonic(), temp_audio_frame))

--- a/facefusion/apis/stream_audio.py
+++ b/facefusion/apis/stream_audio.py
@@ -17,11 +17,11 @@ def run_audio_encode_loop(rtc_peer : RtcPeer, audio_queue : Queue[Tuple[float, A
 	audio_encoder = opus_encoder.create(48000, 2)
 
 	while numpy.any(temp_audio_frame):
-		output_audio_buffer = opus_encoder.encode(audio_encoder, temp_audio_frame.tobytes(), 960)
+		audio_buffer = opus_encoder.encode(audio_encoder, temp_audio_frame.tobytes(), 960)
 
-		if output_audio_buffer:
+		if audio_buffer:
 			audio_timestamp = int(temp_audio_time * 48000)
-			rtc.send_audio(rtc_peer, output_audio_buffer, audio_timestamp)
+			rtc.send_audio(rtc_peer, audio_buffer, audio_timestamp)
 
 		temp_audio_time, temp_audio_frame = audio_queue.get()
 

--- a/facefusion/apis/stream_manager.py
+++ b/facefusion/apis/stream_manager.py
@@ -1,6 +1,7 @@
 import ctypes
 import threading
 from collections.abc import AsyncIterator
+from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 from typing import Optional
 
@@ -8,7 +9,7 @@ import cv2
 import numpy
 from starlette.websockets import WebSocket
 
-from facefusion import rtc, rtc_store, streamer
+from facefusion import rtc, rtc_store, state_manager, streamer
 from facefusion.apis.stream_audio import receive_audio_frames, run_audio_encode_loop
 from facefusion.apis.stream_video import receive_video_frames, run_video_encode_loop
 from facefusion.audio import create_empty_audio_frame
@@ -104,10 +105,12 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 
 
 def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
+	#todo: we need to test different maxsize for video queue (audio quaue is x 10) here or make it depend on execution thread count
 	video_queue : Queue[VideoPack] = Queue(maxsize = 30)
 	audio_queue : Queue[AudioPack] = Queue(maxsize = 300)
+	video_executor = ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count'))
 
-	video_receiver_thread = threading.Thread(target = receive_video_frames, args = (rtc_peer.get('video'), video_queue), daemon = True)
+	video_receiver_thread = threading.Thread(target = receive_video_frames, args = (rtc_peer.get('video'), video_queue, video_executor), daemon = True)
 	video_encoder_thread = threading.Thread(target = run_video_encode_loop, args = (rtc_peer, video_queue), daemon = True)
 	video_receiver_thread.start()
 	video_encoder_thread.start()
@@ -122,6 +125,7 @@ def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 
 	video_receiver_thread.join()
 	video_encoder_thread.join()
+	video_executor.shutdown(wait = True)
 	rtc_store.delete_peers(session_id)
 
 

--- a/facefusion/apis/stream_manager.py
+++ b/facefusion/apis/stream_manager.py
@@ -1,9 +1,9 @@
 import ctypes
 import threading
 from collections.abc import AsyncIterator
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from queue import Queue
-from typing import Optional
+from typing import Optional, Tuple
 
 import cv2
 import numpy
@@ -14,7 +14,7 @@ from facefusion.apis.stream_audio import receive_audio_frames, run_audio_encode_
 from facefusion.apis.stream_video import receive_video_frames, run_video_encode_loop
 from facefusion.audio import create_empty_audio_frame
 from facefusion.libraries import datachannel as datachannel_module
-from facefusion.types import AudioCodec, AudioPack, PeerConnection, RtcPeer, RtcPeerAudio, SdpAnswer, SdpOffer, SessionId, VideoCodec, VideoPack, VisionFrame
+from facefusion.types import AudioCodec, AudioFrame, PeerConnection, Resolution, RtcPeer, RtcPeerAudio, SdpAnswer, SdpOffer, SessionId, VideoCodec, VisionFrame
 
 
 async def process_image(websocket : WebSocket) -> None:
@@ -106,8 +106,9 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 
 def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
 	execution_thread_count = state_manager.get_item('execution_thread_count')
-	video_queue : Queue[VideoPack] = Queue(maxsize = execution_thread_count)
-	audio_queue : Queue[AudioPack] = Queue(maxsize = execution_thread_count * 10)
+	#todo: is bytes, Resolution not a XXXPointer type
+	video_queue : Queue[Tuple[float, Future[Tuple[bytes, Resolution]]]] = Queue(maxsize = execution_thread_count)
+	audio_queue : Queue[Tuple[float, AudioFrame]] = Queue(maxsize = execution_thread_count * 10)
 	video_executor = ThreadPoolExecutor(max_workers = execution_thread_count)
 
 	video_receiver_thread = threading.Thread(target = receive_video_frames, args = (rtc_peer.get('video'), video_queue, video_executor), daemon = True)

--- a/facefusion/apis/stream_manager.py
+++ b/facefusion/apis/stream_manager.py
@@ -105,10 +105,10 @@ def process_video(session_id : SessionId, sdp_offer : SdpOffer) -> Optional[SdpA
 
 
 def run_peer_loop(session_id : SessionId, rtc_peer : RtcPeer) -> None:
-	#todo: we need to test different maxsize for video queue (audio quaue is x 10) here or make it depend on execution thread count
-	video_queue : Queue[VideoPack] = Queue(maxsize = 30)
-	audio_queue : Queue[AudioPack] = Queue(maxsize = 300)
-	video_executor = ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count'))
+	execution_thread_count = state_manager.get_item('execution_thread_count')
+	video_queue : Queue[VideoPack] = Queue(maxsize = execution_thread_count)
+	audio_queue : Queue[AudioPack] = Queue(maxsize = execution_thread_count * 10)
+	video_executor = ThreadPoolExecutor(max_workers = execution_thread_count)
 
 	video_receiver_thread = threading.Thread(target = receive_video_frames, args = (rtc_peer.get('video'), video_queue, video_executor), daemon = True)
 	video_encoder_thread = threading.Thread(target = run_video_encode_loop, args = (rtc_peer, video_queue), daemon = True)

--- a/facefusion/apis/stream_video.py
+++ b/facefusion/apis/stream_video.py
@@ -196,7 +196,7 @@ def update_video_encoder_bitrate(video_codec : VideoCodec, video_encoder : VpxEn
 
 
 #todo: we can remove the dead args or pass audio buffer
-def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_queue : Queue[VideoPack], video_executor : ThreadPoolExecutor, track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
+def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_queue : Queue[Tuple[float, Future[Tuple[bytes, Resolution]]]], video_executor : ThreadPoolExecutor, track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
 	video_buffer = ctypes.string_at(data, size)
 	vision_frame = decode_video_frame(video_codec, video_decoder, video_buffer)
 

--- a/facefusion/apis/stream_video.py
+++ b/facefusion/apis/stream_video.py
@@ -15,8 +15,10 @@ from facefusion.codecs import aom_decoder, aom_encoder, vpx_decoder, vpx_encoder
 from facefusion.types import AomDecoder, AomEncoder, AomPointer, BitRate, Resolution, RtcPeer, RtcPeerVideo, VideoCodec, VideoFuture, VideoPack, VisionFrame, VpxDecoder, VpxEncoder, VpxPointer
 
 
+# todo: why is this called encode_loop, is there a decode loop as well?
 def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[VideoPack]) -> None:
 	video_codec = rtc_peer.get('video').get('codec')
+	# todo video_future, video_time, video_buffer, video_resolution
 	output_future, output_video_time = video_queue.get()
 	output_buffer, output_resolution = output_future.result()
 
@@ -24,7 +26,7 @@ def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[VideoPack]) ->
 		temp_resolution : Resolution = output_resolution
 		temp_bitrate : BitRate = 8000
 		video_encoder = create_video_encoder(video_codec, temp_resolution, temp_bitrate)
-		previous_video_time = output_video_time
+		temp_video_time = output_video_time
 		frame_index = 0
 
 		while output_buffer:
@@ -41,17 +43,20 @@ def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[VideoPack]) ->
 
 			output_video_buffer = encode_video_frame(video_codec, video_encoder, output_buffer, temp_resolution, frame_index)
 
+			# todo: video buffer
 			if output_video_buffer:
-				rtc.send_video(rtc_peer, output_video_buffer, int(output_video_time * 90000))
+				video_timestamp = int(output_video_time * 90000)
+				rtc.send_video(rtc_peer, output_video_buffer, video_timestamp)
 
 			encode_time = time.monotonic() - encode_start
-			frame_interval = output_video_time - previous_video_time
-			previous_video_time = output_video_time
+			frame_interval = output_video_time - temp_video_time
+			temp_video_time = output_video_time
 
 			receiver_bitrate = calculate_receiver_bitrate(rtc_peer, encode_time, frame_interval)
 			rtc.adapt_receiver_bitrate(rtc_peer, receiver_bitrate)
 			frame_index += 1
 
+			#todo video_future, video_time, video_resolution
 			output_future, output_video_time = video_queue.get()
 			output_buffer, output_resolution = output_future.result()
 
@@ -94,6 +99,7 @@ def calculate_receiver_bitrate(rtc_peer : RtcPeer, encode_time : float, frame_in
 	return bitrate
 
 
+#todo: does not feel final as this is an clamp and not calculate
 def calculate_sender_bitrate(rtc_peer : RtcPeer, bitrate : BitRate) -> BitRate:
 	min_bitrate : BitRate = 500
 	max_bitrate : BitRate = 8000
@@ -193,6 +199,7 @@ def update_video_encoder_bitrate(video_codec : VideoCodec, video_encoder : VpxEn
 	return False
 
 
+#todo: we can remove the dead args or pass audio buffer
 def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_queue : Queue[VideoPack], video_executor : ThreadPoolExecutor, track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
 	video_buffer = ctypes.string_at(data, size)
 	vision_frame = decode_video_frame(video_codec, video_decoder, video_buffer)

--- a/facefusion/apis/stream_video.py
+++ b/facefusion/apis/stream_video.py
@@ -200,9 +200,6 @@ def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | Ao
 	video_buffer = ctypes.string_at(data, size)
 	vision_frame = decode_video_frame(video_codec, video_decoder, video_buffer)
 
-	if numpy.any(vision_frame):
-		if video_queue.full():
-			video_queue.get_nowait()
-
+	if numpy.any(vision_frame) and video_queue.qsize() < video_queue.maxsize:
 		video_future = video_executor.submit(process_video_frame, vision_frame)
 		video_queue.put((time.monotonic(), video_future))

--- a/facefusion/apis/stream_video.py
+++ b/facefusion/apis/stream_video.py
@@ -3,7 +3,7 @@ import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from queue import Queue
-from typing import Optional
+from typing import Optional, Tuple
 
 import cv2
 import numpy
@@ -12,59 +12,55 @@ from facefusion import rtc, streamer
 from facefusion.apis.stream_event import create_receive_event
 from facefusion.audio import create_empty_audio_frame
 from facefusion.codecs import aom_decoder, aom_encoder, vpx_decoder, vpx_encoder
-from facefusion.types import AomDecoder, AomEncoder, AomPointer, BitRate, Resolution, RtcPeer, RtcPeerVideo, VideoCodec, VideoFuture, VideoPack, VisionFrame, VpxDecoder, VpxEncoder, VpxPointer
+from facefusion.types import AomDecoder, AomEncoder, AomPointer, BitRate, Resolution, RtcPeer, RtcPeerVideo, VideoCodec, VisionFrame, VpxDecoder, VpxEncoder, VpxPointer
 
 
-# todo: why is this called encode_loop, is there a decode loop as well?
-def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[VideoPack]) -> None:
+def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[Tuple[float, Future[Tuple[bytes, Resolution]]]]) -> None:
 	video_codec = rtc_peer.get('video').get('codec')
-	# todo video_future, video_time, video_buffer, video_resolution
-	output_future, output_video_time = video_queue.get()
-	output_buffer, output_resolution = output_future.result()
+	video_time, video_future = video_queue.get()
+	video_buffer, video_resolution = video_future.result()
 
-	if output_buffer:
-		temp_resolution : Resolution = output_resolution
+	if video_buffer:
+		temp_resolution : Resolution = video_resolution
 		temp_bitrate : BitRate = 8000
 		video_encoder = create_video_encoder(video_codec, temp_resolution, temp_bitrate)
-		temp_video_time = output_video_time
+		temp_video_time = video_time
 		frame_index = 0
 
-		while output_buffer:
+		while video_buffer:
 			encode_start = time.monotonic()
 			sender_bitrate = calculate_sender_bitrate(rtc_peer, temp_bitrate)
 
-			if output_resolution[0] - temp_resolution[0] or output_resolution[1] - temp_resolution[1]:
-				temp_resolution = output_resolution
+			if video_resolution[0] - temp_resolution[0] or video_resolution[1] - temp_resolution[1]:
+				temp_resolution = video_resolution
 				update_video_encoder_resolution(video_codec, video_encoder, temp_resolution)
 
 			if sender_bitrate - temp_bitrate:
 				temp_bitrate = sender_bitrate
 				update_video_encoder_bitrate(video_codec, video_encoder, temp_bitrate)
 
-			output_video_buffer = encode_video_frame(video_codec, video_encoder, output_buffer, temp_resolution, frame_index)
+			output_video_buffer = encode_video_frame(video_codec, video_encoder, video_buffer, temp_resolution, frame_index)
 
-			# todo: video buffer
 			if output_video_buffer:
-				video_timestamp = int(output_video_time * 90000)
+				video_timestamp = int(video_time * 90000)
 				rtc.send_video(rtc_peer, output_video_buffer, video_timestamp)
 
 			encode_time = time.monotonic() - encode_start
-			frame_interval = output_video_time - temp_video_time
-			temp_video_time = output_video_time
+			frame_interval = video_time - temp_video_time
+			temp_video_time = video_time
 
 			receiver_bitrate = calculate_receiver_bitrate(rtc_peer, encode_time, frame_interval)
 			rtc.adapt_receiver_bitrate(rtc_peer, receiver_bitrate)
 			frame_index += 1
 
-			#todo video_future, video_time, video_resolution
-			output_future, output_video_time = video_queue.get()
-			output_buffer, output_resolution = output_future.result()
+			video_time, video_future = video_queue.get()
+			video_buffer, video_resolution = video_future.result()
 
 		destroy_video_encoder(video_codec, video_encoder)
 		rtc.clear_bitrate(rtc_peer)
 
 
-def receive_video_frames(rtc_peer_video : RtcPeerVideo, video_queue : Queue[VideoPack], video_executor : ThreadPoolExecutor) -> None:
+def receive_video_frames(rtc_peer_video : RtcPeerVideo, video_queue : Queue[Tuple[float, Future[Tuple[bytes, Resolution]]]], video_executor : ThreadPoolExecutor) -> None:
 	video_track = rtc_peer_video.get('receiver_track')
 	video_codec = rtc_peer_video.get('codec')
 	video_decoder = create_video_decoder(video_codec)
@@ -73,13 +69,13 @@ def receive_video_frames(rtc_peer_video : RtcPeerVideo, video_queue : Queue[Vide
 	receive_event = create_receive_event(video_track, video_frame_handler)
 	receive_event.wait()
 
-	empty_future : VideoFuture = Future()
+	empty_future : Future[Tuple[bytes, Resolution]] = Future()
 	empty_future.set_result((bytes(), (0, 0)))
-	video_queue.put((empty_future, 0.0))
+	video_queue.put((0.0, empty_future))
 	destroy_video_decoder(video_codec, video_decoder)
 
 
-def process_video_frame(vision_frame : VisionFrame) -> tuple[bytes, Resolution]:
+def process_video_frame(vision_frame : VisionFrame) -> Tuple[bytes, Resolution]:
 	output_vision_frame = streamer.process_frame(create_empty_audio_frame(), vision_frame)
 	output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 	output_vision_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
@@ -103,10 +99,10 @@ def calculate_receiver_bitrate(rtc_peer : RtcPeer, encode_time : float, frame_in
 def calculate_sender_bitrate(rtc_peer : RtcPeer, bitrate : BitRate) -> BitRate:
 	min_bitrate : BitRate = 500
 	max_bitrate : BitRate = 8000
-	__bitrate__ : BitRate = rtc_peer.get('sender_bitrate').value
+	peer_bitrate : BitRate = rtc_peer.get('sender_bitrate').value
 
-	if __bitrate__ > 0:
-		bitrate = max(min_bitrate, min(max_bitrate, __bitrate__))
+	if peer_bitrate > 0:
+		bitrate = max(min_bitrate, min(max_bitrate, peer_bitrate))
 
 	return bitrate
 
@@ -209,4 +205,4 @@ def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | Ao
 			video_queue.get_nowait()
 
 		video_future = video_executor.submit(process_video_frame, vision_frame)
-		video_queue.put((video_future, time.monotonic()))
+		video_queue.put((time.monotonic(), video_future))

--- a/facefusion/apis/stream_video.py
+++ b/facefusion/apis/stream_video.py
@@ -39,11 +39,11 @@ def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[Tuple[float, F
 				temp_bitrate = sender_bitrate
 				update_video_encoder_bitrate(video_codec, video_encoder, temp_bitrate)
 
-			output_video_buffer = encode_video_frame(video_codec, video_encoder, video_buffer, temp_resolution, frame_index)
+			__video_buffer__ = encode_video_frame(video_codec, video_encoder, video_buffer, temp_resolution, frame_index)
 
-			if output_video_buffer:
+			if __video_buffer__:
 				video_timestamp = int(video_time * 90000)
-				rtc.send_video(rtc_peer, output_video_buffer, video_timestamp)
+				rtc.send_video(rtc_peer, __video_buffer__, video_timestamp)
 
 			encode_time = time.monotonic() - encode_start
 			frame_interval = video_time - temp_video_time
@@ -75,11 +75,11 @@ def receive_video_frames(rtc_peer_video : RtcPeerVideo, video_queue : Queue[Tupl
 	destroy_video_decoder(video_codec, video_decoder)
 
 
-def process_video_frame(vision_frame : VisionFrame) -> Tuple[bytes, Resolution]:
-	output_vision_frame = streamer.process_frame(create_empty_audio_frame(), vision_frame)
+def process_video_frame(input_vision_frame : VisionFrame) -> Tuple[bytes, Resolution]:
+	output_vision_frame = streamer.process_frame(create_empty_audio_frame(), input_vision_frame)
 	output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
-	output_vision_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
-	return output_vision_buffer, output_resolution
+	output_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
+	return output_buffer, output_resolution
 
 
 def calculate_receiver_bitrate(rtc_peer : RtcPeer, encode_time : float, frame_interval : float) -> BitRate:

--- a/facefusion/apis/stream_video.py
+++ b/facefusion/apis/stream_video.py
@@ -1,7 +1,6 @@
 import ctypes
 import time
-from collections import deque
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from queue import Queue
 from typing import Optional
@@ -9,67 +8,61 @@ from typing import Optional
 import cv2
 import numpy
 
-from facefusion import rtc, state_manager, streamer
+from facefusion import rtc, streamer
 from facefusion.apis.stream_event import create_receive_event
 from facefusion.audio import create_empty_audio_frame
 from facefusion.codecs import aom_decoder, aom_encoder, vpx_decoder, vpx_encoder
-from facefusion.types import AomDecoder, AomEncoder, AomPointer, BitRate, Resolution, RtcPeer, RtcPeerVideo, VideoCodec, VideoPack, VisionFrame, VpxDecoder, VpxEncoder, VpxPointer
+from facefusion.types import AomDecoder, AomEncoder, AomPointer, BitRate, Resolution, RtcPeer, RtcPeerVideo, VideoCodec, VideoFuture, VideoPack, VisionFrame, VpxDecoder, VpxEncoder, VpxPointer
 
 
 def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[VideoPack]) -> None:
 	video_codec = rtc_peer.get('video').get('codec')
-	temp_vision_frame, temp_video_time = video_queue.get()
+	output_future, output_video_time = video_queue.get()
+	output_buffer, output_resolution = output_future.result()
 
-	if numpy.any(temp_vision_frame):
-		temp_resolution : Resolution = (temp_vision_frame.shape[1], temp_vision_frame.shape[0])
+	if output_buffer:
+		temp_resolution : Resolution = output_resolution
 		temp_bitrate : BitRate = 8000
 		video_encoder = create_video_encoder(video_codec, temp_resolution, temp_bitrate)
-		previous_video_time = temp_video_time
-		#todo: fix typing once issue below is sorted out
-		temp_deque = deque() #type:ignore[var-annotated]
-		execution_thread_count = state_manager.get_item('execution_thread_count')
+		previous_video_time = output_video_time
 		frame_index = 0
 
-		with ThreadPoolExecutor(max_workers = execution_thread_count) as executor:
-			while numpy.any(temp_vision_frame) or temp_deque:
+		while output_buffer:
+			encode_start = time.monotonic()
+			peer_bitrate : BitRate = rtc_peer.get('sender_bitrate').value
+			# todo: horrible method with too many arguments - it needs calculate_xxx_bitrate or whatever is adjusted here - like calculate_receiver_bitrate ?
+			video_encoder, temp_resolution, temp_bitrate, frame_index = adapt_video_encoder(video_codec, video_encoder, temp_resolution, temp_bitrate, output_resolution, peer_bitrate, frame_index)
+			output_video_buffer = encode_video_frame(video_codec, video_encoder, output_buffer, temp_resolution, frame_index)
 
-				if numpy.any(temp_vision_frame) and len(temp_deque) < execution_thread_count:
-					#todo: why does the deque contain a future and not just the data
-					temp_deque.append((executor.submit(process_video_frame, temp_vision_frame), temp_video_time))
-					temp_vision_frame, temp_video_time = video_queue.get()
+			if output_video_buffer:
+				rtc.send_video(rtc_peer, output_video_buffer, int(output_video_time * 90000))
 
-				else:
-					output_future, output_video_time = temp_deque.popleft()
-					encode_start = time.monotonic()
-					output_vision_buffer, output_resolution = output_future.result()
-					peer_bitrate : BitRate = rtc_peer.get('sender_bitrate').value
-					video_encoder, temp_resolution, temp_bitrate, frame_index = adapt_video_encoder(video_codec, video_encoder, temp_resolution, temp_bitrate, output_resolution, peer_bitrate, frame_index)
-					output_video_buffer = encode_video_frame(video_codec, video_encoder, output_vision_buffer, temp_resolution, frame_index)
+			encode_time = time.monotonic() - encode_start
+			frame_interval = output_video_time - previous_video_time
+			previous_video_time = output_video_time
 
-					if output_video_buffer:
-						rtc.send_video(rtc_peer, output_video_buffer, int(output_video_time * 90000))
-
-					encode_time = time.monotonic() - encode_start
-					frame_interval = output_video_time - previous_video_time
-					previous_video_time = output_video_time
-
-					rtc.adapt_receiver_bitrate(rtc_peer, calculate_receiver_bitrate(rtc_peer, encode_time, frame_interval))
-					frame_index += 1
+			rtc.adapt_receiver_bitrate(rtc_peer, calculate_receiver_bitrate(rtc_peer, encode_time, frame_interval))
+			frame_index += 1
+			output_future, output_video_time = video_queue.get()
+			output_buffer, output_resolution = output_future.result()
 
 		destroy_video_encoder(video_codec, video_encoder)
 		rtc.clear_bitrate(rtc_peer)
 
 
-def receive_video_frames(rtc_peer_video : RtcPeerVideo, video_queue : Queue[VideoPack]) -> None:
+def receive_video_frames(rtc_peer_video : RtcPeerVideo, video_queue : Queue[VideoPack], video_executor : ThreadPoolExecutor) -> None:
 	video_track = rtc_peer_video.get('receiver_track')
 	video_codec = rtc_peer_video.get('codec')
 	video_decoder = create_video_decoder(video_codec)
 
-	video_frame_handler = partial(handle_video_frame, video_codec, video_decoder, video_queue)
+	video_frame_handler = partial(handle_video_frame, video_codec, video_decoder, video_queue, video_executor)
 	receive_event = create_receive_event(video_track, video_frame_handler)
 	receive_event.wait()
-	empty_vision_frame = numpy.empty(0)
-	video_queue.put((empty_vision_frame, 0.0))
+
+	empty_future : VideoFuture = Future()
+	empty_future.set_result((bytes(), (0, 0)))
+	video_queue.put((empty_future, 0.0))
+	#todo: is this the correct place to destroy?
 	destroy_video_decoder(video_codec, video_decoder)
 
 
@@ -80,8 +73,10 @@ def process_video_frame(vision_frame : VisionFrame) -> tuple[bytes, Resolution]:
 	return output_vision_buffer, output_resolution
 
 
+#todo: why not video_encoder : VideoEncoder type?
 def adapt_video_encoder(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, resolution : Resolution, bitrate : BitRate, output_resolution : Resolution, peer_bitrate : BitRate, frame_index : int) -> tuple[VpxEncoder | AomEncoder, Resolution, BitRate, int]:
 	if output_resolution[0] - resolution[0] or output_resolution[1] - resolution[1]:
+		# todo: why destroy and recreate all the time, why not via an update method?
 		destroy_video_encoder(video_codec, video_encoder)
 		resolution = output_resolution
 		video_encoder = create_video_encoder(video_codec, resolution, bitrate)
@@ -91,6 +86,7 @@ def adapt_video_encoder(video_codec : VideoCodec, video_encoder : VpxEncoder | A
 		bitrate = peer_bitrate
 
 		if not update_video_encoder_bitrate(video_codec, video_encoder, bitrate):
+			# todo: why destroy and recreate all the time, why not via an update method?
 			destroy_video_encoder(video_codec, video_encoder)
 			video_encoder = create_video_encoder(video_codec, resolution, bitrate)
 			frame_index = 0
@@ -189,7 +185,8 @@ def update_video_encoder_bitrate(video_codec : VideoCodec, video_encoder : VpxEn
 	return False
 
 
-def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_queue : Queue[VideoPack], track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
+#todo: we can remove the dead args or pass video_buffer
+def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_queue : Queue[VideoPack], video_executor : ThreadPoolExecutor, track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
 	video_buffer = ctypes.string_at(data, size)
 	vision_frame = decode_video_frame(video_codec, video_decoder, video_buffer)
 
@@ -197,4 +194,5 @@ def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | Ao
 		if video_queue.full():
 			video_queue.get_nowait()
 
-		video_queue.put((vision_frame, time.monotonic()))
+		video_future = video_executor.submit(process_video_frame, vision_frame)
+		video_queue.put((video_future, time.monotonic()))

--- a/facefusion/apis/stream_video.py
+++ b/facefusion/apis/stream_video.py
@@ -29,9 +29,16 @@ def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[VideoPack]) ->
 
 		while output_buffer:
 			encode_start = time.monotonic()
-			peer_bitrate : BitRate = rtc_peer.get('sender_bitrate').value
-			# todo: horrible method with too many arguments - it needs calculate_xxx_bitrate or whatever is adjusted here - like calculate_receiver_bitrate ?
-			video_encoder, temp_resolution, temp_bitrate, frame_index = adapt_video_encoder(video_codec, video_encoder, temp_resolution, temp_bitrate, output_resolution, peer_bitrate, frame_index)
+			sender_bitrate = calculate_sender_bitrate(rtc_peer, temp_bitrate)
+
+			if output_resolution[0] - temp_resolution[0] or output_resolution[1] - temp_resolution[1]:
+				temp_resolution = output_resolution
+				update_video_encoder_resolution(video_codec, video_encoder, temp_resolution)
+
+			if sender_bitrate - temp_bitrate:
+				temp_bitrate = sender_bitrate
+				update_video_encoder_bitrate(video_codec, video_encoder, temp_bitrate)
+
 			output_video_buffer = encode_video_frame(video_codec, video_encoder, output_buffer, temp_resolution, frame_index)
 
 			if output_video_buffer:
@@ -41,8 +48,10 @@ def run_video_encode_loop(rtc_peer : RtcPeer, video_queue : Queue[VideoPack]) ->
 			frame_interval = output_video_time - previous_video_time
 			previous_video_time = output_video_time
 
-			rtc.adapt_receiver_bitrate(rtc_peer, calculate_receiver_bitrate(rtc_peer, encode_time, frame_interval))
+			receiver_bitrate = calculate_receiver_bitrate(rtc_peer, encode_time, frame_interval)
+			rtc.adapt_receiver_bitrate(rtc_peer, receiver_bitrate)
 			frame_index += 1
+
 			output_future, output_video_time = video_queue.get()
 			output_buffer, output_resolution = output_future.result()
 
@@ -62,7 +71,6 @@ def receive_video_frames(rtc_peer_video : RtcPeerVideo, video_queue : Queue[Vide
 	empty_future : VideoFuture = Future()
 	empty_future.set_result((bytes(), (0, 0)))
 	video_queue.put((empty_future, 0.0))
-	#todo: is this the correct place to destroy?
 	destroy_video_decoder(video_codec, video_decoder)
 
 
@@ -71,27 +79,6 @@ def process_video_frame(vision_frame : VisionFrame) -> tuple[bytes, Resolution]:
 	output_resolution : Resolution = (output_vision_frame.shape[1], output_vision_frame.shape[0])
 	output_vision_buffer = cv2.cvtColor(output_vision_frame, cv2.COLOR_BGR2YUV_I420).tobytes()
 	return output_vision_buffer, output_resolution
-
-
-#todo: why not video_encoder : VideoEncoder type?
-def adapt_video_encoder(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, resolution : Resolution, bitrate : BitRate, output_resolution : Resolution, peer_bitrate : BitRate, frame_index : int) -> tuple[VpxEncoder | AomEncoder, Resolution, BitRate, int]:
-	if output_resolution[0] - resolution[0] or output_resolution[1] - resolution[1]:
-		# todo: why destroy and recreate all the time, why not via an update method?
-		destroy_video_encoder(video_codec, video_encoder)
-		resolution = output_resolution
-		video_encoder = create_video_encoder(video_codec, resolution, bitrate)
-		frame_index = 0
-
-	if peer_bitrate and peer_bitrate - bitrate:
-		bitrate = peer_bitrate
-
-		if not update_video_encoder_bitrate(video_codec, video_encoder, bitrate):
-			# todo: why destroy and recreate all the time, why not via an update method?
-			destroy_video_encoder(video_codec, video_encoder)
-			video_encoder = create_video_encoder(video_codec, resolution, bitrate)
-			frame_index = 0
-
-	return video_encoder, resolution, bitrate, frame_index
 
 
 def calculate_receiver_bitrate(rtc_peer : RtcPeer, encode_time : float, frame_interval : float) -> BitRate:
@@ -103,6 +90,17 @@ def calculate_receiver_bitrate(rtc_peer : RtcPeer, encode_time : float, frame_in
 		scale = frame_interval / encode_time
 		bitrate = int(bitrate * scale)
 		bitrate = max(min_bitrate, min(max_bitrate, bitrate))
+
+	return bitrate
+
+
+def calculate_sender_bitrate(rtc_peer : RtcPeer, bitrate : BitRate) -> BitRate:
+	min_bitrate : BitRate = 500
+	max_bitrate : BitRate = 8000
+	__bitrate__ : BitRate = rtc_peer.get('sender_bitrate').value
+
+	if __bitrate__ > 0:
+		bitrate = max(min_bitrate, min(max_bitrate, __bitrate__))
 
 	return bitrate
 
@@ -175,6 +173,16 @@ def destroy_video_encoder(video_codec : VideoCodec, video_encoder : VpxEncoder |
 		vpx_encoder.destroy(video_encoder)
 
 
+def update_video_encoder_resolution(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, frame_resolution : Resolution) -> bool:
+	if video_codec == 'av1':
+		return aom_encoder.update_resolution(video_encoder, frame_resolution)
+
+	if video_codec in [ 'vp8', 'vp9' ]:
+		return vpx_encoder.update_resolution(video_encoder, frame_resolution)
+
+	return False
+
+
 def update_video_encoder_bitrate(video_codec : VideoCodec, video_encoder : VpxEncoder | AomEncoder, bitrate : BitRate) -> bool:
 	if video_codec == 'av1':
 		return aom_encoder.update_bitrate(video_encoder, bitrate)
@@ -185,7 +193,6 @@ def update_video_encoder_bitrate(video_codec : VideoCodec, video_encoder : VpxEn
 	return False
 
 
-#todo: we can remove the dead args or pass video_buffer
 def handle_video_frame(video_codec : VideoCodec, video_decoder : VpxDecoder | AomDecoder, video_queue : Queue[VideoPack], video_executor : ThreadPoolExecutor, track : int, data : ctypes.c_void_p, size : int, info : ctypes.c_void_p, pointer : ctypes.c_void_p) -> None:
 	video_buffer = ctypes.string_at(data, size)
 	vision_frame = decode_video_frame(video_codec, video_decoder, video_buffer)

--- a/facefusion/codecs/aom_encoder.py
+++ b/facefusion/codecs/aom_encoder.py
@@ -66,6 +66,17 @@ def collect(aom_encoder : AomEncoder) -> bytes:
 	return bytes().join(output_parts)
 
 
+def update_resolution(aom_encoder : AomEncoder, frame_resolution : Resolution) -> bool:
+	aom_library = aom_module.create_static_library()
+
+	if aom_library:
+		struct.pack_into('I', aom_encoder, 128 + 12, frame_resolution[0])
+		struct.pack_into('I', aom_encoder, 128 + 16, frame_resolution[1])
+		return aom_library.aom_codec_enc_config_set(aom_encoder, ctypes.cast(ctypes.addressof(aom_encoder) + 128, ctypes.c_void_p)) == 0
+
+	return False
+
+
 def update_bitrate(aom_encoder : AomEncoder, bitrate : BitRate) -> bool:
 	aom_library = aom_module.create_static_library()
 

--- a/facefusion/codecs/vpx_encoder.py
+++ b/facefusion/codecs/vpx_encoder.py
@@ -76,6 +76,17 @@ def collect(vpx_encoder : VpxEncoder) -> bytes:
 	return bytes().join(output_parts)
 
 
+def update_resolution(vpx_encoder : VpxEncoder, frame_resolution : Resolution) -> bool:
+	vpx_library = vpx_module.create_static_library()
+
+	if vpx_library:
+		struct.pack_into('I', vpx_encoder, 64 + 12, frame_resolution[0])
+		struct.pack_into('I', vpx_encoder, 64 + 16, frame_resolution[1])
+		return vpx_library.vpx_codec_enc_config_set(vpx_encoder, ctypes.cast(ctypes.addressof(vpx_encoder) + 64, ctypes.c_void_p)) == 0
+
+	return False
+
+
 def update_bitrate(vpx_encoder : VpxEncoder, bitrate : BitRate) -> bool:
 	vpx_library = vpx_module.create_static_library()
 

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -1,5 +1,6 @@
 import ctypes
 from collections import namedtuple
+from concurrent.futures import Future
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Literal, NotRequired, Optional, Tuple, TypeAlias, TypedDict, Union
 
@@ -320,7 +321,8 @@ RtcPeer = TypedDict('RtcPeer',
 })
 RtcStore : TypeAlias = Dict[SessionId, List[RtcPeer]]
 
-VideoPack : TypeAlias = tuple[VisionFrame, float]
+VideoFuture : TypeAlias = Future[tuple[bytes, Resolution]]
+VideoPack : TypeAlias = tuple[VideoFuture, float]
 AudioPack : TypeAlias = tuple[AudioFrame, float]
 
 SdpAudioMedia = TypedDict('SdpAudioMedia',

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -322,6 +322,7 @@ RtcPeer = TypedDict('RtcPeer',
 RtcStore : TypeAlias = Dict[SessionId, List[RtcPeer]]
 
 VideoFuture : TypeAlias = Future[tuple[bytes, Resolution]]
+#todo: for me this is no longer a VideoPack cause it is too different from AudioPack - eventual kill the XXXPack convention
 VideoPack : TypeAlias = tuple[VideoFuture, float]
 AudioPack : TypeAlias = tuple[AudioFrame, float]
 

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -1,6 +1,5 @@
 import ctypes
 from collections import namedtuple
-from concurrent.futures import Future
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Literal, NotRequired, Optional, Tuple, TypeAlias, TypedDict, Union
 
@@ -320,11 +319,6 @@ RtcPeer = TypedDict('RtcPeer',
 	'receiver_bitrate': ctypes.c_uint
 })
 RtcStore : TypeAlias = Dict[SessionId, List[RtcPeer]]
-
-VideoFuture : TypeAlias = Future[tuple[bytes, Resolution]]
-#todo: for me this is no longer a VideoPack cause it is too different from AudioPack - eventual kill the XXXPack convention
-VideoPack : TypeAlias = tuple[VideoFuture, float]
-AudioPack : TypeAlias = tuple[AudioFrame, float]
 
 SdpAudioMedia = TypedDict('SdpAudioMedia',
 {

--- a/tests/test_api_stream_audio.py
+++ b/tests/test_api_stream_audio.py
@@ -101,10 +101,9 @@ def test_receive_audio_frames(audio_codec : AudioCodec) -> None:
 			datachannel_mock.rtcSetClosedCallback.call_args[0][1](0, None)
 			audio_receiver_thread.join(timeout = 5.0)
 
-	# todo: buffer frame or output_buffer or output_audio_buffer? follow codebase naming
-	_, buffer_frame = audio_queue.get_nowait()
+	_, temp_audio_frame = audio_queue.get_nowait()
 
-	assert create_hash(buffer_frame.tobytes()) == create_hash(audio_frame.tobytes())
+	assert create_hash(temp_audio_frame.tobytes()) == create_hash(audio_frame.tobytes())
 
 
 def test_handle_audio_frame() -> None:
@@ -116,7 +115,6 @@ def test_handle_audio_frame() -> None:
 	with patch('facefusion.apis.stream_audio.decode_audio_frame', return_value = audio_frame.tobytes()):
 		handle_audio_frame('opus', audio_decoder_mock, audio_queue, 0, ctypes.c_void_p(), 1, ctypes.c_void_p(), ctypes.c_void_p())
 
-	# todo: buffer frame or output_buffer or output_audio_buffer? follow codebase naming
-	_, buffer_frame = audio_queue.get_nowait()
+	_, temp_audio_frame = audio_queue.get_nowait()
 
-	assert create_hash(buffer_frame.tobytes()) == create_hash(audio_frame.tobytes())
+	assert create_hash(temp_audio_frame.tobytes()) == create_hash(audio_frame.tobytes())

--- a/tests/test_api_stream_audio.py
+++ b/tests/test_api_stream_audio.py
@@ -2,6 +2,7 @@ import ctypes
 import threading
 from functools import partial
 from queue import Queue
+from typing import Tuple
 from unittest.mock import MagicMock, patch
 
 import numpy
@@ -13,7 +14,7 @@ from facefusion.download import conditional_download
 from facefusion.ffmpeg import read_audio_buffer
 from facefusion.hash_helper import create_hash
 from facefusion.libraries import datachannel as datachannel_module, opus as opus_module
-from facefusion.types import AudioCodec, AudioPack, FrameHandler, RtcPeer, RtcPeerAudio
+from facefusion.types import AudioCodec, AudioFrame, FrameHandler, RtcPeer, RtcPeerAudio
 from .assert_helper import get_test_example_file, get_test_examples_directory
 
 
@@ -57,9 +58,9 @@ def test_run_audio_encode_loop() -> None:
 		'receiver_bitrate': ctypes.c_uint(0)
 	}
 
-	audio_queue : Queue[AudioPack] = Queue(maxsize = 300)
+	audio_queue : Queue[Tuple[float, AudioFrame]] = Queue(maxsize = 300)
 
-	audio_queue.put((audio_frame, 0.100))
+	audio_queue.put((0.100, audio_frame))
 
 	encoder_mock = MagicMock()
 	encoder_mock.encode.return_value = bytes([ 1 ] * 32)
@@ -68,7 +69,7 @@ def test_run_audio_encode_loop() -> None:
 		with patch('facefusion.apis.stream_audio.rtc.send_audio') as send_audio_mock:
 			audio_loop_thread = threading.Thread(target = run_audio_encode_loop, args = (rtc_peer, audio_queue), daemon = True)
 			audio_loop_thread.start()
-			audio_queue.put((numpy.empty(0), 0.0))
+			audio_queue.put((0.0, numpy.empty(0)))
 			audio_loop_thread.join(timeout = 5.0)
 
 	assert encoder_mock.encode.called is True
@@ -79,7 +80,7 @@ def test_run_audio_encode_loop() -> None:
 def test_receive_audio_frames(audio_codec : AudioCodec) -> None:
 	audio_buffer = read_audio_buffer(get_test_example_file('source.mp3'), 48000, 16, 2)
 	audio_frame = numpy.frombuffer(audio_buffer, dtype = numpy.int16).astype(numpy.float32) / 32768.0
-	audio_queue : Queue[AudioPack] = Queue(maxsize = 300)
+	audio_queue : Queue[Tuple[float, AudioFrame]] = Queue(maxsize = 300)
 
 	datachannel_mock = MagicMock()
 	ready_event = threading.Event()
@@ -100,7 +101,8 @@ def test_receive_audio_frames(audio_codec : AudioCodec) -> None:
 			datachannel_mock.rtcSetClosedCallback.call_args[0][1](0, None)
 			audio_receiver_thread.join(timeout = 5.0)
 
-	buffer_frame, _ = audio_queue.get_nowait()
+	# todo: buffer frame or output_buffer or output_audio_buffer? follow codebase naming
+	_, buffer_frame = audio_queue.get_nowait()
 
 	assert create_hash(buffer_frame.tobytes()) == create_hash(audio_frame.tobytes())
 
@@ -109,11 +111,12 @@ def test_handle_audio_frame() -> None:
 	audio_buffer = read_audio_buffer(get_test_example_file('source.mp3'), 48000, 16, 2)
 	audio_frame = numpy.frombuffer(audio_buffer, dtype = numpy.int16).astype(numpy.float32) / 32768.0
 	audio_decoder_mock = MagicMock()
-	audio_queue : Queue[AudioPack] = Queue(maxsize = 300)
+	audio_queue : Queue[Tuple[float, AudioFrame]] = Queue(maxsize = 300)
 
 	with patch('facefusion.apis.stream_audio.decode_audio_frame', return_value = audio_frame.tobytes()):
 		handle_audio_frame('opus', audio_decoder_mock, audio_queue, 0, ctypes.c_void_p(), 1, ctypes.c_void_p(), ctypes.c_void_p())
 
-	buffer_frame, _ = audio_queue.get_nowait()
+	# todo: buffer frame or output_buffer or output_audio_buffer? follow codebase naming
+	_, buffer_frame = audio_queue.get_nowait()
 
 	assert create_hash(buffer_frame.tobytes()) == create_hash(audio_frame.tobytes())

--- a/tests/test_api_stream_manager.py
+++ b/tests/test_api_stream_manager.py
@@ -17,6 +17,7 @@ from .assert_helper import get_test_example_file, get_test_examples_directory
 @pytest.fixture(scope = 'module', autouse = True)
 def before_all() -> None:
 	state_manager.init_item('download_providers', [ 'github', 'huggingface' ])
+	state_manager.init_item('execution_thread_count', 8)
 	state_manager.init_item('processors', [])
 
 	datachannel_module.pre_check()

--- a/tests/test_api_stream_video.py
+++ b/tests/test_api_stream_video.py
@@ -1,6 +1,7 @@
 import ctypes
 import struct
 import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from queue import Queue
 from unittest.mock import MagicMock, patch
@@ -10,13 +11,13 @@ import numpy
 import pytest
 
 from facefusion import rtc, rtc_store, state_manager
-from facefusion.apis.stream_video import create_video_decoder, create_video_encoder, decode_video_frame, destroy_video_decoder, destroy_video_encoder, encode_video_frame, handle_video_frame, receive_video_frames, run_video_encode_loop, update_video_encoder_bitrate
+from facefusion.apis.stream_video import create_video_decoder, create_video_encoder, decode_video_frame, destroy_video_decoder, destroy_video_encoder, encode_video_frame, handle_video_frame, process_video_frame, receive_video_frames, run_video_encode_loop, update_video_encoder_bitrate
 from facefusion.codecs import aom_encoder, vpx_encoder
 from facefusion.common_helper import is_linux, is_macos, is_windows
 from facefusion.download import conditional_download
 from facefusion.hash_helper import create_hash
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, vpx as vpx_module
-from facefusion.types import FrameHandler, RtcPeer, RtcPeerVideo, VideoCodec, VideoPack
+from facefusion.types import FrameHandler, RtcPeer, RtcPeerVideo, VideoCodec, VideoFuture, VideoPack
 from facefusion.vision import read_video_frame
 from .assert_helper import get_test_example_file, get_test_examples_directory
 
@@ -67,14 +68,16 @@ def test_run_video_encode_loop(video_codec : VideoCodec, payload_type : int) -> 
 
 	video_queue : Queue[VideoPack] = Queue(maxsize = 30)
 
-	video_queue.put((video_frame, 0.1))
+	with ThreadPoolExecutor(max_workers = 1) as executor:
+		video_queue.put((executor.submit(process_video_frame, video_frame), 0.1))
 
-	with patch('facefusion.apis.stream_video.rtc.send_video') as send_video_mock:
-		encode_loop_thread = threading.Thread(target = run_video_encode_loop, args = (rtc_peer, video_queue), daemon = True)
-		encode_loop_thread.start()
-		empty_vision_frame = numpy.empty(0)
-		video_queue.put((empty_vision_frame, 0.0))
-		encode_loop_thread.join(timeout = 5.0)
+		with patch('facefusion.apis.stream_video.rtc.send_video') as send_video_mock:
+			encode_loop_thread = threading.Thread(target = run_video_encode_loop, args = (rtc_peer, video_queue), daemon = True)
+			encode_loop_thread.start()
+			empty_future : VideoFuture = Future()
+			empty_future.set_result((bytes(), (0, 0)))
+			video_queue.put((empty_future, 0.0))
+			encode_loop_thread.join(timeout = 5.0)
 
 	assert send_video_mock.called
 
@@ -101,28 +104,31 @@ def test_receive_video_frames(video_codec : VideoCodec) -> None:
 	ready_event = threading.Event()
 	datachannel_mock.rtcSetClosedCallback.side_effect = partial(set_ready_event, ready_event)
 
-	with patch('facefusion.libraries.datachannel.create_static_library', return_value = datachannel_mock):
-		with patch('facefusion.apis.stream_video.decode_video_frame', return_value = video_frame):
-			rtc_peer_video : RtcPeerVideo =\
-			{
-				'sender_track': 0,
-				'receiver_track': 0,
-				'codec': video_codec
-			}
-			video_receiver_thread = threading.Thread(target = receive_video_frames, args = (rtc_peer_video, video_queue), daemon = True)
-			video_receiver_thread.start()
-			ready_event.wait(timeout = 5.0)
-			datachannel_mock.rtcSetFrameCallback.call_args[0][1](0, bytes([ 0 ]), 1, None, None)
-			datachannel_mock.rtcSetClosedCallback.call_args[0][1](0, None)
-			video_receiver_thread.join(timeout = 5.0)
+	with ThreadPoolExecutor(max_workers = 1) as executor:
+		with patch('facefusion.libraries.datachannel.create_static_library', return_value = datachannel_mock):
+			with patch('facefusion.apis.stream_video.decode_video_frame', return_value = video_frame):
+				with patch('facefusion.apis.stream_video.process_video_frame', return_value = (video_frame.tobytes(), (426, 226))):
+					rtc_peer_video : RtcPeerVideo =\
+					{
+						'sender_track': 0,
+						'receiver_track': 0,
+						'codec': video_codec
+					}
+					video_receiver_thread = threading.Thread(target = receive_video_frames, args = (rtc_peer_video, video_queue, executor), daemon = True)
+					video_receiver_thread.start()
+					ready_event.wait(timeout = 5.0)
+					datachannel_mock.rtcSetFrameCallback.call_args[0][1](0, bytes([ 0 ]), 1, None, None)
+					datachannel_mock.rtcSetClosedCallback.call_args[0][1](0, None)
+					video_receiver_thread.join(timeout = 5.0)
+					output_future, _ = video_queue.get_nowait()
 
-	vision_frame, _ = video_queue.get_nowait()
+	output_vision_buffer, _ = output_future.result()
 
 	if is_linux() or is_windows():
-		assert create_hash(vision_frame.tobytes()) == 'a17439db'
+		assert create_hash(output_vision_buffer) == 'a17439db'
 
 	if is_macos():
-		assert create_hash(vision_frame.tobytes()) == '38d00e2a'
+		assert create_hash(output_vision_buffer) == '38d00e2a'
 
 
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8', 'vp9' ])
@@ -230,13 +236,16 @@ def test_handle_video_frame(video_codec : VideoCodec) -> None:
 	video_decoder = create_video_decoder(video_codec)
 	video_queue : Queue[VideoPack] = Queue(maxsize = 30)
 
-	with patch('facefusion.apis.stream_video.decode_video_frame', return_value = video_frame):
-		handle_video_frame(video_codec, video_decoder, video_queue, 0, ctypes.c_void_p(), 1, ctypes.c_void_p(), ctypes.c_void_p())
+	with ThreadPoolExecutor(max_workers = 1) as executor:
+		with patch('facefusion.apis.stream_video.decode_video_frame', return_value = video_frame):
+			with patch('facefusion.apis.stream_video.process_video_frame', return_value = (video_frame.tobytes(), (426, 226))):
+				handle_video_frame(video_codec, video_decoder, video_queue, executor, 0, ctypes.c_void_p(), 1, ctypes.c_void_p(), ctypes.c_void_p())
+				output_future, _ = video_queue.get_nowait()
 
-	vision_frame, _ = video_queue.get_nowait()
+	output_vision_buffer, _ = output_future.result()
 
 	if is_linux() or is_windows():
-		assert create_hash(vision_frame.tobytes()) == 'a17439db'
+		assert create_hash(output_vision_buffer) == 'a17439db'
 
 	if is_macos():
-		assert create_hash(vision_frame.tobytes()) == '38d00e2a'
+		assert create_hash(output_vision_buffer) == '38d00e2a'

--- a/tests/test_api_stream_video.py
+++ b/tests/test_api_stream_video.py
@@ -11,7 +11,7 @@ import numpy
 import pytest
 
 from facefusion import rtc, rtc_store, state_manager
-from facefusion.apis.stream_video import create_video_decoder, create_video_encoder, decode_video_frame, destroy_video_decoder, destroy_video_encoder, encode_video_frame, handle_video_frame, process_video_frame, receive_video_frames, run_video_encode_loop, update_video_encoder_bitrate
+from facefusion.apis.stream_video import create_video_decoder, create_video_encoder, decode_video_frame, destroy_video_decoder, destroy_video_encoder, encode_video_frame, handle_video_frame, process_video_frame, receive_video_frames, run_video_encode_loop, update_video_encoder_bitrate, update_video_encoder_resolution
 from facefusion.codecs import aom_encoder, vpx_encoder
 from facefusion.common_helper import is_linux, is_macos, is_windows
 from facefusion.download import conditional_download
@@ -201,6 +201,33 @@ def test_create_and_destroy_video_encoder(video_codec : VideoCodec) -> None:
 		assert aom_encoder.encode(video_encoder, input_buffer, (426, 226), 1) == bytes()
 	if video_codec in [ 'vp8', 'vp9' ]:
 		assert vpx_encoder.encode(video_encoder, input_buffer, (426, 226), 1) == bytes()
+
+
+@pytest.mark.parametrize('video_codec', [ 'av1', 'vp8', 'vp9' ])
+def test_update_video_encoder_resolution(video_codec : VideoCodec) -> None:
+	video_encoder = create_video_encoder(video_codec, (426, 226), 4000)
+
+	if video_codec == 'av1':
+		assert struct.unpack_from('I', video_encoder, 128 + 12)[0] == 426
+
+	if video_codec == 'vp8':
+		assert struct.unpack_from('I', video_encoder, 64 + 12)[0] == 426
+
+	if video_codec == 'vp9':
+		assert struct.unpack_from('I', video_encoder, 64 + 12)[0] == 426
+
+	assert update_video_encoder_resolution(video_codec, video_encoder, (320, 180))
+
+	if video_codec == 'av1':
+		assert struct.unpack_from('I', video_encoder, 128 + 12)[0] == 320
+
+	if video_codec == 'vp8':
+		assert struct.unpack_from('I', video_encoder, 64 + 12)[0] == 320
+
+	if video_codec == 'vp9':
+		assert struct.unpack_from('I', video_encoder, 64 + 12)[0] == 320
+
+	destroy_video_encoder(video_codec, video_encoder)
 
 
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8', 'vp9' ])

--- a/tests/test_api_stream_video.py
+++ b/tests/test_api_stream_video.py
@@ -121,16 +121,15 @@ def test_receive_video_frames(video_codec : VideoCodec) -> None:
 					datachannel_mock.rtcSetFrameCallback.call_args[0][1](0, bytes([ 0 ]), 1, None, None)
 					datachannel_mock.rtcSetClosedCallback.call_args[0][1](0, None)
 					video_receiver_thread.join(timeout = 5.0)
-					# todo: video_future? follow codebase naming
-					_, output_future = video_queue.get_nowait()
+					_, video_future = video_queue.get_nowait()
 
-	output_vision_buffer, _ = output_future.result()
+	video_buffer, _ = video_future.result()
 
 	if is_linux() or is_windows():
-		assert create_hash(output_vision_buffer) == 'a17439db'
+		assert create_hash(video_buffer) == 'a17439db'
 
 	if is_macos():
-		assert create_hash(output_vision_buffer) == '38d00e2a'
+		assert create_hash(video_buffer) == '38d00e2a'
 
 
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8', 'vp9' ])
@@ -269,13 +268,12 @@ def test_handle_video_frame(video_codec : VideoCodec) -> None:
 		with patch('facefusion.apis.stream_video.decode_video_frame', return_value = video_frame):
 			with patch('facefusion.apis.stream_video.process_video_frame', return_value = (video_frame.tobytes(), (426, 226))):
 				handle_video_frame(video_codec, video_decoder, video_queue, executor, 0, ctypes.c_void_p(), 1, ctypes.c_void_p(), ctypes.c_void_p())
-				# todo: video_future? follow codebase naming
-				_, output_future = video_queue.get_nowait()
+				_, video_future = video_queue.get_nowait()
 
-	output_vision_buffer, _ = output_future.result()
+	video_buffer, _ = video_future.result()
 
 	if is_linux() or is_windows():
-		assert create_hash(output_vision_buffer) == 'a17439db'
+		assert create_hash(video_buffer) == 'a17439db'
 
 	if is_macos():
-		assert create_hash(output_vision_buffer) == '38d00e2a'
+		assert create_hash(video_buffer) == '38d00e2a'

--- a/tests/test_api_stream_video.py
+++ b/tests/test_api_stream_video.py
@@ -4,6 +4,7 @@ import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from queue import Queue
+from typing import Tuple
 from unittest.mock import MagicMock, patch
 
 import cv2
@@ -17,7 +18,7 @@ from facefusion.common_helper import is_linux, is_macos, is_windows
 from facefusion.download import conditional_download
 from facefusion.hash_helper import create_hash
 from facefusion.libraries import aom as aom_module, datachannel as datachannel_module, vpx as vpx_module
-from facefusion.types import FrameHandler, RtcPeer, RtcPeerVideo, VideoCodec, VideoFuture, VideoPack
+from facefusion.types import FrameHandler, Resolution, RtcPeer, RtcPeerVideo, VideoCodec
 from facefusion.vision import read_video_frame
 from .assert_helper import get_test_example_file, get_test_examples_directory
 
@@ -66,17 +67,17 @@ def test_run_video_encode_loop(video_codec : VideoCodec, payload_type : int) -> 
 		'receiver_bitrate': ctypes.c_uint(8000)
 	}
 
-	video_queue : Queue[VideoPack] = Queue(maxsize = 30)
+	video_queue : Queue[Tuple[float, Future[Tuple[bytes, Resolution]]]] = Queue(maxsize = 30)
 
 	with ThreadPoolExecutor(max_workers = 1) as executor:
-		video_queue.put((executor.submit(process_video_frame, video_frame), 0.1))
+		video_queue.put((0.1, executor.submit(process_video_frame, video_frame)))
 
 		with patch('facefusion.apis.stream_video.rtc.send_video') as send_video_mock:
 			encode_loop_thread = threading.Thread(target = run_video_encode_loop, args = (rtc_peer, video_queue), daemon = True)
 			encode_loop_thread.start()
-			empty_future : VideoFuture = Future()
+			empty_future : Future[Tuple[bytes, Resolution]] = Future()
 			empty_future.set_result((bytes(), (0, 0)))
-			video_queue.put((empty_future, 0.0))
+			video_queue.put((0.0, empty_future))
 			encode_loop_thread.join(timeout = 5.0)
 
 	assert send_video_mock.called
@@ -98,7 +99,7 @@ def test_run_video_encode_loop(video_codec : VideoCodec, payload_type : int) -> 
 @pytest.mark.parametrize('video_codec', [ 'av1', 'vp8', 'vp9' ])
 def test_receive_video_frames(video_codec : VideoCodec) -> None:
 	video_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
-	video_queue : Queue[VideoPack] = Queue(maxsize = 30)
+	video_queue : Queue[Tuple[float, Future[Tuple[bytes, Resolution]]]] = Queue(maxsize = 30)
 
 	datachannel_mock = MagicMock()
 	ready_event = threading.Event()
@@ -120,7 +121,8 @@ def test_receive_video_frames(video_codec : VideoCodec) -> None:
 					datachannel_mock.rtcSetFrameCallback.call_args[0][1](0, bytes([ 0 ]), 1, None, None)
 					datachannel_mock.rtcSetClosedCallback.call_args[0][1](0, None)
 					video_receiver_thread.join(timeout = 5.0)
-					output_future, _ = video_queue.get_nowait()
+					# todo: video_future? follow codebase naming
+					_, output_future = video_queue.get_nowait()
 
 	output_vision_buffer, _ = output_future.result()
 
@@ -261,13 +263,14 @@ def test_update_video_encoder_bitrate(video_codec : VideoCodec) -> None:
 def test_handle_video_frame(video_codec : VideoCodec) -> None:
 	video_frame = read_video_frame(get_test_example_file('target-240p.mp4'))
 	video_decoder = create_video_decoder(video_codec)
-	video_queue : Queue[VideoPack] = Queue(maxsize = 30)
+	video_queue : Queue[Tuple[float, Future[Tuple[bytes, Resolution]]]] = Queue(maxsize = 30)
 
 	with ThreadPoolExecutor(max_workers = 1) as executor:
 		with patch('facefusion.apis.stream_video.decode_video_frame', return_value = video_frame):
 			with patch('facefusion.apis.stream_video.process_video_frame', return_value = (video_frame.tobytes(), (426, 226))):
 				handle_video_frame(video_codec, video_decoder, video_queue, executor, 0, ctypes.c_void_p(), 1, ctypes.c_void_p(), ctypes.c_void_p())
-				output_future, _ = video_queue.get_nowait()
+				# todo: video_future? follow codebase naming
+				_, output_future = video_queue.get_nowait()
 
 	output_vision_buffer, _ = output_future.result()
 


### PR DESCRIPTION
- One queue on the receiver side
- Queue is timestamp and future based
- Update methods for encoders
- Guard for `tobytes` on None in the face store