### PR TITLE
Fix fps bug when using memory mode

### DIFF
--- a/facefusion/ffmpeg.py
+++ b/facefusion/ffmpeg.py
@@ -166,7 +166,7 @@ def extract_frames(target_path : str, temp_video_resolution : Resolution, temp_v
 			ffmpeg_builder.restrict_color_transfer(color_transfer)
 		),
 		ffmpeg_builder.prevent_frame_drop(),
-		ffmpeg_builder.set_start_number(trim_frame_start),
+		ffmpeg_builder.set_start_number(0),
 		ffmpeg_builder.set_output(temp_frame_pattern)
 	)
 
@@ -285,7 +285,7 @@ def merge_video(target_path : str, temp_video_fps : Fps, output_video_resolution
 
 	commands = ffmpeg_builder.chain(
 		ffmpeg_builder.set_input_fps(temp_video_fps),
-		ffmpeg_builder.set_start_number(trim_frame_start),
+		ffmpeg_builder.set_start_number(0),
 		ffmpeg_builder.set_input(temp_frame_pattern),
 		ffmpeg_builder.set_media_resolution(vision.pack_resolution(output_video_resolution)),
 		ffmpeg_builder.set_video_encoder(output_video_encoder),

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -121,7 +121,7 @@ def predict_video_frame_total(video_path : str, fps : Fps, trim_frame_start : in
 
 		if trim_frame_total > 0:
 			extract_frame_total = trim_frame_total * fps / video_fps
-			return max(math.floor(extract_frame_total), 1)
+			return max(math.floor(extract_frame_total + 0.5), 1)
 	return 0
 
 
@@ -129,7 +129,7 @@ def resolve_video_frame_number(video_path : str, fps : Fps, trim_frame_start : i
 	video_fps = detect_video_fps(video_path)
 
 	if video_fps:
-		return trim_frame_start + math.floor(temp_frame_number * video_fps / fps)
+		return trim_frame_start + math.floor((temp_frame_number + 0.5) * video_fps / fps)
 	return trim_frame_start + temp_frame_number
 
 

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -117,9 +117,20 @@ def count_video_frame_total(video_path : str) -> int:
 def predict_video_frame_total(video_path : str, fps : Fps, trim_frame_start : int, trim_frame_end : int) -> int:
 	if is_video(video_path):
 		video_fps = detect_video_fps(video_path)
-		extract_frame_total = count_trim_frame_total(video_path, trim_frame_start, trim_frame_end) * fps / video_fps
-		return math.floor(extract_frame_total)
+		trim_frame_total = count_trim_frame_total(video_path, trim_frame_start, trim_frame_end)
+
+		if trim_frame_total > 0:
+			extract_frame_total = trim_frame_total * fps / video_fps
+			return max(math.floor(extract_frame_total), 1)
 	return 0
+
+
+def resolve_video_frame_number(video_path : str, fps : Fps, trim_frame_start : int, temp_frame_number : int) -> int:
+	video_fps = detect_video_fps(video_path)
+
+	if video_fps:
+		return trim_frame_start + math.floor(temp_frame_number * video_fps / fps)
+	return trim_frame_start + temp_frame_number
 
 
 def detect_video_fps(video_path : str) -> Optional[float]:

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -120,8 +120,7 @@ def predict_video_frame_total(video_path : str, fps : Fps, trim_frame_start : in
 		trim_frame_total = count_trim_frame_total(video_path, trim_frame_start, trim_frame_end)
 
 		if trim_frame_total > 0:
-			extract_frame_total = trim_frame_total * fps / video_fps
-			return max(math.floor(extract_frame_total + 0.5), 1)
+			return max(math.floor((trim_frame_total * fps / video_fps) + 0.5), 1)
 	return 0
 
 

--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -125,12 +125,12 @@ def predict_video_frame_total(video_path : str, fps : Fps, trim_frame_start : in
 	return 0
 
 
-def resolve_video_frame_number(video_path : str, fps : Fps, trim_frame_start : int, temp_frame_number : int) -> int:
+def resolve_video_frame_number(video_path : str, fps : Fps, trim_frame_start : int, frame_number : int) -> int:
 	video_fps = detect_video_fps(video_path)
 
 	if video_fps:
-		return trim_frame_start + math.floor((temp_frame_number + 0.5) * video_fps / fps)
-	return trim_frame_start + temp_frame_number
+		return trim_frame_start + math.floor((frame_number + 0.5) * video_fps / fps)
+	return trim_frame_start + frame_number
 
 
 def detect_video_fps(video_path : str) -> Optional[float]:

--- a/facefusion/workflows/core.py
+++ b/facefusion/workflows/core.py
@@ -37,11 +37,11 @@ def conditional_get_reference_vision_frame() -> VisionFrame:
 	return read_static_image(state_manager.get_item('target_path'))
 
 
-def conditional_get_source_audio_frame(audio_frame_number : int) -> AudioFrame:
+def conditional_get_source_audio_frame(temp_frame_number : int) -> AudioFrame:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
 		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
 		source_audio_path = get_first(filter_audio_paths(state_manager.get_item('source_paths')))
-		source_audio_frame = get_audio_frame(source_audio_path, temp_video_fps, audio_frame_number)
+		source_audio_frame = get_audio_frame(source_audio_path, temp_video_fps, temp_frame_number)
 
 		if numpy.any(source_audio_frame):
 			return source_audio_frame
@@ -49,11 +49,11 @@ def conditional_get_source_audio_frame(audio_frame_number : int) -> AudioFrame:
 	return create_empty_audio_frame()
 
 
-def conditional_get_source_voice_frame(audio_frame_number : int) -> AudioFrame:
+def conditional_get_source_voice_frame(temp_frame_number : int) -> AudioFrame:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
 		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
 		source_audio_path = get_first(filter_audio_paths(state_manager.get_item('source_paths')))
-		source_voice_frame = get_voice_frame(source_audio_path, temp_video_fps, audio_frame_number)
+		source_voice_frame = get_voice_frame(source_audio_path, temp_video_fps, temp_frame_number)
 
 		if numpy.any(source_voice_frame):
 			return source_voice_frame
@@ -67,11 +67,11 @@ def conditional_get_target_vision_frames(frame_number : int) -> List[VisionFrame
 	return [ read_static_image(state_manager.get_item('target_path')) ]
 
 
-def process_temp_frame(target_vision_frames : List[VisionFrame], temp_vision_frame : VisionFrame, audio_frame_number : int) -> VisionFrame:
+def process_temp_frame(target_vision_frames : List[VisionFrame], temp_vision_frame : VisionFrame, temp_frame_number : int) -> VisionFrame:
 	reference_vision_frame = conditional_get_reference_vision_frame()
 	source_vision_frames = read_static_images(state_manager.get_item('source_paths'))
-	source_audio_frame = conditional_get_source_audio_frame(audio_frame_number)
-	source_voice_frame = conditional_get_source_voice_frame(audio_frame_number)
+	source_audio_frame = conditional_get_source_audio_frame(temp_frame_number)
+	source_voice_frame = conditional_get_source_voice_frame(temp_frame_number)
 	temp_vision_mask = extract_vision_mask(temp_vision_frame)
 
 	for processor_module in get_processors_modules(state_manager.get_item('processors')):

--- a/facefusion/workflows/core.py
+++ b/facefusion/workflows/core.py
@@ -9,7 +9,7 @@ from facefusion.filesystem import filter_audio_paths
 from facefusion.processors.core import get_processors_modules
 from facefusion.temp_helper import clear_temp_directory, create_temp_directory
 from facefusion.types import AudioFrame, ErrorCode, VisionFrame
-from facefusion.vision import conditional_merge_vision_mask, extract_vision_mask, read_static_image, read_static_images, read_static_video_frame, restrict_video_fps, select_video_frames
+from facefusion.vision import conditional_merge_vision_mask, extract_vision_mask, read_static_image, read_static_images, read_static_video_frame, resolve_video_frame_number, restrict_trim_frame, restrict_video_fps, select_video_frames
 
 
 def is_process_stopping() -> bool:
@@ -61,8 +61,11 @@ def conditional_get_source_voice_frame(temp_frame_number : int) -> AudioFrame:
 	return create_empty_audio_frame()
 
 
-def conditional_get_target_vision_frames(frame_number : int) -> List[VisionFrame]:
+def conditional_get_target_vision_frames(temp_frame_number : int) -> List[VisionFrame]:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
+		trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
+		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
+		frame_number = resolve_video_frame_number(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, temp_frame_number)
 		return select_video_frames(state_manager.get_item('target_path'), frame_number, state_manager.get_item('target_frame_amount'))
 	return [ read_static_image(state_manager.get_item('target_path')) ]
 

--- a/facefusion/workflows/core.py
+++ b/facefusion/workflows/core.py
@@ -9,7 +9,7 @@ from facefusion.filesystem import filter_audio_paths
 from facefusion.processors.core import get_processors_modules
 from facefusion.temp_helper import clear_temp_directory, create_temp_directory
 from facefusion.types import AudioFrame, ErrorCode, VisionFrame
-from facefusion.vision import conditional_merge_vision_mask, extract_vision_mask, read_static_image, read_static_images, read_static_video_frame, restrict_trim_frame, restrict_video_fps, select_video_frames
+from facefusion.vision import conditional_merge_vision_mask, extract_vision_mask, read_static_image, read_static_images, read_static_video_frame, restrict_video_fps, select_video_frames
 
 
 def is_process_stopping() -> bool:
@@ -37,12 +37,11 @@ def conditional_get_reference_vision_frame() -> VisionFrame:
 	return read_static_image(state_manager.get_item('target_path'))
 
 
-def conditional_get_source_audio_frame(frame_number : int) -> AudioFrame:
+def conditional_get_source_audio_frame(audio_frame_number : int) -> AudioFrame:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
-		trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
 		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
 		source_audio_path = get_first(filter_audio_paths(state_manager.get_item('source_paths')))
-		source_audio_frame = get_audio_frame(source_audio_path, temp_video_fps, frame_number - trim_frame_start)
+		source_audio_frame = get_audio_frame(source_audio_path, temp_video_fps, audio_frame_number)
 
 		if numpy.any(source_audio_frame):
 			return source_audio_frame
@@ -50,12 +49,11 @@ def conditional_get_source_audio_frame(frame_number : int) -> AudioFrame:
 	return create_empty_audio_frame()
 
 
-def conditional_get_source_voice_frame(frame_number : int) -> AudioFrame:
+def conditional_get_source_voice_frame(audio_frame_number : int) -> AudioFrame:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
-		trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
 		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
 		source_audio_path = get_first(filter_audio_paths(state_manager.get_item('source_paths')))
-		source_voice_frame = get_voice_frame(source_audio_path, temp_video_fps, frame_number - trim_frame_start)
+		source_voice_frame = get_voice_frame(source_audio_path, temp_video_fps, audio_frame_number)
 
 		if numpy.any(source_voice_frame):
 			return source_voice_frame
@@ -69,11 +67,11 @@ def conditional_get_target_vision_frames(frame_number : int) -> List[VisionFrame
 	return [ read_static_image(state_manager.get_item('target_path')) ]
 
 
-def process_temp_frame(target_vision_frames : List[VisionFrame], temp_vision_frame : VisionFrame, frame_number : int) -> VisionFrame:
+def process_temp_frame(target_vision_frames : List[VisionFrame], temp_vision_frame : VisionFrame, audio_frame_number : int) -> VisionFrame:
 	reference_vision_frame = conditional_get_reference_vision_frame()
 	source_vision_frames = read_static_images(state_manager.get_item('source_paths'))
-	source_audio_frame = conditional_get_source_audio_frame(frame_number)
-	source_voice_frame = conditional_get_source_voice_frame(frame_number)
+	source_audio_frame = conditional_get_source_audio_frame(audio_frame_number)
+	source_voice_frame = conditional_get_source_voice_frame(audio_frame_number)
 	temp_vision_mask = extract_vision_mask(temp_vision_frame)
 
 	for processor_module in get_processors_modules(state_manager.get_item('processors')):

--- a/facefusion/workflows/core.py
+++ b/facefusion/workflows/core.py
@@ -37,11 +37,11 @@ def conditional_get_reference_vision_frame() -> VisionFrame:
 	return read_static_image(state_manager.get_item('target_path'))
 
 
-def conditional_get_source_audio_frame(temp_frame_number : int) -> AudioFrame:
+def conditional_get_source_audio_frame(frame_number : int) -> AudioFrame:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
 		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
 		source_audio_path = get_first(filter_audio_paths(state_manager.get_item('source_paths')))
-		source_audio_frame = get_audio_frame(source_audio_path, temp_video_fps, temp_frame_number)
+		source_audio_frame = get_audio_frame(source_audio_path, temp_video_fps, frame_number)
 
 		if numpy.any(source_audio_frame):
 			return source_audio_frame
@@ -49,11 +49,11 @@ def conditional_get_source_audio_frame(temp_frame_number : int) -> AudioFrame:
 	return create_empty_audio_frame()
 
 
-def conditional_get_source_voice_frame(temp_frame_number : int) -> AudioFrame:
+def conditional_get_source_voice_frame(frame_number : int) -> AudioFrame:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
 		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
 		source_audio_path = get_first(filter_audio_paths(state_manager.get_item('source_paths')))
-		source_voice_frame = get_voice_frame(source_audio_path, temp_video_fps, temp_frame_number)
+		source_voice_frame = get_voice_frame(source_audio_path, temp_video_fps, frame_number)
 
 		if numpy.any(source_voice_frame):
 			return source_voice_frame
@@ -61,20 +61,20 @@ def conditional_get_source_voice_frame(temp_frame_number : int) -> AudioFrame:
 	return create_empty_audio_frame()
 
 
-def conditional_get_target_vision_frames(temp_frame_number : int) -> List[VisionFrame]:
+def conditional_get_target_vision_frames(frame_number : int) -> List[VisionFrame]:
 	if state_manager.get_item('workflow_mode') == 'image-to-video':
 		trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
 		temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
-		frame_number = resolve_video_frame_number(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, temp_frame_number)
+		frame_number = resolve_video_frame_number(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, frame_number)
 		return select_video_frames(state_manager.get_item('target_path'), frame_number, state_manager.get_item('target_frame_amount'))
 	return [ read_static_image(state_manager.get_item('target_path')) ]
 
 
-def process_temp_frame(target_vision_frames : List[VisionFrame], temp_vision_frame : VisionFrame, temp_frame_number : int) -> VisionFrame:
+def process_temp_frame(target_vision_frames : List[VisionFrame], temp_vision_frame : VisionFrame, frame_number : int) -> VisionFrame:
 	reference_vision_frame = conditional_get_reference_vision_frame()
 	source_vision_frames = read_static_images(state_manager.get_item('source_paths'))
-	source_audio_frame = conditional_get_source_audio_frame(temp_frame_number)
-	source_voice_frame = conditional_get_source_voice_frame(temp_frame_number)
+	source_audio_frame = conditional_get_source_audio_frame(frame_number)
+	source_voice_frame = conditional_get_source_voice_frame(frame_number)
 	temp_vision_mask = extract_vision_mask(temp_vision_frame)
 
 	for processor_module in get_processors_modules(state_manager.get_item('processors')):

--- a/facefusion/workflows/to_video.py
+++ b/facefusion/workflows/to_video.py
@@ -1,4 +1,3 @@
-import math
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Deque
@@ -14,7 +13,7 @@ from facefusion.processors.core import get_processors_modules
 from facefusion.temp_helper import move_temp_file, resolve_temp_frame_set
 from facefusion.time_helper import calculate_end_time
 from facefusion.types import ErrorCode, Resolution, VisionFrame
-from facefusion.vision import detect_video_fps, detect_video_resolution, pack_resolution, predict_video_frame_total, read_static_image, read_static_video_frame, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, write_image
+from facefusion.vision import detect_video_resolution, pack_resolution, predict_video_frame_total, read_static_image, read_static_video_frame, resolve_video_frame_number, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, write_image
 from facefusion.workflows.core import conditional_get_target_vision_frames, is_process_stopping, process_temp_frame
 
 
@@ -43,15 +42,14 @@ def extract_frames() -> ErrorCode:
 	return 0
 
 
-def process_disk_frame(temp_frame_path : str, frame_number : int, audio_frame_number : int) -> bool:
+def process_disk_frame(temp_frame_path : str, frame_number : int, temp_frame_number : int) -> bool:
 	target_vision_frames = conditional_get_target_vision_frames(frame_number)
 	temp_vision_frame = read_static_image(temp_frame_path, 'rgba')
-	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, audio_frame_number)
+	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, temp_frame_number)
 	return write_image(temp_frame_path, temp_vision_frame)
 
 
 def process_disk_frames() -> ErrorCode:
-	trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
 	temp_frame_set = resolve_temp_frame_set(state_manager.get_item('target_path'))
 
 	if temp_frame_set:
@@ -63,8 +61,8 @@ def process_disk_frames() -> ErrorCode:
 			with ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count')) as executor:
 				futures : Deque[Future[bool]] = deque()
 
-				for frame_number, temp_frame_path in temp_frame_set.items():
-					future = executor.submit(process_disk_frame, temp_frame_path, frame_number, frame_number - trim_frame_start)
+				for temp_frame_number, frame_number in enumerate(temp_frame_set):
+					future = executor.submit(process_disk_frame, temp_frame_set.get(frame_number), frame_number, temp_frame_number)
 					futures.append(future)
 
 				while futures:
@@ -92,7 +90,10 @@ def process_disk_frames() -> ErrorCode:
 	return 0
 
 
-def process_memory_frame(frame_number : int, audio_frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
+def process_memory_frame(temp_frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
+	trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
+	temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
+	frame_number = resolve_video_frame_number(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, temp_frame_number)
 	target_vision_frames = select_video_frames(state_manager.get_item('target_path'), frame_number, state_manager.get_item('target_frame_amount'))
 	target_vision_frame = get_middle(target_vision_frames)
 	temp_vision_frame = target_vision_frame.copy()
@@ -100,7 +101,7 @@ def process_memory_frame(frame_number : int, audio_frame_number : int, temp_vide
 	if not (target_vision_frame.shape[1], target_vision_frame.shape[0]) == temp_video_resolution:
 		temp_vision_frame = cv2.resize(target_vision_frame, temp_video_resolution)
 
-	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, audio_frame_number)
+	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, temp_frame_number)
 
 	if not (temp_vision_frame.shape[1], temp_vision_frame.shape[0]) == output_video_resolution:
 		temp_vision_frame = cv2.resize(temp_vision_frame, output_video_resolution)
@@ -119,13 +120,7 @@ def process_memory_frames() -> ErrorCode:
 	output_video_resolution = scale_resolution(detect_video_resolution(state_manager.get_item('target_path')), state_manager.get_item('output_video_scale'))
 	temp_video_resolution = restrict_video_resolution(state_manager.get_item('target_path'), output_video_resolution)
 	temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
-	video_fps = detect_video_fps(state_manager.get_item('target_path'))
-	temp_frame_total = predict_video_frame_total(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, trim_frame_end)
-
-	if trim_frame_end > trim_frame_start:
-		temp_frame_total = max(temp_frame_total, 1)
-
-	temp_frame_range = range(temp_frame_total)
+	temp_frame_range = range(predict_video_frame_total(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, trim_frame_end))
 
 	if temp_frame_range:
 		video_writer = video_manager.get_writer(state_manager.get_item('target_path'), temp_video_fps, output_video_resolution, output_video_resolution, state_manager.get_item('output_video_fps'))
@@ -138,9 +133,8 @@ def process_memory_frames() -> ErrorCode:
 			with ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count')) as executor:
 				futures : Deque[Future[VisionFrame]] = deque()
 
-				for frame_index in temp_frame_range:
-					frame_number = trim_frame_start + math.floor(frame_index * video_fps / temp_video_fps)
-					future = executor.submit(process_memory_frame, frame_number, frame_index, temp_video_resolution, output_video_resolution)
+				for temp_frame_number in temp_frame_range:
+					future = executor.submit(process_memory_frame, temp_frame_number, temp_video_resolution, output_video_resolution)
 					futures.append(future)
 
 				while futures:

--- a/facefusion/workflows/to_video.py
+++ b/facefusion/workflows/to_video.py
@@ -43,14 +43,15 @@ def extract_frames() -> ErrorCode:
 	return 0
 
 
-def process_disk_frame(temp_frame_path : str, frame_number : int) -> bool:
+def process_disk_frame(temp_frame_path : str, frame_number : int, audio_frame_number : int) -> bool:
 	target_vision_frames = conditional_get_target_vision_frames(frame_number)
 	temp_vision_frame = read_static_image(temp_frame_path, 'rgba')
-	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, frame_number)
+	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, audio_frame_number)
 	return write_image(temp_frame_path, temp_vision_frame)
 
 
 def process_disk_frames() -> ErrorCode:
+	trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
 	temp_frame_set = resolve_temp_frame_set(state_manager.get_item('target_path'))
 
 	if temp_frame_set:
@@ -63,7 +64,7 @@ def process_disk_frames() -> ErrorCode:
 				futures : Deque[Future[bool]] = deque()
 
 				for frame_number, temp_frame_path in temp_frame_set.items():
-					future = executor.submit(process_disk_frame, temp_frame_path, frame_number)
+					future = executor.submit(process_disk_frame, temp_frame_path, frame_number, frame_number - trim_frame_start)
 					futures.append(future)
 
 				while futures:
@@ -91,7 +92,7 @@ def process_disk_frames() -> ErrorCode:
 	return 0
 
 
-def process_memory_frame(frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
+def process_memory_frame(frame_number : int, audio_frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
 	target_vision_frames = select_video_frames(state_manager.get_item('target_path'), frame_number, state_manager.get_item('target_frame_amount'))
 	target_vision_frame = get_middle(target_vision_frames)
 	temp_vision_frame = target_vision_frame.copy()
@@ -99,7 +100,7 @@ def process_memory_frame(frame_number : int, temp_video_resolution : Resolution,
 	if not (target_vision_frame.shape[1], target_vision_frame.shape[0]) == temp_video_resolution:
 		temp_vision_frame = cv2.resize(target_vision_frame, temp_video_resolution)
 
-	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, frame_number)
+	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, audio_frame_number)
 
 	if not (temp_vision_frame.shape[1], temp_vision_frame.shape[0]) == output_video_resolution:
 		temp_vision_frame = cv2.resize(temp_vision_frame, output_video_resolution)
@@ -119,7 +120,12 @@ def process_memory_frames() -> ErrorCode:
 	temp_video_resolution = restrict_video_resolution(state_manager.get_item('target_path'), output_video_resolution)
 	temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
 	video_fps = detect_video_fps(state_manager.get_item('target_path'))
-	temp_frame_range = range(predict_video_frame_total(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, trim_frame_end))
+	temp_frame_total = predict_video_frame_total(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, trim_frame_end)
+
+	if trim_frame_end > trim_frame_start:
+		temp_frame_total = max(temp_frame_total, 1)
+
+	temp_frame_range = range(temp_frame_total)
 
 	if temp_frame_range:
 		video_writer = video_manager.get_writer(state_manager.get_item('target_path'), temp_video_fps, output_video_resolution, output_video_resolution, state_manager.get_item('output_video_fps'))
@@ -134,7 +140,7 @@ def process_memory_frames() -> ErrorCode:
 
 				for frame_index in temp_frame_range:
 					frame_number = trim_frame_start + math.floor(frame_index * video_fps / temp_video_fps)
-					future = executor.submit(process_memory_frame, frame_number, temp_video_resolution, output_video_resolution)
+					future = executor.submit(process_memory_frame, frame_number, frame_index, temp_video_resolution, output_video_resolution)
 					futures.append(future)
 
 				while futures:

--- a/facefusion/workflows/to_video.py
+++ b/facefusion/workflows/to_video.py
@@ -1,3 +1,4 @@
+import math
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Deque
@@ -13,7 +14,7 @@ from facefusion.processors.core import get_processors_modules
 from facefusion.temp_helper import move_temp_file, resolve_temp_frame_set
 from facefusion.time_helper import calculate_end_time
 from facefusion.types import ErrorCode, Resolution, VisionFrame
-from facefusion.vision import detect_video_resolution, pack_resolution, read_static_image, read_static_video_frame, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, write_image
+from facefusion.vision import detect_video_fps, detect_video_resolution, pack_resolution, predict_video_frame_total, read_static_image, read_static_video_frame, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, write_image
 from facefusion.workflows.core import conditional_get_target_vision_frames, is_process_stopping, process_temp_frame
 
 
@@ -117,7 +118,8 @@ def process_memory_frames() -> ErrorCode:
 	output_video_resolution = scale_resolution(detect_video_resolution(state_manager.get_item('target_path')), state_manager.get_item('output_video_scale'))
 	temp_video_resolution = restrict_video_resolution(state_manager.get_item('target_path'), output_video_resolution)
 	temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
-	temp_frame_range = range(trim_frame_start, trim_frame_end)
+	video_fps = detect_video_fps(state_manager.get_item('target_path'))
+	temp_frame_range = range(predict_video_frame_total(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, trim_frame_end))
 
 	if temp_frame_range:
 		video_writer = video_manager.get_writer(state_manager.get_item('target_path'), temp_video_fps, output_video_resolution, output_video_resolution, state_manager.get_item('output_video_fps'))
@@ -130,7 +132,8 @@ def process_memory_frames() -> ErrorCode:
 			with ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count')) as executor:
 				futures : Deque[Future[VisionFrame]] = deque()
 
-				for frame_number in temp_frame_range:
+				for frame_index in temp_frame_range:
+					frame_number = trim_frame_start + math.floor(frame_index * video_fps / temp_video_fps)
 					future = executor.submit(process_memory_frame, frame_number, temp_video_resolution, output_video_resolution)
 					futures.append(future)
 

--- a/facefusion/workflows/to_video.py
+++ b/facefusion/workflows/to_video.py
@@ -42,10 +42,10 @@ def extract_frames() -> ErrorCode:
 	return 0
 
 
-def process_disk_frame(temp_frame_path : str, temp_frame_number : int) -> bool:
-	target_vision_frames = conditional_get_target_vision_frames(temp_frame_number)
+def process_disk_frame(temp_frame_path : str, frame_number : int) -> bool:
+	target_vision_frames = conditional_get_target_vision_frames(frame_number)
 	temp_vision_frame = read_static_image(temp_frame_path, 'rgba')
-	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, temp_frame_number)
+	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, frame_number)
 	return write_image(temp_frame_path, temp_vision_frame)
 
 
@@ -61,8 +61,8 @@ def process_disk_frames() -> ErrorCode:
 			with ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count')) as executor:
 				futures : Deque[Future[bool]] = deque()
 
-				for temp_frame_number, temp_frame_path in enumerate(temp_frame_set.values()):
-					future = executor.submit(process_disk_frame, temp_frame_path, temp_frame_number)
+				for frame_number, temp_frame_path in enumerate(temp_frame_set.values()):
+					future = executor.submit(process_disk_frame, temp_frame_path, frame_number)
 					futures.append(future)
 
 				while futures:
@@ -90,15 +90,15 @@ def process_disk_frames() -> ErrorCode:
 	return 0
 
 
-def process_memory_frame(temp_frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
-	target_vision_frames = conditional_get_target_vision_frames(temp_frame_number)
+def process_memory_frame(frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
+	target_vision_frames = conditional_get_target_vision_frames(frame_number)
 	target_vision_frame = get_middle(target_vision_frames)
 	temp_vision_frame = target_vision_frame.copy()
 
 	if not (target_vision_frame.shape[1], target_vision_frame.shape[0]) == temp_video_resolution:
 		temp_vision_frame = cv2.resize(target_vision_frame, temp_video_resolution)
 
-	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, temp_frame_number)
+	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, frame_number)
 
 	if not (temp_vision_frame.shape[1], temp_vision_frame.shape[0]) == output_video_resolution:
 		temp_vision_frame = cv2.resize(temp_vision_frame, output_video_resolution)
@@ -130,8 +130,8 @@ def process_memory_frames() -> ErrorCode:
 			with ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count')) as executor:
 				futures : Deque[Future[VisionFrame]] = deque()
 
-				for temp_frame_number in temp_frame_range:
-					future = executor.submit(process_memory_frame, temp_frame_number, temp_video_resolution, output_video_resolution)
+				for frame_number in temp_frame_range:
+					future = executor.submit(process_memory_frame, frame_number, temp_video_resolution, output_video_resolution)
 					futures.append(future)
 
 				while futures:

--- a/facefusion/workflows/to_video.py
+++ b/facefusion/workflows/to_video.py
@@ -13,7 +13,7 @@ from facefusion.processors.core import get_processors_modules
 from facefusion.temp_helper import move_temp_file, resolve_temp_frame_set
 from facefusion.time_helper import calculate_end_time
 from facefusion.types import ErrorCode, Resolution, VisionFrame
-from facefusion.vision import detect_video_resolution, pack_resolution, predict_video_frame_total, read_static_image, read_static_video_frame, resolve_video_frame_number, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, write_image
+from facefusion.vision import detect_video_resolution, pack_resolution, predict_video_frame_total, read_static_image, read_static_video_frame, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, write_image
 from facefusion.workflows.core import conditional_get_target_vision_frames, is_process_stopping, process_temp_frame
 
 
@@ -42,8 +42,8 @@ def extract_frames() -> ErrorCode:
 	return 0
 
 
-def process_disk_frame(temp_frame_path : str, frame_number : int, temp_frame_number : int) -> bool:
-	target_vision_frames = conditional_get_target_vision_frames(frame_number)
+def process_disk_frame(temp_frame_path : str, temp_frame_number : int) -> bool:
+	target_vision_frames = conditional_get_target_vision_frames(temp_frame_number)
 	temp_vision_frame = read_static_image(temp_frame_path, 'rgba')
 	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, temp_frame_number)
 	return write_image(temp_frame_path, temp_vision_frame)
@@ -61,8 +61,8 @@ def process_disk_frames() -> ErrorCode:
 			with ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count')) as executor:
 				futures : Deque[Future[bool]] = deque()
 
-				for temp_frame_number, frame_number in enumerate(temp_frame_set):
-					future = executor.submit(process_disk_frame, temp_frame_set.get(frame_number), frame_number, temp_frame_number)
+				for temp_frame_number, temp_frame_path in enumerate(temp_frame_set.values()):
+					future = executor.submit(process_disk_frame, temp_frame_path, temp_frame_number)
 					futures.append(future)
 
 				while futures:
@@ -91,10 +91,7 @@ def process_disk_frames() -> ErrorCode:
 
 
 def process_memory_frame(temp_frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
-	trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
-	temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
-	frame_number = resolve_video_frame_number(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, temp_frame_number)
-	target_vision_frames = select_video_frames(state_manager.get_item('target_path'), frame_number, state_manager.get_item('target_frame_amount'))
+	target_vision_frames = conditional_get_target_vision_frames(temp_frame_number)
 	target_vision_frame = get_middle(target_vision_frames)
 	temp_vision_frame = target_vision_frame.copy()
 

--- a/facefusion/workflows/to_video.py
+++ b/facefusion/workflows/to_video.py
@@ -61,7 +61,7 @@ def process_disk_frames() -> ErrorCode:
 			with ThreadPoolExecutor(max_workers = state_manager.get_item('execution_thread_count')) as executor:
 				futures : Deque[Future[bool]] = deque()
 
-				for frame_number, temp_frame_path in enumerate(temp_frame_set.values()):
+				for frame_number, temp_frame_path in temp_frame_set.items():
 					future = executor.submit(process_disk_frame, temp_frame_path, frame_number)
 					futures.append(future)
 

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -127,7 +127,7 @@ def test_extract_frames() -> None:
 		assert extract_frames(target_path, (452, 240), 30.0, trim_frame_start, trim_frame_end) is True
 		assert len(resolve_temp_frame_set(target_path)) == frame_total
 
-		temp_vision_frame = read_image(resolve_temp_frame_set(target_path).get(trim_frame_start))
+		temp_vision_frame = read_image(resolve_temp_frame_set(target_path).get(0))
 
 		assert temp_vision_frame.std() > frame_std
 		assert temp_vision_frame.max() > frame_max

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -6,7 +6,7 @@ import pytest
 from facefusion import ffmpeg, ffmpeg_builder, process_manager
 from facefusion.common_helper import is_linux
 from facefusion.download import conditional_download
-from facefusion.vision import calculate_histogram_difference, count_trim_frame_total, count_video_frame_total, detect_image_resolution, detect_video_duration, detect_video_fps, detect_video_resolution, match_frame_color, normalize_resolution, pack_resolution, predict_video_frame_total, read_image, read_video_frame, restrict_image_resolution, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, unpack_resolution, write_image
+from facefusion.vision import calculate_histogram_difference, count_trim_frame_total, count_video_frame_total, detect_image_resolution, detect_video_duration, detect_video_fps, detect_video_resolution, match_frame_color, normalize_resolution, pack_resolution, predict_video_frame_total, read_image, read_video_frame, resolve_video_frame_number, restrict_image_resolution, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, unpack_resolution, write_image
 from .helper import get_test_example_file, get_test_examples_directory, get_test_output_file, prepare_test_output_directory
 
 
@@ -156,7 +156,17 @@ def test_predict_video_frame_total() -> None:
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 12.5, 0, 100) == 50
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 200) == 200
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 1, 0, 1) == 1
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 100, 100) == 0
 	assert predict_video_frame_total('invalid', 25, 0, 100) == 0
