### PR TITLE
Tag HEVC output as hvc1 and move moov atom to the front

### DIFF
--- a/facefusion/ffmpeg.py
+++ b/facefusion/ffmpeg.py
@@ -186,6 +186,7 @@ def restore_audio(target_path : str, output_path : str, trim_frame_start : int, 
 		ffmpeg_builder.select_media_stream('0:v:0'),
 		ffmpeg_builder.select_media_stream('1:a:0'),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
+		ffmpeg_builder.set_faststart(),
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -208,6 +209,7 @@ def replace_audio(target_path : str, audio_path : str, output_path : str) -> boo
 		ffmpeg_builder.set_audio_quality(output_audio_encoder, output_audio_quality),
 		ffmpeg_builder.set_audio_volume(output_audio_volume),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
+		ffmpeg_builder.set_faststart(),
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -228,6 +230,7 @@ def merge_video(target_path : str, temp_video_fps : Fps, output_video_resolution
 		ffmpeg_builder.set_input(temp_frames_pattern),
 		ffmpeg_builder.set_media_resolution(pack_resolution(output_video_resolution)),
 		ffmpeg_builder.set_video_encoder(output_video_encoder),
+		ffmpeg_builder.set_video_tag(output_video_encoder),
 		ffmpeg_builder.set_video_quality(output_video_encoder, output_video_quality),
 		ffmpeg_builder.set_video_preset(output_video_encoder, output_video_preset),
 		ffmpeg_builder.concat(
@@ -259,6 +262,7 @@ def concat_video(output_path : str, temp_output_paths : List[str]) -> bool:
 		ffmpeg_builder.set_input(concat_video_file.name),
 		ffmpeg_builder.copy_video_encoder(),
 		ffmpeg_builder.copy_audio_encoder(),
+		ffmpeg_builder.set_faststart(),
 		ffmpeg_builder.force_output(output_path)
 	)
 	process = run_ffmpeg(commands)

--- a/facefusion/ffmpeg.py
+++ b/facefusion/ffmpeg.py
@@ -172,6 +172,7 @@ def restore_audio(target_path : str, output_path : str, trim_frame_start : int, 
 	target_video_fps = detect_video_fps(target_path)
 	temp_video_path = get_temp_file_path(target_path)
 	temp_video_format = cast(VideoFormat, get_file_format(temp_video_path))
+	output_video_format = cast(VideoFormat, get_file_format(output_path))
 	temp_video_duration = detect_video_duration(temp_video_path)
 
 	output_audio_encoder = fix_audio_encoder(temp_video_format, output_audio_encoder)
@@ -186,7 +187,7 @@ def restore_audio(target_path : str, output_path : str, trim_frame_start : int, 
 		ffmpeg_builder.select_media_stream('0:v:0'),
 		ffmpeg_builder.select_media_stream('1:a:0'),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
-		ffmpeg_builder.set_faststart(),
+		ffmpeg_builder.set_faststart() if output_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -198,6 +199,7 @@ def replace_audio(target_path : str, audio_path : str, output_path : str) -> boo
 	output_audio_volume = state_manager.get_item('output_audio_volume')
 	temp_video_path = get_temp_file_path(target_path)
 	temp_video_format = cast(VideoFormat, get_file_format(temp_video_path))
+	output_video_format = cast(VideoFormat, get_file_format(output_path))
 	temp_video_duration = detect_video_duration(temp_video_path)
 
 	output_audio_encoder = fix_audio_encoder(temp_video_format, output_audio_encoder)
@@ -209,7 +211,7 @@ def replace_audio(target_path : str, audio_path : str, output_path : str) -> boo
 		ffmpeg_builder.set_audio_quality(output_audio_encoder, output_audio_quality),
 		ffmpeg_builder.set_audio_volume(output_audio_volume),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
-		ffmpeg_builder.set_faststart(),
+		ffmpeg_builder.set_faststart() if output_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -230,7 +232,7 @@ def merge_video(target_path : str, temp_video_fps : Fps, output_video_resolution
 		ffmpeg_builder.set_input(temp_frames_pattern),
 		ffmpeg_builder.set_media_resolution(pack_resolution(output_video_resolution)),
 		ffmpeg_builder.set_video_encoder(output_video_encoder),
-		ffmpeg_builder.set_video_tag(output_video_encoder),
+		ffmpeg_builder.set_video_tag(output_video_encoder) if temp_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
 		ffmpeg_builder.set_video_quality(output_video_encoder, output_video_quality),
 		ffmpeg_builder.set_video_preset(output_video_encoder, output_video_preset),
 		ffmpeg_builder.concat(
@@ -257,12 +259,13 @@ def concat_video(output_path : str, temp_output_paths : List[str]) -> bool:
 		concat_video_file.close()
 
 	output_path = os.path.abspath(output_path)
+	output_video_format = cast(VideoFormat, get_file_format(output_path))
 	commands = ffmpeg_builder.chain(
 		ffmpeg_builder.unsafe_concat(),
 		ffmpeg_builder.set_input(concat_video_file.name),
 		ffmpeg_builder.copy_video_encoder(),
 		ffmpeg_builder.copy_audio_encoder(),
-		ffmpeg_builder.set_faststart(),
+		ffmpeg_builder.set_faststart() if output_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
 		ffmpeg_builder.force_output(output_path)
 	)
 	process = run_ffmpeg(commands)

--- a/facefusion/ffmpeg.py
+++ b/facefusion/ffmpeg.py
@@ -187,7 +187,7 @@ def restore_audio(target_path : str, output_path : str, trim_frame_start : int, 
 		ffmpeg_builder.select_media_stream('0:v:0'),
 		ffmpeg_builder.select_media_stream('1:a:0'),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
-		ffmpeg_builder.set_faststart() if output_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
+		ffmpeg_builder.conditional_set_faststart(output_video_format),
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -211,7 +211,7 @@ def replace_audio(target_path : str, audio_path : str, output_path : str) -> boo
 		ffmpeg_builder.set_audio_quality(output_audio_encoder, output_audio_quality),
 		ffmpeg_builder.set_audio_volume(output_audio_volume),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
-		ffmpeg_builder.set_faststart() if output_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
+		ffmpeg_builder.conditional_set_faststart(output_video_format),
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -232,7 +232,7 @@ def merge_video(target_path : str, temp_video_fps : Fps, output_video_resolution
 		ffmpeg_builder.set_input(temp_frames_pattern),
 		ffmpeg_builder.set_media_resolution(pack_resolution(output_video_resolution)),
 		ffmpeg_builder.set_video_encoder(output_video_encoder),
-		ffmpeg_builder.set_video_tag(output_video_encoder) if temp_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
+		ffmpeg_builder.conditional_set_video_tag(output_video_encoder, temp_video_format),
 		ffmpeg_builder.set_video_quality(output_video_encoder, output_video_quality),
 		ffmpeg_builder.set_video_preset(output_video_encoder, output_video_preset),
 		ffmpeg_builder.concat(
@@ -265,7 +265,7 @@ def concat_video(output_path : str, temp_output_paths : List[str]) -> bool:
 		ffmpeg_builder.set_input(concat_video_file.name),
 		ffmpeg_builder.copy_video_encoder(),
 		ffmpeg_builder.copy_audio_encoder(),
-		ffmpeg_builder.set_faststart() if output_video_format in [ 'm4v', 'mov', 'mp4' ] else [],
+		ffmpeg_builder.conditional_set_faststart(output_video_format),
 		ffmpeg_builder.force_output(output_path)
 	)
 	process = run_ffmpeg(commands)

--- a/facefusion/ffmpeg_builder.py
+++ b/facefusion/ffmpeg_builder.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import numpy
 
 from facefusion.filesystem import get_file_format
-from facefusion.types import AudioEncoder, Command, CommandSet, Duration, Fps, StreamMode, VideoEncoder, VideoPreset
+from facefusion.types import AudioEncoder, Command, CommandSet, Duration, Fps, StreamMode, VideoEncoder, VideoFormat, VideoPreset
 
 
 def run(commands : List[Command]) -> List[Command]:
@@ -187,14 +187,16 @@ def copy_video_encoder() -> List[Command]:
 	return set_video_encoder('copy')
 
 
-def set_video_tag(video_encoder : VideoEncoder) -> List[Command]:
-	if video_encoder in [ 'libx265', 'hevc_nvenc', 'hevc_amf', 'hevc_qsv', 'hevc_videotoolbox' ]:
+def conditional_set_video_tag(video_encoder : VideoEncoder, video_format : VideoFormat) -> List[Command]:
+	if video_format in [ 'm4v', 'mov', 'mp4' ] and video_encoder in [ 'libx265', 'hevc_nvenc', 'hevc_amf', 'hevc_qsv', 'hevc_videotoolbox' ]:
 		return [ '-tag:v', 'hvc1' ]
 	return []
 
 
-def set_faststart() -> List[Command]:
-	return [ '-movflags', '+faststart' ]
+def conditional_set_faststart(video_format : VideoFormat) -> List[Command]:
+	if video_format in [ 'm4v', 'mov', 'mp4' ]:
+		return [ '-movflags', '+faststart' ]
+	return []
 
 
 def set_video_quality(video_encoder : VideoEncoder, video_quality : int) -> List[Command]:

--- a/facefusion/ffmpeg_builder.py
+++ b/facefusion/ffmpeg_builder.py
@@ -187,6 +187,16 @@ def copy_video_encoder() -> List[Command]:
 	return set_video_encoder('copy')
 
 
+def set_video_tag(video_encoder : VideoEncoder) -> List[Command]:
+	if video_encoder in [ 'libx265', 'hevc_nvenc', 'hevc_amf', 'hevc_qsv', 'hevc_videotoolbox' ]:
+		return [ '-tag:v', 'hvc1' ]
+	return []
+
+
+def set_faststart() -> List[Command]:
+	return [ '-movflags', '+faststart' ]
+
+
 def set_video_quality(video_encoder : VideoEncoder, video_quality : int) -> List[Command]:
 	if video_encoder in [ 'libx264', 'libx264rgb', 'libx265' ]:
 		video_compression = numpy.round(numpy.interp(video_quality, [ 0, 100 ], [ 51, 0 ])).astype(int).item()

--- a/tests/test_ffmpeg_builder.py
+++ b/tests/test_ffmpeg_builder.py
@@ -1,7 +1,7 @@
 from shutil import which
 
 from facefusion import ffmpeg_builder
-from facefusion.ffmpeg_builder import chain, concat, keep_video_alpha, run, select_frame_range, set_audio_quality, set_audio_sample_size, set_stream_mode, set_video_encoder, set_video_fps, set_video_quality
+from facefusion.ffmpeg_builder import chain, concat, keep_video_alpha, run, select_frame_range, set_audio_quality, set_audio_sample_size, set_faststart, set_stream_mode, set_video_encoder, set_video_fps, set_video_quality, set_video_tag
 
 
 def test_run() -> None:
@@ -108,3 +108,17 @@ def test_set_video_quality() -> None:
 	assert set_video_quality('hevc_videotoolbox', 0) == [ '-b:v', '1024k' ]
 	assert set_video_quality('hevc_videotoolbox', 50) == [ '-b:v', '25768k' ]
 	assert set_video_quality('hevc_videotoolbox', 100) == [ '-b:v', '50512k' ]
+
+
+def test_set_video_tag() -> None:
+	assert set_video_tag('libx265') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('hevc_nvenc') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('hevc_amf') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('hevc_qsv') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('hevc_videotoolbox') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('libx264') == []
+	assert set_video_tag('h264_nvenc') == []
+
+
+def test_set_faststart() -> None:
+	assert set_faststart() == [ '-movflags', '+faststart' ]

--- a/tests/test_ffmpeg_builder.py
+++ b/tests/test_ffmpeg_builder.py
@@ -111,13 +111,8 @@ def test_set_video_quality() -> None:
 
 
 def test_set_video_tag() -> None:
-	assert set_video_tag('libx265') == [ '-tag:v', 'hvc1' ]
-	assert set_video_tag('hevc_nvenc') == [ '-tag:v', 'hvc1' ]
-	assert set_video_tag('hevc_amf') == [ '-tag:v', 'hvc1' ]
-	assert set_video_tag('hevc_qsv') == [ '-tag:v', 'hvc1' ]
 	assert set_video_tag('hevc_videotoolbox') == [ '-tag:v', 'hvc1' ]
 	assert set_video_tag('libx264') == []
-	assert set_video_tag('h264_nvenc') == []
 
 
 def test_set_faststart() -> None:

--- a/tests/test_ffmpeg_builder.py
+++ b/tests/test_ffmpeg_builder.py
@@ -1,7 +1,7 @@
 from shutil import which
 
 from facefusion import ffmpeg_builder
-from facefusion.ffmpeg_builder import chain, concat, keep_video_alpha, run, select_frame_range, set_audio_quality, set_audio_sample_size, set_faststart, set_stream_mode, set_video_encoder, set_video_fps, set_video_quality, set_video_tag
+from facefusion.ffmpeg_builder import chain, concat, conditional_set_faststart, conditional_set_video_tag, keep_video_alpha, run, select_frame_range, set_audio_quality, set_audio_sample_size, set_stream_mode, set_video_encoder, set_video_fps, set_video_quality
 
 
 def test_run() -> None:
@@ -110,10 +110,12 @@ def test_set_video_quality() -> None:
 	assert set_video_quality('hevc_videotoolbox', 100) == [ '-b:v', '50512k' ]
 
 
-def test_set_video_tag() -> None:
-	assert set_video_tag('hevc_videotoolbox') == [ '-tag:v', 'hvc1' ]
-	assert set_video_tag('libx264') == []
+def test_conditional_set_video_tag() -> None:
+	assert conditional_set_video_tag('hevc_videotoolbox', 'mp4') == [ '-tag:v', 'hvc1' ]
+	assert conditional_set_video_tag('hevc_videotoolbox', 'mkv') == []
+	assert conditional_set_video_tag('libx264', 'mp4') == []
 
 
-def test_set_faststart() -> None:
-	assert set_faststart() == [ '-movflags', '+faststart' ]
+def test_conditional_set_faststart() -> None:
+	assert conditional_set_faststart('mp4') == [ '-movflags', '+faststart' ]
+	assert conditional_set_faststart('mkv') == []


### PR DESCRIPTION
## Problem

ffmpeg defaults HEVC in MP4 to the `hev1` sample entry and leaves the moov atom at the tail. Apple players (QuickTime, Finder QuickLook) refuse to decode `hev1` and stall reading a tail-placed moov on large files, so `hevc_nvenc` / `libx265` renders cannot be previewed on macOS.

## Change

- `ffmpeg_builder.set_video_tag()` — emit `-tag:v hvc1` for every HEVC encoder (`libx265`, `hevc_nvenc`, `hevc_amf`, `hevc_qsv`, `hevc_videotoolbox`). Applied in `merge_video` where the encoder is known; `-c:v copy` in the audio mux / concat steps preserves the tag.
- `ffmpeg_builder.set_faststart()` — emit `-movflags +faststart`, applied in `restore_audio` / `replace_audio` / `concat_video` which write the final output.

H.264 and other codecs are left untouched.

## Other containers (mkv etc.)

Verified against every output format (avi, m4v, mkv, mp4, mov, webm, wmv) with real ffmpeg: the muxers outside mp4/mov simply ignore `-tag:v hvc1` and `-movflags +faststart`, and `fix_video_encoder` already remaps HEVC away from the containers that reject it. No container guard needed. The mkv failure I mentioned turned out to be an unrelated ffmpeg 8 issue in the existing `test_ffmpeg.py` fixture setup (matroska now defaults to ac3, which rejects `-ar 16000`, so `before_all` writes a 0-byte `target-240p-16khz.mkv`) — happy to send that as a separate PR.

## Tests

`test_ffmpeg_builder.py`: `set_video_tag` returns `hvc1` for the five HEVC encoders and `[]` for H.264; `set_faststart` returns `+faststart`.

Verified on a real `hevc_nvenc` render: before the patch QuickLook hangs on the output, after the patch the file carries `hvc1` with a front-placed moov and previews fine. The same patch has been running in production on top of master.