### PR TITLE
Tag HEVC output as hvc1 and move moov atom to the front

### DIFF
--- a/facefusion/ffmpeg.py
+++ b/facefusion/ffmpeg.py
@@ -220,6 +220,7 @@ def restore_audio(target_path : str, output_path : str, trim_frame_start : int, 
 		ffmpeg_builder.select_media_stream('0:v:0'),
 		ffmpeg_builder.select_media_stream('1:a:0'),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
+		ffmpeg_builder.set_faststart(temp_video_format),
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -242,6 +243,7 @@ def replace_audio(audio_path : str, output_path : str) -> bool:
 		ffmpeg_builder.set_audio_quality(output_audio_encoder, output_audio_quality),
 		ffmpeg_builder.set_audio_volume(output_audio_volume),
 		ffmpeg_builder.set_video_duration(temp_video_duration),
+		ffmpeg_builder.set_faststart(temp_video_format),
 		ffmpeg_builder.force_output(output_path)
 	)
 	return run_ffmpeg(commands).returncode == 0
@@ -262,6 +264,7 @@ def merge_video(target_path : str, output_path : str, temp_video_fps : Fps, outp
 		ffmpeg_builder.set_input(temp_frames_pattern),
 		ffmpeg_builder.set_media_resolution(pack_resolution(output_video_resolution)),
 		ffmpeg_builder.set_video_encoder(output_video_encoder),
+		ffmpeg_builder.set_video_tag(output_video_encoder, temp_video_format),
 		ffmpeg_builder.set_video_quality(output_video_encoder, output_video_quality),
 		ffmpeg_builder.set_video_preset(output_video_encoder, output_video_preset),
 		ffmpeg_builder.concat(
@@ -288,11 +291,13 @@ def concat_video(output_path : str, temp_output_paths : List[str]) -> bool:
 		concat_video_file.close()
 
 	output_path = os.path.abspath(output_path)
+	output_video_format = cast(VideoFormat, get_file_format(output_path))
 	commands = ffmpeg_builder.chain(
 		ffmpeg_builder.unsafe_concat(),
 		ffmpeg_builder.set_input(concat_video_file.name),
 		ffmpeg_builder.copy_video_encoder(),
 		ffmpeg_builder.copy_audio_encoder(),
+		ffmpeg_builder.set_faststart(output_video_format),
 		ffmpeg_builder.force_output(output_path)
 	)
 	process = run_ffmpeg(commands)

--- a/facefusion/ffmpeg_builder.py
+++ b/facefusion/ffmpeg_builder.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import numpy
 
 from facefusion.filesystem import get_file_format
-from facefusion.types import AudioEncoder, Command, CommandSet, Duration, Fps, SampleRate, StreamMode, VideoEncoder, VideoPreset
+from facefusion.types import AudioEncoder, Command, CommandSet, Duration, Fps, SampleRate, StreamMode, VideoEncoder, VideoFormat, VideoPreset
 
 
 def run(commands : List[Command]) -> List[Command]:
@@ -205,6 +205,18 @@ def set_video_encoder(video_encoder : str) -> List[Command]:
 
 def copy_video_encoder() -> List[Command]:
 	return set_video_encoder('copy')
+
+
+def set_faststart(video_format : VideoFormat) -> List[Command]:
+	if video_format in [ 'm4v', 'mov', 'mp4' ]:
+		return [ '-movflags', '+faststart' ]
+	return []
+
+
+def set_video_tag(video_encoder : VideoEncoder, video_format : VideoFormat) -> List[Command]:
+	if video_format in [ 'm4v', 'mov', 'mp4' ] and video_encoder in [ 'libx265', 'hevc_nvenc', 'hevc_amf', 'hevc_qsv', 'hevc_videotoolbox' ]:
+		return [ '-tag:v', 'hvc1' ]
+	return []
 
 
 def set_video_quality(video_encoder : VideoEncoder, video_quality : int) -> List[Command]:

--- a/tests/test_ffmpeg_builder.py
+++ b/tests/test_ffmpeg_builder.py
@@ -1,7 +1,7 @@
 from shutil import which
 
 from facefusion import ffmpeg_builder
-from facefusion.ffmpeg_builder import capture_video, chain, concat, enforce_pixel_format, keep_video_alpha, run, select_frame_range, set_audio_quality, set_audio_sample_size, set_stream_mode, set_stream_quality, set_video_encoder, set_video_fps, set_video_quality
+from facefusion.ffmpeg_builder import capture_video, chain, concat, enforce_pixel_format, keep_video_alpha, run, select_frame_range, set_audio_quality, set_audio_sample_size, set_faststart, set_stream_mode, set_stream_quality, set_video_encoder, set_video_fps, set_video_quality, set_video_tag
 
 
 def test_run() -> None:
@@ -108,6 +108,24 @@ def test_set_video_quality() -> None:
 	assert set_video_quality('hevc_videotoolbox', 0) == [ '-b:v', '1024k' ]
 	assert set_video_quality('hevc_videotoolbox', 50) == [ '-b:v', '25768k' ]
 	assert set_video_quality('hevc_videotoolbox', 100) == [ '-b:v', '50512k' ]
+
+
+def test_set_faststart() -> None:
+	assert set_faststart('m4v') == [ '-movflags', '+faststart' ]
+	assert set_faststart('mov') == [ '-movflags', '+faststart' ]
+	assert set_faststart('mp4') == [ '-movflags', '+faststart' ]
+	assert set_faststart('mkv') == []
+	assert set_faststart('webm') == []
+
+
+def test_set_video_tag() -> None:
+	assert set_video_tag('libx265', 'm4v') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('hevc_nvenc', 'mov') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('hevc_videotoolbox', 'mp4') == [ '-tag:v', 'hvc1' ]
+	assert set_video_tag('libx265', 'mkv') == []
+	assert set_video_tag('libx265', 'webm') == []
+	assert set_video_tag('libx264', 'mp4') == []
+	assert set_video_tag('h264_nvenc', 'mp4') == []
 
 
 def test_capture_video() -> None:


### PR DESCRIPTION
Ports the hvc1 tagging + faststart change to the `v4` branch (same fix already in `next` via #1153).

## What

- **`hvc1` video tag** on the HEVC encode (`merge_video`) so the output plays in QuickTime / Safari / Apple ecosystem players instead of showing a black frame. Default `hev1` tagging is not recognized by Apple's HEVC decoder.
- **`+faststart`** on the final mux stages (`restore_audio` / `replace_audio` / `concat_video`) to move the moov atom to the front, enabling progressive download / streaming start before the whole file is fetched.

## How

- New `FfmpegBuilder.set_video_tag()` and `set_faststart()` helpers (same names/impl as the merged `next` version).
- `hvc1` tag is applied at the encode stage; the final copy stages inherit it, and add `+faststart`.
- Added `test_set_faststart` / `test_set_video_tag`.

flake8 / mypy clean, pytest green.