### PR TITLE
shrink frame-store residency with a separate keep_margin

### DIFF
--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -69,6 +69,7 @@ def read_video_reader_window(video_reader : VideoReader, frame_start : int, fram
 	id = video_reader.get('id')
 	frame_set = frame_store.get_frame_store(id)
 	buffer_margin = 16
+	keep_margin = 4
 	frame_gaps = []
 
 	for frame_index in range(frame_start, frame_end + 1):
@@ -88,7 +89,7 @@ def read_video_reader_window(video_reader : VideoReader, frame_start : int, fram
 			if numpy.any(vision_frame):
 				frame_store.set_frame(id, decode_index, vision_frame)
 
-	frame_store.reduce_frames(id, frame_start - buffer_margin, frame_end + buffer_margin)
+	frame_store.reduce_frames(id, frame_start - keep_margin, frame_end + keep_margin)
 	return frame_store.select_frame_set(id, frame_start, frame_end)
 
 

--- a/tests/test_video_manager.py
+++ b/tests/test_video_manager.py
@@ -121,7 +121,7 @@ def test_read_video_reader_window() -> None:
 
 	read_video_reader_window(video_reader, 21, 25)
 
-	assert min(get_frame_store(video_reader.get('id'))) == 5
+	assert min(get_frame_store(video_reader.get('id'))) == 17
 	assert max(get_frame_store(video_reader.get('id'))) == 25
 
 	frame_set = read_video_reader_window(video_reader, 268, 275)


### PR DESCRIPTION
Split the single buffer_margin (16) into two: buffer_margin (seek drain-vs-refresh threshold, stays 16) and keep_margin (eviction window, 4). Sequential reads never look back, so the fat behind-margin was dead weight.                                              
                                                                                                                                                                                                                                                                         
  - Peak resident 25 → 13 frames (~155 → ~81 MB at 1080p), decodes unchanged (254/250 windows)                                                                                                                                                                           
  - Seek threshold untouched → UI-preview jumps still fill instead of respawning                                                                                                                                                                                         
  - Eviction test boundary updated (min 5 → 17)   