### PR TITLE
Pin fp16 models to the Neural Engine and cache compiled CoreML models

### DIFF
--- a/facefusion/processors/modules/face_swapper/core.py
+++ b/facefusion/processors/modules/face_swapper/core.py
@@ -12,12 +12,12 @@ import facefusion.jobs.job_store
 from facefusion import config, content_analyser, face_classifier, face_detector, face_landmarker, face_masker, face_recognizer, inference_manager, logger, state_manager, translator, video_manager
 from facefusion.common_helper import get_first, get_middle, is_macos
 from facefusion.download import conditional_download_hashes, conditional_download_sources, resolve_download_url
-from facefusion.execution import has_execution_provider
+from facefusion.execution import has_execution_provider, resolve_cache_path
 from facefusion.face_creator import average_face_identity, get_one_face, get_static_faces, scale_face
 from facefusion.face_helper import paste_back, warp_face_by_face_landmark_5
 from facefusion.face_masker import create_area_mask, create_box_mask, create_occlusion_mask, create_region_mask
 from facefusion.face_selector import select_faces, sort_faces_by_order
-from facefusion.filesystem import filter_image_paths, has_image, in_directory, is_image, is_video, resolve_relative_path, same_file_extension
+from facefusion.filesystem import create_directory, filter_image_paths, has_image, in_directory, is_directory, is_image, is_video, resolve_relative_path, same_file_extension
 from facefusion.model_helper import get_static_model_initializer
 from facefusion.processors.modules.face_swapper import choices as face_swapper_choices
 from facefusion.processors.modules.face_swapper.types import FaceSwapperInputs
@@ -25,7 +25,7 @@ from facefusion.processors.pixel_boost import explode_pixel_boost, implode_pixel
 from facefusion.processors.types import ProcessorOutputs
 from facefusion.program_helper import find_argument_group
 from facefusion.thread_helper import conditional_thread_semaphore
-from facefusion.types import ApplyStateItem, Args, DownloadScope, Embedding, Face, InferencePool, InferenceProvider, ModelOptions, ModelSet, ProcessMode, VisionFrame
+from facefusion.types import ApplyStateItem, Args, DownloadScope, Embedding, Face, InferenceOptionSet, InferencePool, InferenceProvider, ModelOptions, ModelSet, ProcessMode, VisionFrame
 from facefusion.vision import read_static_image, read_static_images, read_static_video_chunk, read_static_video_frame, unpack_resolution
 
 
@@ -508,13 +508,28 @@ def resolve_inference_providers() -> List[InferenceProvider]:
 
 	if is_macos() and has_execution_provider('coreml'):
 		if model_type in [ 'ghost', 'uniface' ] or model_precision == 'fp16':
+			inference_option_set : InferenceOptionSet =\
+			{
+				'ModelFormat': 'MLProgram',
+				'SpecializationStrategy': 'FastPrediction'
+			}
+			cache_path = resolve_cache_path()
+
+			if model_precision == 'fp16':
+				inference_option_set.update(
+				{
+					'MLComputeUnits': 'CPUAndNeuralEngine'
+				})
+
+			if is_directory(cache_path) or create_directory(cache_path):
+				inference_option_set.update(
+				{
+					'ModelCacheDirectory': cache_path
+				})
+
 			return\
 			[
-				(facefusion.choices.execution_provider_set.get('coreml'),
-				{
-					'ModelFormat': 'MLProgram',
-					'SpecializationStrategy': 'FastPrediction'
-				})
+				(facefusion.choices.execution_provider_set.get('coreml'), inference_option_set)
 			]
 
 	return []

--- a/facefusion/processors/modules/frame_enhancer/core.py
+++ b/facefusion/processors/modules/frame_enhancer/core.py
@@ -12,14 +12,14 @@ import facefusion.jobs.job_store
 from facefusion import config, content_analyser, inference_manager, logger, state_manager, translator, video_manager
 from facefusion.common_helper import create_int_metavar, is_macos
 from facefusion.download import conditional_download_hashes, conditional_download_sources, resolve_download_url
