### PR TITLE
route window read through frame_store

### DIFF
--- a/docs/framestore_architecture.md
+++ b/docs/framestore_architecture.md
@@ -1,0 +1,80 @@
+# FrameStore Architecture Plan
+
+Architecture change + simplification for `video_manager` frame reading. Not a cleanup — it replaces two competing frame caches and the single-cursor seek heuristics with one owner.
+
+## Problem (today)
+
+- **One reader per file, shared and lock-serialized.** Different access patterns fight over one cursor and force `kill + respawn` (seek thrash).
+- **Two range-read mechanisms doing the same job:**
+  - `read_video_chunk` (in `vision`) — `lru_cache(maxsize = 2)`, used by ~11 processors.
+  - `read_video_reader_window` (in `video_manager`) — rolling `frame_set` + margin eviction, used by `select_video_frames`.
+  - Their todos even argue with each other ("window read replaces the chunk cache" vs "restore the chunk_size approach").
+- **Cache + eviction logic is inline** inside `read_video_reader_window`; the `[memory]` todo lives there.
+- **`frame_set` is glued onto the reader handle** — state mixed into identity.
+
+## Target architecture
+
+- **Reader = dumb sequential decoder.** `{process, position}` (+ `file_path`, `metadata`). Plays forward, decodes on demand. No cache.
+- **FrameStore = the single owner of decoded frames.** Keyed by `(source, frame_number)`, lives inside `video_manager`. Every consumer already routes through `video_manager` to get frames, so the store sits behind that same door.
+- **Writer = self-describing sink.** Already done in the writer PR.
+
+The store does the work a per-reader cache cannot:
+- **Decode once, serve many** — overlapping windows reuse frames instead of each decoding.
+- **Interest-based eviction** — a frame is dropped when no live window covers it (union of live ranges), replacing the crude `< frame_start - margin` trim.
+- **One memory budget** — a single place that caps frames in RAM.
+
+## Illustrative shape (not final)
+
+```
+# frame_store lives in video_manager, keyed by (source, frame_number)
+read_frame_window(source, frame_start, frame_end)   # hits store, decodes misses via a reader
+store_frame(source, frame_number, vision_frame)
+evict_frames(source, live_ranges)                   # drop frames no live window covers
+clear_frame_store()                                 # called from clear_video_pool
+```
+
+`read_video_chunk` and `read_video_reader_window` both collapse into `read_frame_window` — "give me frames `[a, b]`".
+
+## What dies (the simplification)
+
+- `read_video_chunk`'s `lru_cache` **and** `read_video_reader_window`'s `frame_set` → one store.
+- inline eviction in `read_video_reader_window` → store policy.
+- 11 processor `read_static_video_chunk.cache_clear()` lines → **deleted** (store clears via `clear_video_pool()`, which every processor already calls right next to it).
+- the `skip 128` drain / `refresh` / `conditional_set_position` seek dance → shrinks; the store owns decode strategy.
+
+## Scope / blast radius
+
+- **Core store + window read** → `video_manager`-internal.
+- **Chunk unification** → reaches ~11 processors, but only their teardown: the `cache_clear()` calls get removed, not rewired. Shallow and wide, mostly subtraction.
+- **No deep processor changes.** Public read functions keep their signatures.
+
+## Open decisions
+
+- **id-key / multiple readers per file** — enables independent cursors (kills seek thrash). Only worth it if multiplicity is a real goal; adds pools + lifecycle sync (fights "avoid globals"). **Deferred** — decide before phase 3.
+- **`position` stays on the reader** — it is the process cursor, inseparable from the process. Not moved.
+- **Do not chase symmetric `{process, file_path, metadata}` reader** — a reader is a stateful cursor, a writer is a sink; the asymmetry is correct.
+- **`image_to_video`'s `calculate_frame_look_ahead` (3 GB)** — a *different* concern (executor future buffer, not the reader cache). Folding it into the store budget is optional, separate.
+
+## Pros / cons
+
+**Pros**
+- Decode once, share overlaps — less redundant decoding.
+- One memory owner — predictable RAM, kills scattered budgets.
+- Dumb readers — deletes the seek heuristics.
+- Two caches become one — the chunk-vs-window todo dilemma disappears.
+- Cache in one place — testable, one home for the memory todo.
+
+**Cons**
+- A subsystem, not a cleanup — real design cost.
+- Eviction is easy to get wrong — evict too early = re-decode; never = leak.
+- Concurrency moves into the store — it needs its own locking; it did not vanish.
+- Multiplicity (if adopted) = more ffmpeg processes = more CPU/RAM.
+- Over-engineering risk if overlaps/multiplicity are not actually needed.
+
+## Phasing
+
+1. **Writer PR** — done. Ship it.
+2. **FrameStore (contained):** route `read_video_reader_window` + `read_video_chunk` through the store; delete the `lru_cache` and `frame_set`; fold store clear into `clear_video_pool`; delete the 11 `cache_clear()` lines.
+3. **(optional) id-keyed multiple readers:** kill seek thrash; fold the look-ahead budget in. Needs the multiplicity decision first.
+
+**Bottom line:** worth it because it is mostly subtraction — two caches and the seek heuristics collapse into one owner. The one real question is multiplicity (phase 3); phase 2 stands on its own.

