### PR TITLE
Restrict the preview frame slider and the reader seek to the last frame index

### DIFF
--- a/facefusion/ffprobe.py
+++ b/facefusion/ffprobe.py
@@ -74,7 +74,7 @@ def extract_audio_metadata(audio_path : str) -> AudioMetadata:
 
 	duration = float(format_entries.get('duration'))
 	sample_rate = int(audio_entries.get('sample_rate'))
-	frame_total = int(duration * sample_rate)
+	frame_total = round(duration * sample_rate)
 	channel_total = int(audio_entries.get('channels'))
 	bit_rate = int(format_entries.get('bit_rate'))
 
@@ -101,7 +101,7 @@ def extract_video_metadata(video_path : str) -> VideoMetadata:
 
 	duration = float(format_entries.get('duration'))
 	fps = extract_video_fps(video_entries.get('r_frame_rate'))
-	frame_total = int(duration * fps)
+	frame_total = round(duration * fps)
 	width = int(video_entries.get('width'))
 	height = int(video_entries.get('height'))
 	bit_rate = int(format_entries.get('bit_rate'))

--- a/facefusion/uis/components/preview_options.py
+++ b/facefusion/uis/components/preview_options.py
@@ -26,8 +26,9 @@ def render() -> None:
 		'visible': False
 	}
 	if is_video(state_manager.get_item('target_path')):
+		video_frame_total = count_video_frame_total(state_manager.get_item('target_path'))
 		preview_frame_slider_options['value'] = state_manager.get_item('reference_frame_number')
-		preview_frame_slider_options['maximum'] = count_video_frame_total(state_manager.get_item('target_path')) - 1
+		preview_frame_slider_options['maximum'] = video_frame_total - 1
 		preview_frame_slider_options['visible'] = True
 	PREVIEW_FRAME_SLIDER = gradio.Slider(**preview_frame_slider_options)
 	with gradio.Row():

--- a/facefusion/uis/components/preview_options.py
+++ b/facefusion/uis/components/preview_options.py
@@ -27,7 +27,7 @@ def render() -> None:
 	}
 	if is_video(state_manager.get_item('target_path')):
 		preview_frame_slider_options['value'] = state_manager.get_item('reference_frame_number')
-		preview_frame_slider_options['maximum'] = count_video_frame_total(state_manager.get_item('target_path'))
+		preview_frame_slider_options['maximum'] = count_video_frame_total(state_manager.get_item('target_path')) - 1
 		preview_frame_slider_options['visible'] = True
 	PREVIEW_FRAME_SLIDER = gradio.Slider(**preview_frame_slider_options)
 	with gradio.Row():
@@ -57,5 +57,5 @@ def listen() -> None:
 def update_preview_frame_slider() -> gradio.Slider:
 	if is_video(state_manager.get_item('target_path')):
 		video_frame_total = count_video_frame_total(state_manager.get_item('target_path'))
-		return gradio.Slider(maximum = video_frame_total, visible = True)
+		return gradio.Slider(maximum = video_frame_total - 1, visible = True)
 	return gradio.Slider(value = 0, visible = False)

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -35,7 +35,8 @@ def get_reader(video_path : str, context : str) -> VideoReader:
 
 
 def conditional_seek_video_reader(video_reader : VideoReader, frame_number : int = 0) -> None:
-	frame_number = min(video_reader.get('metadata').get('frame_total') - 1, frame_number)
+	frame_total = video_reader.get('metadata').get('frame_total')
+	frame_number = min(frame_total - 1, frame_number)
 	skip_total = frame_number - video_reader.get('frame_number')
 	skip_margin = 128
 

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -35,7 +35,7 @@ def get_reader(video_path : str, context : str) -> VideoReader:
 
 
 def conditional_seek_video_reader(video_reader : VideoReader, frame_number : int = 0) -> None:
-	frame_number = min(video_reader.get('metadata').get('frame_total'), frame_number)
+	frame_number = min(video_reader.get('metadata').get('frame_total') - 1, frame_number)
 	skip_total = frame_number - video_reader.get('frame_number')
 	skip_margin = 128
 

--- a/tests/test_ffprobe.py
+++ b/tests/test_ffprobe.py
@@ -41,7 +41,7 @@ def test_extract_audio_metadata() -> None:
 
 	assert audio_metadata.get('sample_rate') == 44100
 	assert audio_metadata.get('channel_total') == 1
-	assert audio_metadata.get('frame_total') == 167039
+	assert audio_metadata.get('frame_total') == 167040
 	assert audio_metadata.get('bit_rate') == 128000
 
 	audio_metadata = extract_audio_metadata(get_test_example_file('source-48000khz-2ch.wav'))


### PR DESCRIPTION
  `count_video_frame_total()` returns a frame *count*, so the last valid frame number is `frame_total - 1`. Two places consumed it as an index.                                                                                                                          
                                                                                                                                                                                                                                                                         
  - the preview frame slider exposed `frame_total` as its maximum, so its final position requested a frame that does not exist                                                                                                                                           
  - `conditional_seek_video_reader()` clamped with `min(frame_total, frame_number)`, which never prevented the out of range read it exists to prevent    