### PR TITLE
avoid tobytes copy

### DIFF
--- a/facefusion/face_store.py
+++ b/facefusion/face_store.py
@@ -11,7 +11,7 @@ FACE_STORE : FaceStore = {}
 
 def get_faces(vision_frame : VisionFrame) -> Optional[List[Face]]:
 	if numpy.any(vision_frame):
-		vision_hash = create_hash(vision_frame.tobytes())
+		vision_hash = create_hash(vision_frame.data)
 
 		if FACE_STORE.get(vision_hash):
 			return FACE_STORE.get(vision_hash).get('faces')
@@ -21,7 +21,7 @@ def get_faces(vision_frame : VisionFrame) -> Optional[List[Face]]:
 
 def set_faces(vision_frame : VisionFrame, faces : List[Face]) -> None:
 	if numpy.any(vision_frame):
-		vision_hash = create_hash(vision_frame.tobytes())
+		vision_hash = create_hash(vision_frame.data)
 		FACE_STORE.setdefault(vision_hash,
 		{
 			'lock': threading.Lock()
@@ -30,7 +30,7 @@ def set_faces(vision_frame : VisionFrame, faces : List[Face]) -> None:
 
 def resolve_lock(vision_frame : VisionFrame) -> threading.Lock:
 	if numpy.any(vision_frame):
-		vision_hash = create_hash(vision_frame.tobytes())
+		vision_hash = create_hash(vision_frame.data)
 		return FACE_STORE.setdefault(vision_hash,
 		{
 			'lock': threading.Lock()

--- a/facefusion/uis/components/webcam.py
+++ b/facefusion/uis/components/webcam.py
@@ -106,7 +106,7 @@ def start(webcam_device_id : int, webcam_mode : WebcamMode, webcam_resolution : 
 				yield capture_vision_frame
 			if webcam_mode in [ 'udp', 'v4l2' ]:
 				try:
-					stream.stdin.write(capture_vision_frame.tobytes())
+					stream.stdin.write(capture_vision_frame.data)
 				except Exception:
 					pass
 

--- a/facefusion/video_manager.py
+++ b/facefusion/video_manager.py
@@ -133,7 +133,7 @@ def get_writer(video_path : str, temp_video_fps : Fps, temp_video_resolution : R
 
 
 def write_video_frame(video_writer : VideoWriter, vision_frame : VisionFrame) -> None:
-	video_writer.get('process').stdin.write(vision_frame.tobytes())
+	video_writer.get('process').stdin.write(vision_frame.data)
 
 
 def close_video_writer(video_writer : VideoWriter) -> bool:


### PR DESCRIPTION
minor but measurable performance optimization is to avoid tobytes() copies.