--- a/docs/framestore_pr_plan.md
+++ b/docs/framestore_pr_plan.md
@@ -1,0 +1,114 @@
+# FrameStore — Implementation Plan (small PRs)
+
+Branch: `feat/frame-store` off `next`. Each PR is small, independently green (pytest + flake8 + mypy), and mutation-verified (mutate the production line, confirm a test fails).
+
+Guiding rule: **the store is a pure cache** — it holds frames, reports hits/misses, evicts. It never decodes. `video_manager` orchestrates: on a miss it decodes via a reader and stores the frame. This keeps `frame_store` ffmpeg-free and unit-testable in isolation.
+
+---
+
+## PR 1 — `frame_store` module (pure cache, unused)
+
+**Goal:** land the store in isolation, no app behavior change.
+
+**Changes**
+- New `facefusion/frame_store.py`. Keyed by `source` (file_path for now), then `frame_number`.
+- Functions: `get_frame_store`, `store_frame`, `read_frame_range`, `evict_frames`, `clear_frame_store`.
+- `read_frame_range(source, start, end)` returns the cached frames in range; `evict_frames` drops frames outside the live range.
+- Types in `types.py`: `FrameStore`, `FrameStoreSet`.
+
+**Tests** — `tests/test_frame_store.py` (no ffmpeg, pure/fast)
+- `test_store_frame` — stored frame is retrievable.
+- `test_read_frame_range` — returns exactly the cached numbers in `[start, end]`, gaps reported/absent.
+- `test_read_frame_range_overlap` — second overlapping range reuses already-stored frames (same object, no duplicate store).
+- `test_evict_frames` — frames outside the live range are dropped, inside are kept.
+- `test_clear_frame_store` — empties the store.
+
+**Merge bar:** unit tests green + mutation-verified; module unused elsewhere.
+
+---
+
+## PR 2 — window read via the store; drop `frame_set` from the reader
+
+**Goal:** `read_video_reader_window` uses `frame_store` instead of the reader's inline cache.
+
+**Changes**
+- `read_video_reader_window` becomes an orchestrator: ask the store for the range, decode misses via the reader, `store_frame`, return the range.
+- Remove `frame_set` from `VideoReader` (types) and from `get_reader`/`refresh_video_reader`.
+- `clear_video_pool` also calls `clear_frame_store`.
+
+**Tests** — update `tests/test_video_manager.py`
+- Keep `test_read_video_reader_window` (range correctness) and `test_evict_video_reader_buffer` (rewired to the store) — must stay green.
+- Add `test_read_video_reader_window_reuse` — reading `[0,4]` then `[2,6]` decodes `2,3,4` only once (assert via frame identity / a decode spy).
+- Strengthen assertions (Henry's note) — drop the `question if the assertions are good` todos on the tests reworked here.
+
+**Merge bar:** `video_manager`-contained; green + mutation-verified.
+
+---
+
+## PR 3 — chunk read via the store; delete the lru cache + 11 `cache_clear()` lines
+
+**Goal:** collapse the second cache into the store.
+
+**Changes**
+- `read_video_chunk` (vision) becomes a store range read (thin caller of the same primitive as the window read).
+- Remove the `lru_cache` on `read_static_video_chunk`.
+- Delete the 11 processor `read_static_video_chunk.cache_clear()` lines — the store clears via `clear_video_pool()`, which each processor already calls next to it.
+
+**Tests**
+- `tests/test_vision.py` chunk tests — chunk range correctness preserved; add a reuse assertion shared with the window path.
+- Sanity: a processor teardown still clears frames (one integration assertion that the store is empty after `clear_video_pool`).
+
+**Merge bar:** wide but shallow (deletions only in processors); full suite green.
+
+---
+
+## PR 4 — dumb readers, simplify the seek heuristics
+
+**Goal:** now that the store owns caching, shrink the single-cursor seek dance.
+
+**Changes**
+- Simplify/retire `conditional_set_video_reader_position` skip-margin + `refresh` coupling where the store now covers reuse.
+- Reader settles to `{process, file_path, metadata, position}`.
+
+**Tests**
+- Keep the process-identity proof test (forward-skip keeps the process, out-of-range refresh kills it → `returncode == -9`).
+- Adjust for any retired functions; mutation-verify the remaining seek path.
+
+**Merge bar:** `video_manager`-contained; green.
+
+---
+
+## PR 5 — (deferred) id-keyed multiple readers
+
+**Goal:** multiple independent cursors per file → kill seek thrash for good.
+
+**Decision required first:** do we actually want multiplicity? Adds id-keyed pools + lifecycle sync (fights "avoid globals"). Only do it if phase-4 seek behavior is still a real bottleneck.
+
+**Tests:** two readers on one file advance independently; store overlap dedups across them.
+
+---
+
+## PR A — (independent, parallel) writer metadata fix
+
+Not part of the store, but Henry's earlier review still stands and it can merge on its own.
+
+**Changes**
+- `VideoWriterMetadata` (`temp_video_fps`, `temp_video_resolution`, `output_video_resolution`, `output_video_fps`).
+- `VideoWriter = {process, file_path, metadata: VideoWriterMetadata}`; drop the target-metadata (`ffprobe`) transfer.
+- `get_writer(target_path, video_writer_metadata)`; update the one caller.
+
+**Tests**
+- `test_get_writer` — asserts `file_path` and `metadata` are stored (self-describing) + pooling identity.
+
+**Merge bar:** green; independent of the store PRs.
+
+---
+
+## Order & sequencing
+1. **PR 1** (store, isolated) — safest first.
+2. **PR 2** (window) and **PR 3** (chunk) — after PR 1; sequence PR 2 → PR 3.
+3. **PR 4** (dumb readers) — after 2 and 3.
+4. **PR 5** — only if multiplicity is confirmed.
+5. **PR A** (writer) — anytime, independent.
+
+Each PR: never commit without request; run `flake8 facefusion tests`, `mypy facefusion.py install.py`, and `pytest` before marking done.

--- a/docs/framestore_summary.md
+++ b/docs/framestore_summary.md
@@ -1,0 +1,26 @@
+# FrameStore — Short Version
+
+## Idea
+One shared shelf of decoded frames inside `video_manager`, keyed by `(source, frame_number)`. Everyone asks it for frames; it decodes misses via a dumb reader and reuses the rest.
+
+## Why
+Today there are two frame caches doing the same job (`read_video_chunk` lru + `read_video_reader_window` frame_set), plus messy single-cursor seek rules. The store replaces all of it with one owner.
+
+## What changes
+- Readers become dumb forward decoders (no cache).
+- `read_video_chunk` + `read_video_reader_window` → one range read.
+- Cache, overlaps, and eviction live in the store.
+- Store clears via `clear_video_pool()` → delete 11 processor `cache_clear()` lines.
+
+## Scope
+Mostly inside `video_manager`. The only outside touch is removing those 11 `cache_clear()` lines. Public read functions keep their signatures.
+
+## Open question
+Multiple readers per file (id key) — only if we want independent cursors to kill seek thrash. Deferred.
+
+## Order
+1. Writer PR — done.
+2. FrameStore (contained).
+3. Optional: multiple readers.
+
+Full version: [framestore_architecture.md](framestore_architecture.md)

--- a/facefusion/frame_store.py
+++ b/facefusion/frame_store.py
@@ -1,0 +1,38 @@
+from facefusion.types import FrameStoreSet, VisionFrame, VisionFrameSet
+
+FRAME_STORE_SET : FrameStoreSet = {}
+
+
+def get_frame_store(source : str) -> VisionFrameSet:
+	if source not in FRAME_STORE_SET:
+		FRAME_STORE_SET[source] = {}
+
+	return FRAME_STORE_SET.get(source)
+
+
+def store_frame(source : str, frame_number : int, vision_frame : VisionFrame) -> None:
+	frame_store = get_frame_store(source)
+	frame_store[frame_number] = vision_frame
+
+
+def read_frame_range(source : str, frame_start : int, frame_end : int) -> VisionFrameSet:
+	frame_store = get_frame_store(source)
+	frame_set = {}
+
+	for frame_number in range(frame_start, frame_end + 1):
+		if frame_number in frame_store:
+			frame_set[frame_number] = frame_store.get(frame_number)
+
+	return frame_set
+
+
+def evict_frames(source : str, frame_min : int) -> None:
+	frame_store = get_frame_store(source)
+
+	for frame_number in list(frame_store):
+		if frame_number < frame_min:
+			del frame_store[frame_number]
+
+
+def clear_frame_store() -> None:
+	FRAME_STORE_SET.clear()

--- a/facefusion/frame_store.py
+++ b/facefusion/frame_store.py
@@ -26,12 +26,16 @@ def read_frame_range(source : str, frame_start : int, frame_end : int) -> Vision
 	return frame_set
 
 
-def evict_frames(source : str, frame_min : int) -> None:
+def evict_frames(source : str, frame_min : int, frame_max : int) -> None:
 	frame_store = get_frame_store(source)
+	keep_range = range(frame_min, frame_max + 1)
+	frame_set = {}
 
-	for frame_number in list(frame_store):
-		if frame_number < frame_min:
-			del frame_store[frame_number]
+	for frame_number in frame_store:
+		if frame_number in keep_range:
+			frame_set[frame_number] = frame_store.get(frame_number)
+
+	FRAME_STORE_SET[source] = frame_set
 
 
 def clear_frame_store() -> None:

--- a/facefusion/types.py
+++ b/facefusion/types.py
@@ -130,8 +130,7 @@ VideoReader = TypedDict('VideoReader',
 	'process' : subprocess.Popen[bytes],
 	'file_path' : str,
 	'metadata' : VideoMetadata,
-	'position' : int,
-	'frame_set' : VisionFrameSet
+	'position' : int
 })
 VideoReaderSet : TypeAlias = Dict[str, VideoReader]
 VideoWriter = TypedDict('VideoWriter',
@@ -146,6 +145,7 @@ VideoPoolSet = TypedDict('VideoPoolSet',
 	'reader' : VideoReaderSet,
 	'writer' : VideoWriterSet
 })
