### PR TITLE
Add frame_store module

### DIFF
--- a/facefusion/frame_store.py
+++ b/facefusion/frame_store.py
@@ -3,20 +3,20 @@ from facefusion.types import FrameStoreSet, VisionFrame, VisionFrameSet
 FRAME_STORE_SET : FrameStoreSet = {}
 
 
-def get_frame_store(reader_id : str) -> VisionFrameSet:
-	if reader_id not in FRAME_STORE_SET:
-		FRAME_STORE_SET[reader_id] = {}
+def get_frame_store(id : str) -> VisionFrameSet:
+	if id not in FRAME_STORE_SET:
+		FRAME_STORE_SET[id] = {}
 
-	return FRAME_STORE_SET.get(reader_id)
+	return FRAME_STORE_SET.get(id)
 
 
-def store_frame(reader_id : str, frame_number : int, vision_frame : VisionFrame) -> None:
-	frame_store = get_frame_store(reader_id)
+def set_frame(id : str, frame_number : int, vision_frame : VisionFrame) -> None:
+	frame_store = get_frame_store(id)
 	frame_store[frame_number] = vision_frame
 
 
-def select_frame_range(reader_id : str, frame_start : int, frame_end : int) -> VisionFrameSet:
-	frame_store = get_frame_store(reader_id)
+def select_frame_set(id : str, frame_start : int, frame_end : int) -> VisionFrameSet:
+	frame_store = get_frame_store(id)
 	frame_set = {}
 
 	for frame_number in range(frame_start, frame_end + 1):
@@ -26,17 +26,9 @@ def select_frame_range(reader_id : str, frame_start : int, frame_end : int) -> V
 	return frame_set
 
 
-def flush_frames(reader_id : str, frame_min : int, frame_max : int) -> None:
-	frame_store = get_frame_store(reader_id)
-	keep_range = range(frame_min, frame_max + 1)
-	frame_set = {}
-
-	for frame_number in frame_store:
-		if frame_number in keep_range:
-			frame_set[frame_number] = frame_store.get(frame_number)
-
-	FRAME_STORE_SET[reader_id] = frame_set
+def reduce_frames(id : str, frame_min : int, frame_max : int) -> None:
+	FRAME_STORE_SET[id] = select_frame_set(id, frame_min, frame_max)
 
 
-def clear_frame_store() -> None:
+def clear_frames() -> None:
 	FRAME_STORE_SET.clear()

--- a/facefusion/frame_store.py
+++ b/facefusion/frame_store.py
@@ -3,20 +3,20 @@ from facefusion.types import FrameStoreSet, VisionFrame, VisionFrameSet
 FRAME_STORE_SET : FrameStoreSet = {}
 
 
-def get_frame_store(source : str) -> VisionFrameSet:
-	if source not in FRAME_STORE_SET:
-		FRAME_STORE_SET[source] = {}
+def get_frame_store(reader_id : str) -> VisionFrameSet:
+	if reader_id not in FRAME_STORE_SET:
+		FRAME_STORE_SET[reader_id] = {}
 
-	return FRAME_STORE_SET.get(source)
+	return FRAME_STORE_SET.get(reader_id)
 
 
-def store_frame(source : str, frame_number : int, vision_frame : VisionFrame) -> None:
-	frame_store = get_frame_store(source)
+def store_frame(reader_id : str, frame_number : int, vision_frame : VisionFrame) -> None:
+	frame_store = get_frame_store(reader_id)
 	frame_store[frame_number] = vision_frame
 
 
-def read_frame_range(source : str, frame_start : int, frame_end : int) -> VisionFrameSet:
-	frame_store = get_frame_store(source)
+def select_frame_range(reader_id : str, frame_start : int, frame_end : int) -> VisionFrameSet:
+	frame_store = get_frame_store(reader_id)
 	frame_set = {}
 
 	for frame_number in range(frame_start, frame_end + 1):
@@ -26,8 +26,8 @@ def read_frame_range(source : str, frame_start : int, frame_end : int) -> Vision
 	return frame_set
 
 