+
+
+def test_resolve_video_frame_number() -> None:
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 12.5, 0, 100) == 200
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 12.5, 20, 100) == 220
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 0, 3) == 7
+	assert resolve_video_frame_number('invalid', 25, 20, 100) == 120
 
 
 def test_detect_video_fps() -> None:

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -157,8 +157,6 @@ def test_predict_video_frame_total() -> None:
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 200) == 200
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 12, 0, 270) == 130
-	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 9, 0, 270) == 97
-	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 11, 0, 270) == 119
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 13, 0, 270) == 140
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 1, 0, 1) == 1
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 100, 100) == 0
@@ -166,14 +164,9 @@ def test_predict_video_frame_total() -> None:
 
 
 def test_resolve_video_frame_number() -> None:
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 0) == 0
 	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
 	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 25, 20, 100) == 120
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 0, 0) == 1
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 0, 19) == 48
 	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 100, 19) == 148
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 5, 100, 0) == 102
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 5, 100, 9) == 147
 	assert resolve_video_frame_number('invalid', 25, 20, 100) == 120
 
 

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -156,16 +156,24 @@ def test_predict_video_frame_total() -> None:
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 12.5, 0, 100) == 50
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 200) == 200
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 12, 0, 270) == 130
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 9, 0, 270) == 97
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 11, 0, 270) == 119
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 13, 0, 270) == 140
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 1, 0, 1) == 1
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 100, 100) == 0
 	assert predict_video_frame_total('invalid', 25, 0, 100) == 0
 
 
 def test_resolve_video_frame_number() -> None:
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 0) == 0
 	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 12.5, 0, 100) == 200
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 12.5, 20, 100) == 220
-	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 0, 3) == 7
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 25, 20, 100) == 120
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 0, 0) == 1
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 0, 19) == 48
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 10, 100, 19) == 148
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 5, 100, 0) == 102
+	assert resolve_video_frame_number(get_test_example_file('target-240p-25fps.mp4'), 5, 100, 9) == 147
 	assert resolve_video_frame_number('invalid', 25, 20, 100) == 120
 
 


### PR DESCRIPTION
1. frame_number now means the output-timeline position, 0-based. The loop counts output frames (range(predict_video_frame_total(...))); the source frame is derived per iteration.
                                                                                     
2. New resolve_video_frame_number the temp→source mapping, trim_frame_start + floor((frame_number + 0.5) · video_fps / fps). Lives in conditional_get_target_vision_frames, one place, so disk and memory share it.
                                                                                                                  
3. predict_video_frame_total rounds floor(x + 0.5), not floor, and clamps to ≥1. Same midpoint model. floor was wrong on 3 of 6 measured ratios and made memory emit 2002 frames where disk emits 2003.      