+FrameStoreSet : TypeAlias = Dict[str, VisionFrameSet]
 
 ProcessState = Literal['checking', 'processing', 'stopping', 'pending']
 Args : TypeAlias = Dict[str, Any]

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -66,18 +66,22 @@ def read_video_reader_window(video_reader : VideoReader, frame_start : int, fram
 	source = video_reader.get('file_path')
 	frame_set = frame_store.get_frame_store(source)
 	buffer_margin = 16
+	missing_numbers = [ frame_number for frame_number in range(frame_start, frame_end + 1) if frame_number not in frame_set ]
 
-	if frame_start not in frame_set and (frame_start < video_reader.get('position') or frame_start > video_reader.get('position') + buffer_margin):
-		refresh_video_reader(video_reader, frame_start)
+	if missing_numbers:
+		frame_position = missing_numbers[0]
 
-	for frame_number in range(video_reader.get('position'), frame_end + 1):
-		vision_frame = read_video_reader_frame(video_reader)
+		if frame_position < video_reader.get('position') or frame_position > video_reader.get('position') + buffer_margin:
+			refresh_video_reader(video_reader, frame_position)
 
-		if numpy.any(vision_frame):
-			frame_store.store_frame(source, frame_number, vision_frame)
+		for frame_number in range(video_reader.get('position'), missing_numbers[-1] + 1):
+			vision_frame = read_video_reader_frame(video_reader)
 
-	frame_store.evict_frames(source, frame_start - buffer_margin)
-	return frame_set
+			if numpy.any(vision_frame):
+				frame_store.store_frame(source, frame_number, vision_frame)
+
+	frame_store.evict_frames(source, frame_start - buffer_margin, frame_end + buffer_margin)
+	return frame_store.read_frame_range(source, frame_start, frame_end)
 
 
 #todo: needs review - [lifecycle] [critical: low] pooled writer keyed by target_path, metadata forwarded by the caller

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import numpy
 
-from facefusion import ffmpeg, ffprobe
+from facefusion import ffmpeg, ffprobe, frame_store
 from facefusion.types import Fps, Resolution, VideoMetadata, VideoPoolSet, VideoReader, VideoWriter, VisionFrame, VisionFrameSet
 
 VIDEO_POOL_SET : VideoPoolSet =\
@@ -22,8 +22,7 @@ def get_reader(video_path : str) -> VideoReader:
 			'process': ffmpeg.create_video_reader(video_path, 0, video_metadata),
 			'file_path': video_path,
 			'metadata': video_metadata,
-			'position': 0,
-			'frame_set': {}
+			'position': 0
 		}
 
 	return VIDEO_POOL_SET.get('reader').get(video_path)
