### PR TITLE
Simplify video_manager

### DIFF
--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -124,7 +124,6 @@ VideoMetadata = TypedDict('VideoMetadata',
 	'color_transfer' : ColorTransfer
 })
 #todo: needs review - [types] [critical: low] reader and writer state around ffmpeg processes, metadata embedded whole
-#todo: question if the body of VideoReader and VideoWriter needs all the keys
 VideoReader = TypedDict('VideoReader',
 {
 	'process' : subprocess.Popen[bytes],
@@ -136,9 +135,7 @@ VideoReader = TypedDict('VideoReader',
 VideoReaderSet : TypeAlias = Dict[str, VideoReader]
 VideoWriter = TypedDict('VideoWriter',
 {
-	'process' : subprocess.Popen[bytes],
-	'file_path' : str,
-	'metadata' : VideoMetadata
+	'process' : subprocess.Popen[bytes]
 })
 VideoWriterSet : TypeAlias = Dict[str, VideoWriter]
 VideoPoolSet = TypedDict('VideoPoolSet',

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -111,13 +111,8 @@ def close_video_writer(video_writer : VideoWriter) -> bool:
 
 #todo: needs review - [lifecycle] [critical: high] kill over terminate, sigterm deadlocks while the pipe is full
 def clear_video_pool() -> None:
-	for video_reader in VIDEO_POOL_SET.get('reader').values():
-		video_reader.get('process').kill()
-		video_reader.get('process').wait()
-
-	for video_writer in VIDEO_POOL_SET.get('writer').values():
-		video_writer.get('process').kill()
-		video_writer.get('process').wait()
-
-	VIDEO_POOL_SET['reader'].clear()
-	VIDEO_POOL_SET['writer'].clear()
+	for video_pool in VIDEO_POOL_SET.values():
+		for video_pool_item in video_pool.values():
+			video_pool_item.get('process').kill()
+			video_pool_item.get('process').wait()
+		video_pool.clear()

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -108,8 +108,13 @@ def close_video_writer(video_writer : VideoWriter) -> bool:
 
 #todo: needs review - [lifecycle] [critical: high] kill over terminate, sigterm deadlocks while the pipe is full
 def clear_video_pool() -> None:
-	for video_pool in VIDEO_POOL_SET.values():
-		for video_pool_item in video_pool.values():
-			video_pool_item.get('process').kill()
-			video_pool_item.get('process').wait()
-		video_pool.clear()
+	for video_reader in VIDEO_POOL_SET.get('reader').values():
+		video_reader.get('process').kill()
+		video_reader.get('process').wait()
+
+	for video_writer in VIDEO_POOL_SET.get('writer').values():
+		video_writer.get('process').kill()
+		video_writer.get('process').wait()
+
+	VIDEO_POOL_SET['reader'].clear()
+	VIDEO_POOL_SET['writer'].clear()

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy
 
 from facefusion import ffmpeg, ffprobe
-from facefusion.types import Fps, Resolution, VideoMetadata, VideoPoolSet, VideoReader, VideoWriter, VisionFrame, VisionFrameSet
+from facefusion.types import Fps, Resolution, VideoPoolSet, VideoReader, VideoWriter, VisionFrame, VisionFrameSet
 
 VIDEO_POOL_SET : VideoPoolSet =\
 {
@@ -85,13 +85,11 @@ def read_video_reader_window(video_reader : VideoReader, frame_start : int, fram
 
 
 #todo: needs review - [lifecycle] [critical: low] pooled writer keyed by target_path, metadata forwarded by the caller
-def get_writer(target_path : str, video_metadata : VideoMetadata, temp_video_fps : Fps, temp_video_resolution : Resolution, output_video_resolution : Resolution, output_video_fps : Fps) -> VideoWriter:
+def get_writer(target_path : str, temp_video_fps : Fps, temp_video_resolution : Resolution, output_video_resolution : Resolution, output_video_fps : Fps) -> VideoWriter:
 	if target_path not in VIDEO_POOL_SET.get('writer'):
 		VIDEO_POOL_SET['writer'][target_path] =\
 		{
-			'process': ffmpeg.create_video_writer(target_path, temp_video_fps, temp_video_resolution, output_video_resolution, output_video_fps),
-			'file_path': target_path,
-			'metadata': video_metadata
+			'process': ffmpeg.create_video_writer(target_path, temp_video_fps, temp_video_resolution, output_video_resolution, output_video_fps)
 		}
 
 	return VIDEO_POOL_SET.get('writer').get(target_path)

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -34,11 +34,11 @@ def conditional_set_video_reader_position(video_reader : VideoReader, frame_posi
 	skip_margin = 128
 	skip_total = frame_position - video_reader.get('position')
 
-	if skip_total > 0 and skip_total <= skip_margin:
+	if skip_total in range(1, skip_margin + 1):
 		for _ in range(skip_total):
 			read_video_reader_frame(video_reader)
 
-	if not video_reader.get('position') == frame_position:
+	if skip_total < 0 or skip_total > skip_margin:
 		refresh_video_reader(video_reader, frame_position)
 
 

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -84,7 +84,6 @@ def read_video_reader_window(video_reader : VideoReader, frame_start : int, fram
 	return frame_set
 
 
-#todo: needs review - [lifecycle] [critical: low] pooled writer keyed by target_path, metadata forwarded by the caller
 def get_writer(target_path : str, temp_video_fps : Fps, temp_video_resolution : Resolution, output_video_resolution : Resolution, output_video_fps : Fps) -> VideoWriter:
 	if target_path not in VIDEO_POOL_SET.get('writer'):
 		VIDEO_POOL_SET['writer'][target_path] =\

--- a/facefusion/workflows/image_to_video.py
+++ b/facefusion/workflows/image_to_video.py
@@ -6,7 +6,7 @@ import cv2
 import numpy
 from tqdm import tqdm
 
-from facefusion import content_analyser, ffmpeg, ffprobe, logger, process_manager, state_manager, translator, video_manager
+from facefusion import content_analyser, ffmpeg, logger, process_manager, state_manager, translator, video_manager
 from facefusion.audio import create_empty_audio_frame, get_audio_frame, get_voice_frame
 from facefusion.common_helper import get_first, get_middle
 from facefusion.filesystem import filter_audio_paths, is_video
@@ -253,8 +253,7 @@ def process_stream_frames() -> ErrorCode:
 	frame_range = range(trim_frame_start, trim_frame_end)
 
 	if frame_range:
-		video_metadata = ffprobe.extract_static_video_metadata(state_manager.get_item('target_path'))
-		video_writer = video_manager.get_writer(state_manager.get_item('target_path'), video_metadata, temp_video_fps, temp_video_resolution, output_video_resolution, state_manager.get_item('output_video_fps'))
+		video_writer = video_manager.get_writer(state_manager.get_item('target_path'), temp_video_fps, temp_video_resolution, output_video_resolution, state_manager.get_item('output_video_fps'))
 		frame_look_ahead = calculate_frame_look_ahead(temp_video_resolution)
 
 		with tqdm(total = len(frame_range), desc = translator.get('processing'), unit = 'frame', ascii = ' =', disable = state_manager.get_item('log_level') in [ 'warn', 'error' ]) as progress:

--- a/tests/test_video_manager.py
+++ b/tests/test_video_manager.py
@@ -136,11 +136,10 @@ def test_evict_video_reader_buffer() -> None:
 #todo: run mutation testing, strip down to the minimum, test with real data
 def test_get_writer() -> None:
 	target_path = get_test_example_file('target-240p-25fps.mp4')
-	video_metadata = extract_video_metadata(target_path)
 	create_temp_directory(target_path)
-	video_writer = get_writer(target_path, video_metadata, 25.0, (426, 226), (426, 226), 25.0)
+	video_writer = get_writer(target_path, 25.0, (426, 226), (426, 226), 25.0)
 
-	assert get_writer(target_path, video_metadata, 25.0, (426, 226), (426, 226), 25.0) is video_writer
+	assert get_writer(target_path, 25.0, (426, 226), (426, 226), 25.0) is video_writer
 
 
 #todo: needs review - [testing] question if the assertions are good
@@ -149,7 +148,7 @@ def test_write_video_writer_frame() -> None:
 	target_path = get_test_example_file('target-240p-25fps.mp4')
 	create_temp_directory(target_path)
 	video_reader = get_reader(target_path)
-	video_writer = get_writer(target_path, video_reader.get('metadata'), 25.0, (426, 226), (426, 226), 25.0)
+	video_writer = get_writer(target_path, 25.0, (426, 226), (426, 226), 25.0)
 
 	for frame_number in range(25):
 		vision_frame = read_video_reader_frame(video_reader)
@@ -172,7 +171,7 @@ def test_close_video_writer() -> None:
 	target_path = get_test_example_file('target-240p-30fps.mp4')
 	create_temp_directory(target_path)
 	video_reader = get_reader(target_path)
-	video_writer = get_writer(target_path, video_reader.get('metadata'), 30.0, (426, 226), (426, 226), 30.0)
+	video_writer = get_writer(target_path, 30.0, (426, 226), (426, 226), 30.0)
 	vision_frame = read_video_reader_frame(video_reader)
 	write_video_writer_frame(video_writer, vision_frame)
 
@@ -185,7 +184,7 @@ def test_clear_video_pool() -> None:
 	target_path = get_test_example_file('target-240p-25fps.mp4')
 	create_temp_directory(target_path)
 	video_reader = get_reader(target_path)
-	video_writer = get_writer(target_path, video_reader.get('metadata'), 25.0, (426, 226), (426, 226), 25.0)
+	video_writer = get_writer(target_path, 25.0, (426, 226), (426, 226), 25.0)
 	clear_video_pool()
 
 	assert video_reader.get('process').returncode == -9


### PR DESCRIPTION
  - Seek guard: range membership + positive refresh check — no <=, no not ==                                                                                                                                                                                             
  - clear_video_pool: one pass over both pools                                                                                                                                                                                                                           
  - Drop write-only VideoWriter keys (file_path, metadata) + unused get_writer param                                                                                                                                                                                     
  - Prune now-dead imports (VideoMetadata, ffprobe) and the resolved key-audit todo                                                                                                                                                                                      
  - Update the one caller + tests; behavior unchanged                                                 