### PR TITLE
Revamp execution provider overrides/adjustments

### DIFF
--- a/facefusion/inference_manager.py
+++ b/facefusion/inference_manager.py
@@ -93,10 +93,23 @@ def resolve_static_inference_providers(module_name : str, execution_device_id : 
 	module = importlib.import_module(module_name)
 	execution_providers = state_manager.get_item('execution_providers')
 
-	if hasattr(module, 'resolve_inference_providers'):
-		inference_providers = getattr(module, 'resolve_inference_providers')()
+	if hasattr(module, 'override_inference_providers'):
+		override_inference_providers = getattr(module, 'override_inference_providers')()
 
-		if inference_providers:
+		if override_inference_providers:
+			return override_inference_providers
+
+	if hasattr(module, 'adjust_inference_providers'):
+		adjust_inference_providers = getattr(module, 'adjust_inference_providers')()
+
+		if adjust_inference_providers:
+			inference_providers = create_inference_providers(execution_device_id, execution_providers)
+
+			for adjust_inference_provider in adjust_inference_providers:
+				for inference_provider in inference_providers:
+					if inference_provider[0] == adjust_inference_provider[0] and inference_provider[1]:
+						inference_provider[1].update(adjust_inference_provider[1])
+
 			return inference_providers
 
 	return create_inference_providers(execution_device_id, execution_providers)

--- a/facefusion/processors/modules/background_remover/core.py
+++ b/facefusion/processors/modules/background_remover/core.py
@@ -479,7 +479,7 @@ def clear_inference_pool() -> None:
 	inference_manager.clear_inference_pool(__name__, model_names)
 
 
-def resolve_inference_providers() -> List[InferenceProvider]:
+def override_inference_providers() -> List[InferenceProvider]:
 	model_type = get_model_options().get('type')
 
 	if is_macos() and has_execution_provider('coreml') or is_windows() and has_execution_provider('directml') and model_type == 'corridor_key':

--- a/facefusion/processors/modules/face_swapper/core.py
+++ b/facefusion/processors/modules/face_swapper/core.py
@@ -507,22 +507,12 @@ def adjust_inference_providers() -> List[InferenceProvider]:
 	model_type = get_model_options().get('type')
 
 	if is_macos() and has_execution_provider('coreml'):
-		if model_type in [ 'ghost', 'uniface' ]:
+		if model_type in [ 'ghost', 'uniface' ] or model_precision == 'fp16':
 			return\
 			[
 				(facefusion.choices.execution_provider_set.get('coreml'),
 				{
 					'ModelFormat': 'MLProgram'
-				})
-			]
-
-		if model_precision == 'fp16':
-			return\
-			[
-				(facefusion.choices.execution_provider_set.get('coreml'),
-				{
-					'ModelFormat': 'MLProgram',
-					'MLComputeUnits': 'CPUAndNeuralEngine'
 				})
 			]
 

--- a/facefusion/processors/modules/face_swapper/core.py
+++ b/facefusion/processors/modules/face_swapper/core.py
@@ -502,18 +502,27 @@ def clear_inference_pool() -> None:
 	inference_manager.clear_inference_pool(__name__, model_names)
 
 
-def resolve_inference_providers() -> List[InferenceProvider]:
+def adjust_inference_providers() -> List[InferenceProvider]:
 	model_precision = get_model_options().get('precision')
 	model_type = get_model_options().get('type')
 
 	if is_macos() and has_execution_provider('coreml'):
-		if model_type in [ 'ghost', 'uniface' ] or model_precision == 'fp16':
+		if model_type in [ 'ghost', 'uniface' ]:
+			return\
+			[
+				(facefusion.choices.execution_provider_set.get('coreml'),
+				{
+					'ModelFormat': 'MLProgram'
+				})
+			]
+
+		if model_precision == 'fp16':
 			return\
 			[
 				(facefusion.choices.execution_provider_set.get('coreml'),
 				{
 					'ModelFormat': 'MLProgram',
-					'SpecializationStrategy': 'FastPrediction'
+					'MLComputeUnits': 'CPUAndNeuralEngine'
 				})
 			]
 

--- a/facefusion/processors/modules/frame_colorizer/core.py
+++ b/facefusion/processors/modules/frame_colorizer/core.py
@@ -172,7 +172,7 @@ def clear_inference_pool() -> None:
 	inference_manager.clear_inference_pool(__name__, model_names)
 
 
-def resolve_inference_providers() -> List[InferenceProvider]:
+def override_inference_providers() -> List[InferenceProvider]:
 	if is_macos() and has_execution_provider('coreml'):
 		return [ facefusion.choices.execution_provider_set.get('cpu') ]
 

--- a/facefusion/processors/modules/frame_enhancer/core.py
+++ b/facefusion/processors/modules/frame_enhancer/core.py
@@ -566,8 +566,7 @@ def adjust_inference_providers() -> List[InferenceProvider]:
 		[
 			(facefusion.choices.execution_provider_set.get('coreml'),
 			{
-				'ModelFormat': 'MLProgram',
-				'MLComputeUnits': 'CPUAndNeuralEngine'
+				'ModelFormat': 'MLProgram'
 			})
 		]
 

--- a/facefusion/processors/modules/frame_enhancer/core.py
+++ b/facefusion/processors/modules/frame_enhancer/core.py
@@ -558,7 +558,7 @@ def clear_inference_pool() -> None:
 	inference_manager.clear_inference_pool(__name__, model_names)
 
 
-def resolve_inference_providers() -> List[InferenceProvider]:
+def adjust_inference_providers() -> List[InferenceProvider]:
 	model_precision = get_model_options().get('precision')
 
 	if is_macos() and has_execution_provider('coreml') and model_precision == 'fp16':
@@ -567,7 +567,7 @@ def resolve_inference_providers() -> List[InferenceProvider]:
 			(facefusion.choices.execution_provider_set.get('coreml'),
 			{
 				'ModelFormat': 'MLProgram',
-				'SpecializationStrategy': 'FastPrediction'
+				'MLComputeUnits': 'CPUAndNeuralEngine'
 			})
 		]
 