-from facefusion.execution import has_execution_provider
-from facefusion.filesystem import in_directory, is_image, is_video, resolve_relative_path, same_file_extension
+from facefusion.execution import has_execution_provider, resolve_cache_path
+from facefusion.filesystem import create_directory, in_directory, is_directory, is_image, is_video, resolve_relative_path, same_file_extension
 from facefusion.processors.modules.frame_enhancer import choices as frame_enhancer_choices
 from facefusion.processors.modules.frame_enhancer.types import FrameEnhancerInputs
 from facefusion.processors.types import ProcessorOutputs
 from facefusion.program_helper import find_argument_group
 from facefusion.thread_helper import conditional_thread_semaphore
-from facefusion.types import ApplyStateItem, Args, DownloadScope, InferencePool, InferenceProvider, ModelOptions, ModelSet, ProcessMode, VisionFrame
+from facefusion.types import ApplyStateItem, Args, DownloadScope, InferenceOptionSet, InferencePool, InferenceProvider, ModelOptions, ModelSet, ProcessMode, VisionFrame
 from facefusion.vision import blend_frame, create_tile_frames, merge_tile_frames, read_static_image, read_static_video_chunk, read_static_video_frame
 
 
@@ -562,13 +562,23 @@ def resolve_inference_providers() -> List[InferenceProvider]:
 	model_precision = get_model_options().get('precision')
 
 	if is_macos() and has_execution_provider('coreml') and model_precision == 'fp16':
+		inference_option_set : InferenceOptionSet =\
+		{
+			'ModelFormat': 'MLProgram',
+			'SpecializationStrategy': 'FastPrediction',
+			'MLComputeUnits': 'CPUAndNeuralEngine'
+		}
+		cache_path = resolve_cache_path()
+
+		if is_directory(cache_path) or create_directory(cache_path):
+			inference_option_set.update(
+			{
+				'ModelCacheDirectory': cache_path
+			})
+
 		return\
 		[
-			(facefusion.choices.execution_provider_set.get('coreml'),
-			{
-				'ModelFormat': 'MLProgram',
-				'SpecializationStrategy': 'FastPrediction'
-			})
+			(facefusion.choices.execution_provider_set.get('coreml'), inference_option_set)
 		]
 
 	return []


### PR DESCRIPTION
## What

Two additions to the CoreML `MLProgram` provider branches in `face_swapper` and `frame_enhancer`:

1. `MLComputeUnits: CPUAndNeuralEngine` for `fp16` models. The CoreML default (`ALL`) splits the graph between GPU and ANE and pays a transfer penalty at every hand-off. fp16 models are exactly the ANE-eligible case (the ANE is a fixed-function fp16 engine; fp32-typed programs are barred from it per Apple's typed-execution rules), so pinning them avoids the split. fp32 models (`ghost`, `uniface`) keep the default so they can use the GPU.
2. `ModelCacheDirectory`, mirroring `execution.py`. Without it every session start recompiles the MLProgram, which takes 9-12 seconds for `hyperswap` on an M1 Max.

## Measurements

M1 Max 64GB, macOS 15, onnxruntime 1.26.0, `hyperswap_1a_256`, static input, median of 15+ runs in separate processes:

| Configuration | Median per forward |
|---|---|
| current release (`MLProgram`, default compute units) | 657 ms |
| CPU EP for reference | 304 ms |
| `MLProgram` + `MLComputeUnits: CPUAndNeuralEngine` | **78 ms** |

Session creation with a warm `ModelCacheDirectory` drops from 9-12 s to under 1 s.

## Related observation (not part of this PR)

The remaining gap to the hardware comes from the model graph itself: `hyperswap_*_256` contains 42 `Expand` nodes (AdaIN style broadcast) that the CoreML EP has no builder for, so the graph compiles into 2 partitions with a CPU island in the middle. The `Expand` nodes are mathematically redundant — ONNX broadcasting in the following `Mul`/`Add` produces identical results (mask output is bit-identical after removal). Re-exporting hyperswap without them brings the same forward down to ~25 ms (12x vs CPU EP). That fix belongs in the model export rather than in this repository, so it is only documented here. Deep-Live-Cam hit the same class of issue with `Pad(reflect)` in `inswapper_128` (hacksider/Deep-Live-Cam#1775).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