-def evict_frames(source : str, frame_min : int, frame_max : int) -> None:
-	frame_store = get_frame_store(source)
+def flush_frames(reader_id : str, frame_min : int, frame_max : int) -> None:
+	frame_store = get_frame_store(reader_id)
 	keep_range = range(frame_min, frame_max + 1)
 	frame_set = {}
 
@@ -35,7 +35,7 @@ def evict_frames(source : str, frame_min : int, frame_max : int) -> None:
 		if frame_number in keep_range:
 			frame_set[frame_number] = frame_store.get(frame_number)
 
-	FRAME_STORE_SET[source] = frame_set
+	FRAME_STORE_SET[reader_id] = frame_set
 
 
 def clear_frame_store() -> None:

--- a/facefusion/frame_store.py
+++ b/facefusion/frame_store.py
@@ -1,0 +1,42 @@
+from facefusion.types import FrameStoreSet, VisionFrame, VisionFrameSet
+
+FRAME_STORE_SET : FrameStoreSet = {}
+
+
+def get_frame_store(source : str) -> VisionFrameSet:
+	if source not in FRAME_STORE_SET:
+		FRAME_STORE_SET[source] = {}
+
+	return FRAME_STORE_SET.get(source)
+
+
+def store_frame(source : str, frame_number : int, vision_frame : VisionFrame) -> None:
+	frame_store = get_frame_store(source)
+	frame_store[frame_number] = vision_frame
+
+
+def read_frame_range(source : str, frame_start : int, frame_end : int) -> VisionFrameSet:
+	frame_store = get_frame_store(source)
+	frame_set = {}
+
+	for frame_number in range(frame_start, frame_end + 1):
+		if frame_number in frame_store:
+			frame_set[frame_number] = frame_store.get(frame_number)
+
+	return frame_set
+
+
+def evict_frames(source : str, frame_min : int, frame_max : int) -> None:
+	frame_store = get_frame_store(source)
+	keep_range = range(frame_min, frame_max + 1)
+	frame_set = {}
+
+	for frame_number in frame_store:
+		if frame_number in keep_range:
+			frame_set[frame_number] = frame_store.get(frame_number)
+
+	FRAME_STORE_SET[source] = frame_set
+
+
+def clear_frame_store() -> None:
+	FRAME_STORE_SET.clear()

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -146,6 +146,7 @@ VideoPoolSet = TypedDict('VideoPoolSet',
 	'reader' : VideoReaderSet,
 	'writer' : VideoWriterSet
 })
+FrameStoreSet : TypeAlias = Dict[str, VisionFrameSet]
 
 ProcessState = Literal['checking', 'processing', 'stopping', 'pending']
 Args : TypeAlias = Dict[str, Any]

--- a/tests/test_frame_store.py
+++ b/tests/test_frame_store.py
@@ -2,7 +2,7 @@ import pytest
 
 from facefusion import process_manager
 from facefusion.download import conditional_download
-from facefusion.frame_store import clear_frame_store, flush_frames, get_frame_store, select_frame_range, store_frame
+from facefusion.frame_store import clear_frames, get_frame_store, reduce_frames, select_frame_set, set_frame
 from facefusion.vision import read_video_frame
 from .helper import get_test_example_file, get_test_examples_directory
 
@@ -18,7 +18,7 @@ def before_all() -> None:
 
 @pytest.fixture(scope = 'function', autouse = True)
 def before_each() -> None:
-	clear_frame_store()
+	clear_frames()
 
 
 def test_get_frame_store() -> None:
@@ -28,48 +28,43 @@ def test_get_frame_store() -> None:
 	assert get_frame_store('reader-1') is frame_store
 
 
-def test_store_frame() -> None:
+def test_set_frame() -> None:
 	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
-	store_frame('reader-1', 5, target_frame)
+
+	set_frame('reader-1', 5, target_frame)
 
 	assert get_frame_store('reader-1').get(5) is target_frame
 
 
-def test_select_frame_range() -> None:
-	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
-
-	for frame_number in range(0, 5):
-		store_frame('reader-1', frame_number, target_frame)
-
-	assert sorted(select_frame_range('reader-1', 1, 3)) == [ 1, 2, 3 ]
-	assert select_frame_range('reader-1', 8, 12) == {}
-
-
-def test_select_frame_range_overlap() -> None:
+def test_select_frame_set() -> None:
 	first_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
 	fifth_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 5)