--- a/tests/test_inference_manager.py
+++ b/tests/test_inference_manager.py
@@ -1,3 +1,4 @@
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -5,7 +6,12 @@ import pytest
 from onnxruntime import InferenceSession
 
 from facefusion import content_analyser, state_manager
+from facefusion.execution import resolve_cache_path
 from facefusion.inference_manager import INFERENCE_POOL_SET, get_inference_pool, resolve_static_inference_providers
+
+
+def provide_inference_providers(inference_providers, *args):
+	return inference_providers
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -33,13 +39,17 @@ def test_get_inference_pool() -> None:
 
 
 def test_resolve_static_inference_providers() -> None:
-	resolve_static_inference_providers.cache_clear()
-	override_module = SimpleNamespace(override_inference_providers = lambda: [ ('OverrideExecutionProvider', {}) ])
-	adjust_module = SimpleNamespace(adjust_inference_providers = lambda: [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ])
-	default_module = SimpleNamespace()
+	state_manager.init_item('execution_providers', [ 'coreml' ])
+	cache_path = resolve_cache_path()
+	override_module = SimpleNamespace(override_inference_providers = partial(provide_inference_providers, [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
+	adjust_module = SimpleNamespace(adjust_inference_providers = partial(provide_inference_providers, [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
 
-	with patch.dict('sys.modules', { 'test_override': override_module, 'test_adjust': adjust_module, 'test_default': default_module }),\
-		patch('facefusion.inference_manager.create_inference_providers', side_effect = lambda *args: [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction' }) ]):
-		assert resolve_static_inference_providers('test_override', 0) == [ ('OverrideExecutionProvider', {}) ]
-		assert resolve_static_inference_providers('test_adjust', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelFormat': 'MLProgram' }) ]
-		assert resolve_static_inference_providers('test_default', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction' }) ]
+	resolve_static_inference_providers.cache_clear()
+
+	with patch('facefusion.inference_manager.importlib', **{ 'import_module.return_value': override_module }):
+		assert resolve_static_inference_providers('override_module', 0) == [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]
+
+	with patch('facefusion.inference_manager.importlib', **{ 'import_module.return_value': adjust_module }):
+		assert resolve_static_inference_providers('adjust_module', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelCacheDirectory': cache_path, 'ModelFormat': 'MLProgram' }) ]
+
+	assert resolve_static_inference_providers('test', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelCacheDirectory': cache_path }) ]

--- a/tests/test_inference_manager.py
+++ b/tests/test_inference_manager.py
@@ -1,6 +1,4 @@
-from functools import partial
 from types import SimpleNamespace
-from typing import Any, List
 from unittest.mock import Mock, patch
 
 import pytest
@@ -9,11 +7,6 @@ from onnxruntime import InferenceSession
 from facefusion import content_analyser, state_manager
 from facefusion.execution import resolve_cache_path
 from facefusion.inference_manager import INFERENCE_POOL_SET, get_inference_pool, resolve_static_inference_providers
-from facefusion.types import InferenceProvider
-
-
-def provide_inference_providers(inference_providers : List[InferenceProvider], *args : Any) -> List[InferenceProvider]:
-	return inference_providers
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -40,10 +33,17 @@ def test_get_inference_pool() -> None:
 	assert INFERENCE_POOL_SET.get('cli').get('facefusion.content_analyser.nsfw_1.nsfw_2.nsfw_3.0.cpu').get('nsfw_1') == INFERENCE_POOL_SET.get('ui').get('facefusion.content_analyser.nsfw_1.nsfw_2.nsfw_3.0.cpu').get('nsfw_1')
 
 
-def test_resolve_static_inference_providers() -> None:
-	override_module = SimpleNamespace(override_inference_providers = partial(provide_inference_providers, [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
-	adjust_module = SimpleNamespace(adjust_inference_providers = partial(provide_inference_providers, [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
+@pytest.fixture
+def override_module() -> SimpleNamespace:
+	return SimpleNamespace(override_inference_providers = Mock(return_value = [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
 
+
+@pytest.fixture
+def adjust_module() -> SimpleNamespace:
+	return SimpleNamespace(adjust_inference_providers = Mock(return_value = [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
+
+
+def test_resolve_static_inference_providers(override_module : SimpleNamespace, adjust_module : SimpleNamespace) -> None:
 	state_manager.init_item('execution_providers', ['coreml'])
 	resolve_static_inference_providers.cache_clear()
 

--- a/tests/test_inference_manager.py
+++ b/tests/test_inference_manager.py
@@ -1,10 +1,11 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from onnxruntime import InferenceSession
 
 from facefusion import content_analyser, state_manager
-from facefusion.inference_manager import INFERENCE_POOL_SET, get_inference_pool
+from facefusion.inference_manager import INFERENCE_POOL_SET, get_inference_pool, resolve_static_inference_providers
 
 
 @pytest.fixture(scope = 'module', autouse = True)
@@ -12,7 +13,6 @@ def before_all() -> None:
 	state_manager.init_item('execution_device_ids', [ 0 ])
 	state_manager.init_item('execution_providers', [ 'cpu' ])
 	state_manager.init_item('download_providers', [ 'github' ])
-	content_analyser.pre_check()
 
 
 def test_get_inference_pool() -> None:
@@ -30,3 +30,16 @@ def test_get_inference_pool() -> None:
 		assert isinstance(INFERENCE_POOL_SET.get('cli').get('facefusion.content_analyser.nsfw_1.nsfw_2.nsfw_3.0.cpu').get('nsfw_1'), InferenceSession)
 
 	assert INFERENCE_POOL_SET.get('cli').get('facefusion.content_analyser.nsfw_1.nsfw_2.nsfw_3.0.cpu').get('nsfw_1') == INFERENCE_POOL_SET.get('ui').get('facefusion.content_analyser.nsfw_1.nsfw_2.nsfw_3.0.cpu').get('nsfw_1')
+
+
+def test_resolve_static_inference_providers() -> None:
+	resolve_static_inference_providers.cache_clear()
+	override_module = SimpleNamespace(override_inference_providers = lambda: [ ('OverrideExecutionProvider', {}) ])
+	adjust_module = SimpleNamespace(adjust_inference_providers = lambda: [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ])
+	default_module = SimpleNamespace()
+
+	with patch.dict('sys.modules', { 'test_override': override_module, 'test_adjust': adjust_module, 'test_default': default_module }),\
+		patch('facefusion.inference_manager.create_inference_providers', side_effect = lambda *args: [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction' }) ]):
+		assert resolve_static_inference_providers('test_override', 0) == [ ('OverrideExecutionProvider', {}) ]
+		assert resolve_static_inference_providers('test_adjust', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelFormat': 'MLProgram' }) ]
+		assert resolve_static_inference_providers('test_default', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction' }) ]

--- a/tests/test_inference_manager.py
+++ b/tests/test_inference_manager.py
@@ -1,5 +1,6 @@
 from functools import partial
 from types import SimpleNamespace
+from typing import Any, List
 from unittest.mock import Mock, patch
 
 import pytest
@@ -8,9 +9,10 @@ from onnxruntime import InferenceSession
 from facefusion import content_analyser, state_manager
 from facefusion.execution import resolve_cache_path
 from facefusion.inference_manager import INFERENCE_POOL_SET, get_inference_pool, resolve_static_inference_providers
+from facefusion.types import InferenceProvider
 
 
-def provide_inference_providers(inference_providers, *args):
+def provide_inference_providers(inference_providers : List[InferenceProvider], *args : Any) -> List[InferenceProvider]:
 	return inference_providers
 
 

--- a/tests/test_inference_manager.py
+++ b/tests/test_inference_manager.py
@@ -1,6 +1,6 @@
 from functools import partial
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from onnxruntime import InferenceSession
@@ -39,17 +39,16 @@ def test_get_inference_pool() -> None:
 
 
 def test_resolve_static_inference_providers() -> None:
-	state_manager.init_item('execution_providers', [ 'coreml' ])
-	cache_path = resolve_cache_path()
 	override_module = SimpleNamespace(override_inference_providers = partial(provide_inference_providers, [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
 	adjust_module = SimpleNamespace(adjust_inference_providers = partial(provide_inference_providers, [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]))
 
+	state_manager.init_item('execution_providers', ['coreml'])
 	resolve_static_inference_providers.cache_clear()
 
-	with patch('facefusion.inference_manager.importlib', **{ 'import_module.return_value': override_module }):
+	with patch('facefusion.inference_manager.importlib', Mock(import_module = Mock(return_value = override_module))):
 		assert resolve_static_inference_providers('override_module', 0) == [ ('CoreMLExecutionProvider', { 'ModelFormat': 'MLProgram' }) ]
 
-	with patch('facefusion.inference_manager.importlib', **{ 'import_module.return_value': adjust_module }):
-		assert resolve_static_inference_providers('adjust_module', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelCacheDirectory': cache_path, 'ModelFormat': 'MLProgram' }) ]
+	with patch('facefusion.inference_manager.importlib', Mock(import_module = Mock(return_value = adjust_module))):
+		assert resolve_static_inference_providers('adjust_module', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelCacheDirectory': resolve_cache_path(), 'ModelFormat': 'MLProgram' }) ]
 
-	assert resolve_static_inference_providers('test', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelCacheDirectory': cache_path }) ]
+	assert resolve_static_inference_providers('test', 0) == [ ('CoreMLExecutionProvider', { 'SpecializationStrategy': 'FastPrediction', 'ModelCacheDirectory': resolve_cache_path() }) ]


### PR DESCRIPTION
introduce override_inference_providers to mimic old resolve method and adjust_inference_providers to keep cache entries.