@@ -48,7 +47,6 @@ def refresh_video_reader(video_reader : VideoReader, frame_position : int) -> No
 	video_reader.get('process').wait()
 	video_reader['process'] = ffmpeg.create_video_reader(video_reader.get('file_path'), frame_position, video_reader.get('metadata'))
 	video_reader['position'] = frame_position
-	video_reader['frame_set'].clear()
 
 
 #todo: needs review - [decoding] [critical: high] partial pipe read returns none and desyncs position from the actual stream
@@ -65,7 +63,8 @@ def read_video_reader_frame(video_reader : VideoReader) -> Optional[VisionFrame]
 
 #todo: needs review - [memory] [critical: high] frame_set keeps decoded frames in ram, eviction only trims below frame_start minus buffer_margin
 def read_video_reader_window(video_reader : VideoReader, frame_start : int, frame_end : int) -> VisionFrameSet:
-	frame_set = video_reader.get('frame_set')
+	source = video_reader.get('file_path')
+	frame_set = frame_store.get_frame_store(source)
 	buffer_margin = 16
 
 	if frame_start not in frame_set and (frame_start < video_reader.get('position') or frame_start > video_reader.get('position') + buffer_margin):
@@ -75,12 +74,9 @@ def read_video_reader_window(video_reader : VideoReader, frame_start : int, fram
 		vision_frame = read_video_reader_frame(video_reader)
 
 		if numpy.any(vision_frame):
-			frame_set[frame_number] = vision_frame
+			frame_store.store_frame(source, frame_number, vision_frame)
 
-	for frame_number in list(frame_set):
-		if frame_number < frame_start - buffer_margin:
-			del frame_set[frame_number]
-
+	frame_store.evict_frames(source, frame_start - buffer_margin)
 	return frame_set
 
 
@@ -121,3 +117,4 @@ def clear_video_pool() -> None:
 
 	VIDEO_POOL_SET['reader'].clear()
 	VIDEO_POOL_SET['writer'].clear()
+	frame_store.clear_frame_store()

--- a/poc_aa.py
+++ b/poc_aa.py
@@ -1,0 +1,82 @@
+import statistics
+import time
+
+import numpy
+
+from facefusion import process_manager, state_manager, video_manager
+
+FRAME_STORE_SET = {}
+BUFFER_MARGIN = 16
+FRAME_OFFSET = 2
+REPEAT = 8
+
+
+def run_current(video_path, frame_total):
+	video_manager.clear_video_pool()
+	video_reader = video_manager.get_reader(video_path)
+
+	for frame_number in range(frame_total):
+		video_manager.read_video_reader_window(video_reader, max(frame_number - FRAME_OFFSET, 0), frame_number + FRAME_OFFSET)
+
+
+def run_store(video_path, frame_total):
+	video_manager.clear_video_pool()
+	FRAME_STORE_SET.clear()
+	video_reader = video_manager.get_reader(video_path)
+
+	for frame_number in range(frame_total):
+		frame_start = max(frame_number - FRAME_OFFSET, 0)
+		frame_end = frame_number + FRAME_OFFSET
+
+		if video_path not in FRAME_STORE_SET:
+			FRAME_STORE_SET[video_path] = {}
+		frame_store = FRAME_STORE_SET.get(video_path)
+
+		if frame_start not in frame_store and (frame_start < video_reader.get('position') or frame_start > video_reader.get('position') + BUFFER_MARGIN):
+			video_manager.refresh_video_reader(video_reader, frame_start)
+
+		for window_number in range(video_reader.get('position'), frame_end + 1):
+			vision_frame = video_manager.read_video_reader_frame(video_reader)
+
+			if numpy.any(vision_frame):
+				frame_store[window_number] = vision_frame
+
+		for window_number in list(frame_store):
+			if window_number < frame_start - BUFFER_MARGIN:
+				del frame_store[window_number]
+
+
+def measure(run, video_path, frame_total):
+	start_time = time.perf_counter()
+	run(video_path, frame_total)
+	return time.perf_counter() - start_time
+
+
+def main():
+	state_manager.init_item('temp_pixel_format', 'bgr24')
+	process_manager.start()
+	video_path = '.assets/examples/target-240p.mp4'
+	frame_total = 250
+
+	measure(run_current, video_path, frame_total)
+	measure(run_store, video_path, frame_total)
+
+	a1 = []
+	a2 = []
+	b = []
+
+	for _ in range(REPEAT):
+		a1.append(measure(run_current, video_path, frame_total))
+		a2.append(measure(run_current, video_path, frame_total))
+		b.append(measure(run_store, video_path, frame_total))
+
+	print('current-A median:', round(statistics.median(a1), 4))
+	print('current-B median:', round(statistics.median(a2), 4))
+	print('store    median:', round(statistics.median(b), 4))
+	print('A/A delta:', round((statistics.median(a2) - statistics.median(a1)) / statistics.median(a1) * 100, 1), '%')
+	print('A/store delta:', round((statistics.median(b) - statistics.median(a1)) / statistics.median(a1) * 100, 1), '%')
+	print('all current runs:', [ round(value, 3) for value in a1 + a2 ])
+	print('all store runs:', [ round(value, 3) for value in b ])
+
+
+main()

--- a/poc_frame_store.py
+++ b/poc_frame_store.py
@@ -1,0 +1,151 @@
+import statistics
+import time
+from typing import Dict, List, Tuple
+
+import numpy
+
+from facefusion import process_manager, state_manager, video_manager
+from facefusion.types import VideoReader, VisionFrame, VisionFrameSet
+
+FRAME_STORE_SET : Dict[str, VisionFrameSet] = {}
+
+BUFFER_MARGIN = 16
+FRAME_OFFSET = 2
+REPEAT = 6
+
+
+def get_frame_store(source : str) -> VisionFrameSet:
+	if source not in FRAME_STORE_SET:
+		FRAME_STORE_SET[source] = {}
+
+	return FRAME_STORE_SET.get(source)
+
+
+def clear_frame_store() -> None:
+	FRAME_STORE_SET.clear()
+
+
+def read_window_current(video_reader : VideoReader, frame_start : int, frame_end : int) -> VisionFrameSet:
+	return video_manager.read_video_reader_window(video_reader, frame_start, frame_end)
+
+
+def read_window_store(video_reader : VideoReader, source : str, frame_start : int, frame_end : int) -> VisionFrameSet:
+	frame_store = get_frame_store(source)
+
+	if frame_start not in frame_store and (frame_start < video_reader.get('position') or frame_start > video_reader.get('position') + BUFFER_MARGIN):
+		video_manager.refresh_video_reader(video_reader, frame_start)
+
+	for frame_number in range(video_reader.get('position'), frame_end + 1):
+		vision_frame = video_manager.read_video_reader_frame(video_reader)
+
+		if numpy.any(vision_frame):
+			frame_store[frame_number] = vision_frame
+
+	for frame_number in list(frame_store):
+		if frame_number < frame_start - BUFFER_MARGIN:
+			del frame_store[frame_number]
+
+	return frame_store
+
+
+def select_window(frame_set : VisionFrameSet, frame_number : int) -> List[VisionFrame]:
+	vision_frames = []
+
+	for window_number in range(frame_number - FRAME_OFFSET, frame_number + FRAME_OFFSET + 1):
+		if window_number in frame_set:
+			vision_frames.append(frame_set.get(window_number))
+
+	return vision_frames
+
+
+def run_current(video_path : str, frame_total : int) -> List[List[VisionFrame]]:
+	video_manager.clear_video_pool()
+	video_reader = video_manager.get_reader(video_path)
+	collected = []
+
+	for frame_number in range(frame_total):
+		frame_set = read_window_current(video_reader, max(frame_number - FRAME_OFFSET, 0), frame_number + FRAME_OFFSET)
+		collected.append(select_window(frame_set, frame_number))
+
+	return collected
+
+
+def run_store(video_path : str, frame_total : int) -> List[List[VisionFrame]]:
+	video_manager.clear_video_pool()
+	clear_frame_store()
+	video_reader = video_manager.get_reader(video_path)
+	collected = []
+
+	for frame_number in range(frame_total):
+		frame_set = read_window_store(video_reader, video_path, max(frame_number - FRAME_OFFSET, 0), frame_number + FRAME_OFFSET)
+		collected.append(select_window(frame_set, frame_number))
+
+	return collected
+
+
+def measure(run, video_path : str, frame_total : int) -> float:
+	start_time = time.perf_counter()
+	run(video_path, frame_total)
+	return time.perf_counter() - start_time
+
+
+def verify_equal(video_path : str, frame_total : int) -> bool:
+	current_windows = run_current(video_path, frame_total)
+	store_windows = run_store(video_path, frame_total)
+	equal = True
+
+	for frame_number in range(frame_total):
+		current_middle = current_windows[frame_number][len(current_windows[frame_number]) // 2]
+		store_middle = store_windows[frame_number][len(store_windows[frame_number]) // 2]
+
+		if not numpy.array_equal(current_middle, store_middle):
+			equal = False
+
+	return equal
+
+
+def benchmark(video_path : str) -> Tuple[float, float, int]:
+	video_manager.clear_video_pool()
+	video_reader = video_manager.get_reader(video_path)
+	frame_total = min(video_reader.get('metadata').get('frame_total'), 250)
+
+	measure(run_current, video_path, frame_total)
+	measure(run_store, video_path, frame_total)
+	current_runs = []
+	store_runs = []
+
+	for repeat_number in range(REPEAT):
+		if repeat_number % 2 == 0:
+			current_runs.append(measure(run_current, video_path, frame_total))
+			store_runs.append(measure(run_store, video_path, frame_total))
+		if repeat_number % 2 == 1:
+			store_runs.append(measure(run_store, video_path, frame_total))
+			current_runs.append(measure(run_current, video_path, frame_total))
+
+	return statistics.median(current_runs), statistics.median(store_runs), frame_total
+
+
+def main() -> None:
+	state_manager.init_item('temp_pixel_format', 'bgr24')
+	process_manager.start()
+
+	video_paths =\
+	[
+		'.assets/examples/target-240p.mp4',
+		'.assets/examples/target-720p.mp4',
+		'.assets/examples/target-1080p.mp4'
+	]
+
+	print('video'.ljust(38), 'frames'.rjust(7), 'current(s)'.rjust(12), 'store(s)'.rjust(12), 'delta'.rjust(9), 'equal'.rjust(7))
+
+	for video_path in video_paths:
+		current_median, store_median, frame_total = benchmark(video_path)
+		equal = verify_equal(video_path, frame_total)
+		delta = (store_median - current_median) / current_median * 100
+		print(video_path.ljust(38), str(frame_total).rjust(7), f'{current_median:.4f}'.rjust(12), f'{store_median:.4f}'.rjust(12), f'{delta:+.1f}%'.rjust(9), str(equal).rjust(7))
+
+	video_manager.clear_video_pool()
+	clear_frame_store()
+
+
+main()

--- a/poc_instrument.py
+++ b/poc_instrument.py
@@ -1,0 +1,82 @@
+import numpy
+
+from facefusion import process_manager, state_manager, video_manager
+from facefusion.types import VideoReader, VisionFrameSet
+
+FRAME_STORE_SET = {}
+COUNTER = { 'decode': 0, 'refresh': 0 }
+
+BUFFER_MARGIN = 16
+FRAME_OFFSET = 2
+
+real_read_frame = video_manager.read_video_reader_frame
+real_refresh = video_manager.refresh_video_reader
+
+
+def counting_read_frame(video_reader : VideoReader):
+	COUNTER['decode'] = COUNTER.get('decode') + 1
+	return real_read_frame(video_reader)
+
+
+def counting_refresh(video_reader : VideoReader, frame_position : int) -> None:
+	COUNTER['refresh'] = COUNTER.get('refresh') + 1
+	real_refresh(video_reader, frame_position)
+
+
+video_manager.read_video_reader_frame = counting_read_frame
+video_manager.refresh_video_reader = counting_refresh
+
+
+def run_current(video_path : str, frame_total : int) -> None:
+	video_manager.clear_video_pool()
+	video_reader = video_manager.get_reader(video_path)
+
+	for frame_number in range(frame_total):
+		video_manager.read_video_reader_window(video_reader, max(frame_number - FRAME_OFFSET, 0), frame_number + FRAME_OFFSET)
+
+
+def run_store(video_path : str, frame_total : int) -> None:
+	video_manager.clear_video_pool()
+	FRAME_STORE_SET.clear()
+	video_reader = video_manager.get_reader(video_path)
+
+	for frame_number in range(frame_total):
+		frame_start = max(frame_number - FRAME_OFFSET, 0)
+		frame_end = frame_number + FRAME_OFFSET
+
+		if video_path not in FRAME_STORE_SET:
+			FRAME_STORE_SET[video_path] = {}
+		frame_store = FRAME_STORE_SET.get(video_path)
+
+		if frame_start not in frame_store and (frame_start < video_reader.get('position') or frame_start > video_reader.get('position') + BUFFER_MARGIN):
+			video_manager.refresh_video_reader(video_reader, frame_start)
+
+		for window_number in range(video_reader.get('position'), frame_end + 1):
+			vision_frame = video_manager.read_video_reader_frame(video_reader)
+
+			if numpy.any(vision_frame):
+				frame_store[window_number] = vision_frame
+
+		for window_number in list(frame_store):
+			if window_number < frame_start - BUFFER_MARGIN:
+				del frame_store[window_number]
+
+
+def main() -> None:
+	state_manager.init_item('temp_pixel_format', 'bgr24')
+	process_manager.start()
+	video_path = '.assets/examples/target-240p.mp4'
+	frame_total = 250
+
+	COUNTER['decode'] = 0
+	COUNTER['refresh'] = 0
+	run_current(video_path, frame_total)
+	print('current -> decodes:', COUNTER.get('decode'), 'refreshes:', COUNTER.get('refresh'))
+
+	COUNTER['decode'] = 0
+	COUNTER['refresh'] = 0
+	run_store(video_path, frame_total)
+	print('store   -> decodes:', COUNTER.get('decode'), 'refreshes:', COUNTER.get('refresh'))
+
+
+main()

--- a/poc_memory.py
+++ b/poc_memory.py
@@ -1,0 +1,74 @@
+import numpy
+
+from facefusion import process_manager, state_manager, video_manager
+
+FRAME_STORE_SET = {}
+BUFFER_MARGIN = 16
+FRAME_OFFSET = 2
+
+
+def frame_set_bytes(frame_set) -> int:
+	return sum(vision_frame.nbytes for vision_frame in frame_set.values())
+
+
+def run_current(video_path, frame_total):
+	video_manager.clear_video_pool()
+	video_reader = video_manager.get_reader(video_path)
+	peak_count = 0
+	peak_bytes = 0
+
+	for frame_number in range(frame_total):
+		frame_set = video_manager.read_video_reader_window(video_reader, max(frame_number - FRAME_OFFSET, 0), frame_number + FRAME_OFFSET)
+		peak_count = max(peak_count, len(frame_set))
+		peak_bytes = max(peak_bytes, frame_set_bytes(frame_set))
+
+	return peak_count, peak_bytes
+
+
+def run_store(video_path, frame_total):
+	video_manager.clear_video_pool()
+	FRAME_STORE_SET.clear()
+	video_reader = video_manager.get_reader(video_path)
+	peak_count = 0
+	peak_bytes = 0
+
+	for frame_number in range(frame_total):
+		frame_start = max(frame_number - FRAME_OFFSET, 0)
+		frame_end = frame_number + FRAME_OFFSET
+
+		if video_path not in FRAME_STORE_SET:
+			FRAME_STORE_SET[video_path] = {}
+		frame_store = FRAME_STORE_SET.get(video_path)
+
+		if frame_start not in frame_store and (frame_start < video_reader.get('position') or frame_start > video_reader.get('position') + BUFFER_MARGIN):
+			video_manager.refresh_video_reader(video_reader, frame_start)
+
+		for window_number in range(video_reader.get('position'), frame_end + 1):
+			vision_frame = video_manager.read_video_reader_frame(video_reader)
+
+			if numpy.any(vision_frame):
+				frame_store[window_number] = vision_frame
+
+		for window_number in list(frame_store):
+			if window_number < frame_start - BUFFER_MARGIN:
+				del frame_store[window_number]
+
+		peak_count = max(peak_count, len(frame_store))
+		peak_bytes = max(peak_bytes, frame_set_bytes(frame_store))
+
+	return peak_count, peak_bytes
+
+
+def main():
+	state_manager.init_item('temp_pixel_format', 'bgr24')
+	process_manager.start()
+
+	for video_path in [ '.assets/examples/target-240p.mp4', '.assets/examples/target-1080p.mp4' ]:
+		current_count, current_bytes = run_current(video_path, 250)
+		store_count, store_bytes = run_store(video_path, 250)
+		print(video_path)
+		print('  current peak frames:', current_count, 'peak MB:', round(current_bytes / 1024 ** 2, 1))
+		print('  store   peak frames:', store_count, 'peak MB:', round(store_bytes / 1024 ** 2, 1))
+
+
+main()

--- a/poc_random.py
+++ b/poc_random.py
@@ -1,0 +1,100 @@
+import random
+import time
+
+import numpy
+
+from facefusion import frame_store, process_manager, state_manager, video_manager
+from facefusion.types import VideoReader
+
+COUNTER = { 'decode': 0, 'refresh': 0 }
+BUFFER_MARGIN = 16
+
+real_read_frame = video_manager.read_video_reader_frame
+real_refresh = video_manager.refresh_video_reader
+
+
+def counting_read_frame(video_reader : VideoReader):
+	COUNTER['decode'] = COUNTER.get('decode') + 1
+	return real_read_frame(video_reader)
+
+
+def counting_refresh(video_reader : VideoReader, frame_position : int) -> None:
+	COUNTER['refresh'] = COUNTER.get('refresh') + 1
+	real_refresh(video_reader, frame_position)
+
+
+video_manager.read_video_reader_frame = counting_read_frame
+video_manager.refresh_video_reader = counting_refresh
+
+
+def baseline_read(video_reader : VideoReader, frame_cache, frame_number : int):
+	if frame_number not in frame_cache and (frame_number < video_reader.get('position') or frame_number > video_reader.get('position') + BUFFER_MARGIN):
+		video_manager.refresh_video_reader(video_reader, frame_number)
+		frame_cache.clear()
+
+	for window_number in range(video_reader.get('position'), frame_number + 1):
+		vision_frame = video_manager.read_video_reader_frame(video_reader)
+
+		if numpy.any(vision_frame):
+			frame_cache[window_number] = vision_frame
+
+	for window_number in list(frame_cache):
+		if window_number < frame_number - BUFFER_MARGIN:
+			del frame_cache[window_number]
+
+	return frame_cache.get(frame_number)
+
+
+def store_read(video_reader : VideoReader, frame_number : int):
+	return video_manager.read_video_reader_window(video_reader, frame_number, frame_number).get(frame_number)
+
+
+def cache_mb(frame_cache) -> float:
+	return sum(vision_frame.nbytes for vision_frame in frame_cache.values()) / 1024 ** 2
+
+
+def run(video_path : str, frame_numbers, mode : str):
+	video_manager.clear_video_pool()
+	video_reader = video_manager.get_reader(video_path)
+	frame_cache = {}
+	peak_mb = 0.0
+	COUNTER['decode'] = 0
+	COUNTER['refresh'] = 0
+	start_time = time.perf_counter()
+
+	for frame_number in frame_numbers:
+		if mode == 'baseline':
+			baseline_read(video_reader, frame_cache, frame_number)
+			peak_mb = max(peak_mb, cache_mb(frame_cache))
+		if mode == 'store':
+			store_read(video_reader, frame_number)
+			peak_mb = max(peak_mb, cache_mb(frame_store.get_frame_store(video_path)))
+
+	return COUNTER.get('decode'), COUNTER.get('refresh'), round(time.perf_counter() - start_time, 3), round(peak_mb, 1)
+
+
+def report(title : str, video_path : str, frame_numbers) -> None:
+	base = run(video_path, frame_numbers, 'baseline')
+	store = run(video_path, frame_numbers, 'store')
+	print(title)
+	print('  baseline -> decodes:', base[0], 'refreshes:', base[1], 'time:', base[2], 'peak MB:', base[3])
+	print('  store    -> decodes:', store[0], 'refreshes:', store[1], 'time:', store[2], 'peak MB:', store[3])
+
+
+def main() -> None:
+	state_manager.init_item('temp_pixel_format', 'bgr24')
+	process_manager.start()
+	video_path = '.assets/examples/target-1080p.mp4'
+	frame_total = 250
+
+	random.seed(42)
+	sequential = list(range(frame_total))
+	random_small = [ random.randint(0, 60) for _ in range(frame_total) ]
+	random_wide = [ random.randint(0, frame_total - 1) for _ in range(frame_total) ]
+
+	report('sequential (control)', video_path, sequential)
+	report('random within 0-60 (revisits)', video_path, random_small)
+	report('random within 0-249 (wide)', video_path, random_wide)
+
+
+main()

--- a/poc_real.py
+++ b/poc_real.py
@@ -1,0 +1,92 @@
+import time
+
+from facefusion import process_manager, state_manager, video_manager
+from facefusion.types import VideoReader
+
+FRAME_STORE_SET = {}
+COUNTER = { 'decode': 0, 'refresh': 0 }
+WORKING_SET = 60
+PASSES = 3
+
+real_read_frame = video_manager.read_video_reader_frame
+real_refresh = video_manager.refresh_video_reader
+
+
+def counting_read_frame(video_reader : VideoReader):
+	COUNTER['decode'] = COUNTER.get('decode') + 1
+	return real_read_frame(video_reader)
+
+
+def counting_refresh(video_reader : VideoReader, frame_position : int) -> None:
+	COUNTER['refresh'] = COUNTER.get('refresh') + 1
+	real_refresh(video_reader, frame_position)
+
+
+video_manager.read_video_reader_frame = counting_read_frame
+video_manager.refresh_video_reader = counting_refresh
+
+
+def read_frame_current(video_reader : VideoReader, frame_number : int):
+	frame_set = video_manager.read_video_reader_window(video_reader, frame_number, frame_number)
+	return frame_set.get(frame_number)
+
+
+def read_frame_store(video_reader : VideoReader, source : str, frame_number : int):
+	if source not in FRAME_STORE_SET:
+		FRAME_STORE_SET[source] = {}
+	frame_store = FRAME_STORE_SET.get(source)
+
+	if frame_number in frame_store:
+		return frame_store.get(frame_number)
+
+	video_manager.conditional_set_video_reader_position(video_reader, frame_number)
+	vision_frame = video_manager.read_video_reader_frame(video_reader)
+	frame_store[frame_number] = vision_frame
+	return vision_frame
+
+
+def run_current(video_path : str):
+	video_manager.clear_video_pool()
+	video_reader = video_manager.get_reader(video_path)
+
+	for _ in range(PASSES):
+		for frame_number in range(WORKING_SET):
+			read_frame_current(video_reader, frame_number)
+
+
+def run_store(video_path : str):
+	video_manager.clear_video_pool()
+	FRAME_STORE_SET.clear()
+	video_reader = video_manager.get_reader(video_path)
+
+	for _ in range(PASSES):
+		for frame_number in range(WORKING_SET):
+			read_frame_store(video_reader, video_path, frame_number)
+
+
+def peak_store_mb() -> float:
+	frame_store = FRAME_STORE_SET.get('.assets/examples/target-1080p.mp4')
+	return sum(vision_frame.nbytes for vision_frame in frame_store.values()) / 1024 ** 2
+
+
+def main() -> None:
+	state_manager.init_item('temp_pixel_format', 'bgr24')
+	process_manager.start()
+	video_path = '.assets/examples/target-1080p.mp4'
+
+	COUNTER['decode'] = 0
+	COUNTER['refresh'] = 0
+	start_time = time.perf_counter()
+	run_current(video_path)
+	current_time = time.perf_counter() - start_time
+	print('current -> decodes:', COUNTER.get('decode'), 'refreshes:', COUNTER.get('refresh'), 'time:', round(current_time, 3))
+
+	COUNTER['decode'] = 0
+	COUNTER['refresh'] = 0
+	start_time = time.perf_counter()
+	run_store(video_path)
+	store_time = time.perf_counter() - start_time
+	print('store   -> decodes:', COUNTER.get('decode'), 'refreshes:', COUNTER.get('refresh'), 'time:', round(store_time, 3), 'peak MB:', round(peak_store_mb(), 1))
+
+
+main()

--- a/tests/test_video_manager.py
+++ b/tests/test_video_manager.py
@@ -6,6 +6,7 @@ import pytest
 from facefusion import ffmpeg, ffmpeg_builder, process_manager, state_manager
 from facefusion.download import conditional_download
 from facefusion.ffprobe import extract_video_metadata
+from facefusion.frame_store import get_frame_store
 from facefusion.temp_helper import create_temp_directory, get_temp_file_path
 from facefusion.video_manager import clear_video_pool, close_video_writer, conditional_set_video_reader_position, get_reader, get_writer, read_video_reader_frame, read_video_reader_window, refresh_video_reader, write_video_writer_frame
 from .helper import get_test_example_file, get_test_examples_directory
@@ -126,10 +127,10 @@ def test_read_video_reader_window() -> None:
 def test_evict_video_reader_buffer() -> None:
 	video_reader = get_reader(get_test_example_file('target-240p-25fps.mp4'))
 	read_video_reader_window(video_reader, 0, 4)
-	frame_set = read_video_reader_window(video_reader, 21, 25)
+	read_video_reader_window(video_reader, 21, 25)
 
-	assert min(frame_set) == 5
-	assert max(frame_set) == 25
+	assert min(get_frame_store(video_reader.get('file_path'))) == 5
+	assert max(get_frame_store(video_reader.get('file_path'))) == 25
 
 
 #todo: needs review - [testing] question if the assertions are good


### PR DESCRIPTION
read_video_reader_window now uses frame_store instead of the reader's inline frame_set. Reader becomes a dumb decoder (no cache); refresh no longer clears (frames stay valid by number).                                                                              
                                                                                                                                                                                                                                                                         
  Smarter read: scan gaps → seek to first gap via refresh → decode the gap only → bounded prune → return the range. Cached windows decode nothing.                                                                                                                       
                                                                                                                                                                                                                                                                         
  - frame_set dropped from VideoReader; clear_video_pool clears the store                                                                                                                                                                                                
  - vision unchanged (chunk path stays on its lru_cache)                                                                                                                                                                                                                 
  - store keyed by file_path for now (multiple readers later)       