-	store_frame('reader-1', 2, first_frame)
-	store_frame('reader-1', 5, fifth_frame)
 
-	assert select_frame_range('reader-1', 0, 4).get(2) is first_frame
-	assert select_frame_range('reader-1', 2, 6).get(2) is first_frame
-	assert select_frame_range('reader-1', 2, 6).get(5) is fifth_frame
+	set_frame('reader-1', 2, first_frame)
+	set_frame('reader-1', 5, fifth_frame)
+
+	assert sorted(select_frame_set('reader-1', 0, 4)) == [ 2 ]
+	assert select_frame_set('reader-1', 0, 4).get(2) is first_frame
+	assert sorted(select_frame_set('reader-1', 2, 6)) == [ 2, 5 ]
+	assert select_frame_set('reader-1', 2, 6).get(5) is fifth_frame
+	assert select_frame_set('reader-1', 8, 12) == {}
 
 
-def test_flush_frames() -> None:
+def test_reduce_frames() -> None:
 	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
 
 	for frame_number in range(0, 10):
-		store_frame('reader-1', frame_number, target_frame)
+		set_frame('reader-1', frame_number, target_frame)
 
-	flush_frames('reader-1', 4, 6)
+	reduce_frames('reader-1', 4, 6)
 
 	assert sorted(get_frame_store('reader-1')) == [ 4, 5, 6 ]
 
 
-def test_clear_frame_store() -> None:
+def test_clear_frames() -> None:
 	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
-	store_frame('reader-1', 0, target_frame)
-	clear_frame_store()
+
+	set_frame('reader-1', 0, target_frame)
+	clear_frames()
 
 	assert get_frame_store('reader-1') == {}

--- a/tests/test_frame_store.py
+++ b/tests/test_frame_store.py
@@ -1,7 +1,19 @@
-import numpy
 import pytest
 
-from facefusion.frame_store import clear_frame_store, evict_frames, get_frame_store, read_frame_range, store_frame
+from facefusion import process_manager
+from facefusion.download import conditional_download
+from facefusion.frame_store import clear_frame_store, flush_frames, get_frame_store, select_frame_range, store_frame
+from facefusion.vision import read_video_frame
+from .helper import get_test_example_file, get_test_examples_directory
+
+
+@pytest.fixture(scope = 'module', autouse = True)
+def before_all() -> None:
+	process_manager.start()
+	conditional_download(get_test_examples_directory(),
+	[
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
+	])
 
 
 @pytest.fixture(scope = 'function', autouse = True)
@@ -10,51 +22,54 @@ def before_each() -> None:
 
 
 def test_get_frame_store() -> None:
-	frame_store = get_frame_store('target.mp4')
+	frame_store = get_frame_store('reader-1')
 
 	assert frame_store == {}
-	assert get_frame_store('target.mp4') is frame_store
+	assert get_frame_store('reader-1') is frame_store
 
 
 def test_store_frame() -> None:
-	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
-	store_frame('target.mp4', 5, target_frame)
+	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
+	store_frame('reader-1', 5, target_frame)
 
-	assert get_frame_store('target.mp4').get(5) is target_frame
+	assert get_frame_store('reader-1').get(5) is target_frame
 
 
-def test_read_frame_range() -> None:
-	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
+def test_select_frame_range() -> None:
+	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
 
 	for frame_number in range(0, 5):
-		store_frame('target.mp4', frame_number, target_frame)
+		store_frame('reader-1', frame_number, target_frame)
 
-	assert sorted(read_frame_range('target.mp4', 1, 3)) == [ 1, 2, 3 ]
-	assert read_frame_range('target.mp4', 8, 12) == {}
-
-
-def test_read_frame_range_overlap() -> None:
-	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
-	store_frame('target.mp4', 2, target_frame)
-
-	assert read_frame_range('target.mp4', 0, 4).get(2) is target_frame
-	assert read_frame_range('target.mp4', 2, 6).get(2) is target_frame
+	assert sorted(select_frame_range('reader-1', 1, 3)) == [ 1, 2, 3 ]
+	assert select_frame_range('reader-1', 8, 12) == {}
 
 
-def test_evict_frames() -> None:
-	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
+def test_select_frame_range_overlap() -> None:
+	first_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
+	fifth_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 5)
+	store_frame('reader-1', 2, first_frame)
+	store_frame('reader-1', 5, fifth_frame)
+
+	assert select_frame_range('reader-1', 0, 4).get(2) is first_frame
+	assert select_frame_range('reader-1', 2, 6).get(2) is first_frame
+	assert select_frame_range('reader-1', 2, 6).get(5) is fifth_frame
+
+
+def test_flush_frames() -> None:
+	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
 
 	for frame_number in range(0, 10):
-		store_frame('target.mp4', frame_number, target_frame)
+		store_frame('reader-1', frame_number, target_frame)
 
-	evict_frames('target.mp4', 4, 6)
+	flush_frames('reader-1', 4, 6)
 
-	assert sorted(get_frame_store('target.mp4')) == [ 4, 5, 6 ]
+	assert sorted(get_frame_store('reader-1')) == [ 4, 5, 6 ]
 
 
 def test_clear_frame_store() -> None:
-	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
-	store_frame('target.mp4', 0, target_frame)
+	target_frame = read_video_frame(get_test_example_file('target-240p.mp4'), 0)
+	store_frame('reader-1', 0, target_frame)
 	clear_frame_store()
 
-	assert get_frame_store('target.mp4') == {}
+	assert get_frame_store('reader-1') == {}

--- a/tests/test_frame_store.py
+++ b/tests/test_frame_store.py
@@ -1,0 +1,60 @@
+import numpy
+import pytest
+
+from facefusion.frame_store import clear_frame_store, evict_frames, get_frame_store, read_frame_range, store_frame
+
+
+@pytest.fixture(scope = 'function', autouse = True)
+def before_each() -> None:
+	clear_frame_store()
+
+
+def test_get_frame_store() -> None:
+	frame_store = get_frame_store('target.mp4')
+
+	assert frame_store == {}
+	assert get_frame_store('target.mp4') is frame_store
+
+
+def test_store_frame() -> None:
+	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
+	store_frame('target.mp4', 5, target_frame)
+
+	assert get_frame_store('target.mp4').get(5) is target_frame
+
+
+def test_read_frame_range() -> None:
+	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
+
+	for frame_number in range(0, 5):
+		store_frame('target.mp4', frame_number, target_frame)
+
+	assert sorted(read_frame_range('target.mp4', 1, 3)) == [ 1, 2, 3 ]
+	assert read_frame_range('target.mp4', 8, 12) == {}
+
+
+def test_read_frame_range_overlap() -> None:
+	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
+	store_frame('target.mp4', 2, target_frame)
+
+	assert read_frame_range('target.mp4', 0, 4).get(2) is target_frame
+	assert read_frame_range('target.mp4', 2, 6).get(2) is target_frame
+
+
+def test_evict_frames() -> None:
+	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
+
+	for frame_number in range(0, 10):
+		store_frame('target.mp4', frame_number, target_frame)
+
+	evict_frames('target.mp4', 4, 6)
+
+	assert sorted(get_frame_store('target.mp4')) == [ 4, 5, 6 ]
+
+
+def test_clear_frame_store() -> None:
+	target_frame = numpy.zeros((2, 2, 3), numpy.uint8)
+	store_frame('target.mp4', 0, target_frame)
+	clear_frame_store()
+
+	assert get_frame_store('target.mp4') == {}


### PR DESCRIPTION
 Pure per-source frame cache, keyed by (source, frame_number). Foundation for routing the window and chunk reads through one owner.                                                                                                                                     
                                                                                                                                                                                                                                                                         
  - frame_store.py — get/store/read_frame_range/evict_frames/clear                                                                                                                                                                                                       
  - FrameStoreSet type                                                                                                                                                                                                                                                   
  - unit tests (mutation-verified)     