### PR TITLE
Fix output video fps resampling

### DIFF
--- a/facefusion/vision.py
+++ b/facefusion/vision.py
@@ -117,8 +117,11 @@ def count_video_frame_total(video_path : str) -> int:
 def predict_video_frame_total(video_path : str, fps : Fps, trim_frame_start : int, trim_frame_end : int) -> int:
 	if is_video(video_path):
 		video_fps = detect_video_fps(video_path)
-		extract_frame_total = count_trim_frame_total(video_path, trim_frame_start, trim_frame_end) * fps / video_fps
-		return math.floor(extract_frame_total)
+		trim_frame_start, trim_frame_end = restrict_trim_frame(video_path, trim_frame_start, trim_frame_end)
+		extract_frame_start = math.floor(trim_frame_start * fps / video_fps + 0.5)
+		extract_frame_end = math.floor(trim_frame_end * fps / video_fps + 0.5)
+
+		return extract_frame_end - extract_frame_start
 	return 0
 
 

--- a/facefusion/workflows/to_video.py
+++ b/facefusion/workflows/to_video.py
@@ -1,3 +1,4 @@
+import math
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Deque
@@ -13,7 +14,7 @@ from facefusion.processors.core import get_processors_modules
 from facefusion.temp_helper import move_temp_file, resolve_temp_frame_set
 from facefusion.time_helper import calculate_end_time
 from facefusion.types import ErrorCode, Resolution, VisionFrame
-from facefusion.vision import detect_video_resolution, pack_resolution, read_static_image, read_static_video_frame, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, select_video_frames, write_image
+from facefusion.vision import detect_video_fps, detect_video_resolution, pack_resolution, predict_video_frame_total, read_static_image, read_static_video_frame, restrict_trim_frame, restrict_video_fps, restrict_video_resolution, scale_resolution, write_image
 from facefusion.workflows.core import conditional_get_target_vision_frames, is_process_stopping, process_temp_frame
 
 
@@ -42,8 +43,18 @@ def extract_frames() -> ErrorCode:
 	return 0
 
 
+def resolve_video_frame_number(frame_number : int) -> int:
+	trim_frame_start, _ = restrict_trim_frame(state_manager.get_item('target_path'), state_manager.get_item('trim_frame_start'), state_manager.get_item('trim_frame_end'))
+	temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
+	video_fps = detect_video_fps(state_manager.get_item('target_path'))
+	temp_frame_number = math.floor(trim_frame_start * temp_video_fps / video_fps + 0.5) + frame_number - trim_frame_start
+
+	return math.ceil((temp_frame_number + 0.5) * video_fps / temp_video_fps) - 1
+
+
 def process_disk_frame(temp_frame_path : str, frame_number : int) -> bool:
-	target_vision_frames = conditional_get_target_vision_frames(frame_number)
+	video_frame_number = resolve_video_frame_number(frame_number)
+	target_vision_frames = conditional_get_target_vision_frames(video_frame_number)
 	temp_vision_frame = read_static_image(temp_frame_path, 'rgba')
 	temp_vision_frame = process_temp_frame(target_vision_frames, temp_vision_frame, frame_number)
 	return write_image(temp_frame_path, temp_vision_frame)
@@ -91,7 +102,8 @@ def process_disk_frames() -> ErrorCode:
 
 
 def process_memory_frame(frame_number : int, temp_video_resolution : Resolution, output_video_resolution : Resolution) -> VisionFrame:
-	target_vision_frames = select_video_frames(state_manager.get_item('target_path'), frame_number, state_manager.get_item('target_frame_amount'))
+	video_frame_number = resolve_video_frame_number(frame_number)
+	target_vision_frames = conditional_get_target_vision_frames(video_frame_number)
 	target_vision_frame = get_middle(target_vision_frames)
 	temp_vision_frame = target_vision_frame.copy()
 
@@ -117,7 +129,8 @@ def process_memory_frames() -> ErrorCode:
 	output_video_resolution = scale_resolution(detect_video_resolution(state_manager.get_item('target_path')), state_manager.get_item('output_video_scale'))
 	temp_video_resolution = restrict_video_resolution(state_manager.get_item('target_path'), output_video_resolution)
 	temp_video_fps = restrict_video_fps(state_manager.get_item('target_path'), state_manager.get_item('output_video_fps'))
-	temp_frame_range = range(trim_frame_start, trim_frame_end)
+	temp_frame_total = predict_video_frame_total(state_manager.get_item('target_path'), temp_video_fps, trim_frame_start, trim_frame_end)
+	temp_frame_range = range(trim_frame_start, trim_frame_start + temp_frame_total)
 
 	if temp_frame_range:
 		video_writer = video_manager.get_writer(state_manager.get_item('target_path'), temp_video_fps, output_video_resolution, output_video_resolution, state_manager.get_item('output_video_fps'))

--- a/tests/test_cli_output_fps.py
+++ b/tests/test_cli_output_fps.py
@@ -1,0 +1,65 @@
+import subprocess
+import sys
+
+import numpy
+import pytest
+
+from facefusion import ffmpeg, ffmpeg_builder, process_manager
+from facefusion.download import conditional_download
+from facefusion.jobs.job_manager import clear_jobs, init_jobs
+from facefusion.types import Fps, WorkflowStrategy
+from facefusion.vision import count_video_frame_total, detect_video_fps, read_video_frame
+from .helper import get_test_example_file, get_test_examples_directory, get_test_jobs_directory, get_test_output_file, prepare_test_output_directory
+
+
+@pytest.fixture(scope = 'module', autouse = True)
+def before_all() -> None:
+	process_manager.start()
+	conditional_download(get_test_examples_directory(),
+	[
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
+		'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
+	])
+
+	ffmpeg.run_ffmpeg(
+		ffmpeg_builder.chain(
+			ffmpeg_builder.set_input(get_test_example_file('target-240p.mp4')),
+			ffmpeg_builder.select_frame_range(0, 40, 6.25),
+			ffmpeg_builder.set_video_encoder('libx264'),
+			ffmpeg_builder.enforce_pixel_format('yuv420p'),
+			[
+				'-crf',
+				'0',
+				'-an'
+			],
+			ffmpeg_builder.force_output(get_test_example_file('target-240p-6.25fps.mp4'))
+		)
+	)
+
+
+@pytest.fixture(scope = 'function', autouse = True)
+def before_each() -> None:
+	clear_jobs(get_test_jobs_directory())
+	init_jobs(get_test_jobs_directory())
+	prepare_test_output_directory()
+
+
+@pytest.mark.parametrize('workflow_strategy, output_video_fps, output_video_frame_total',
+[
+	('disk', 6.25, 10),
+	('memory', 6.25, 10)
+])
+def test_output_video_fps(workflow_strategy : WorkflowStrategy, output_video_fps : Fps, output_video_frame_total : int) -> None:
+	output_file_path = get_test_output_file('test-output-video-fps-' + workflow_strategy + '-' + str(output_video_fps) + '.mp4')
+	resample_file_path = get_test_output_file('test-output-video-fps-resample-' + workflow_strategy + '-' + str(output_video_fps) + '.mp4')
+	commands = [ sys.executable, 'facefusion.py', 'headless-run', '--jobs-path', get_test_jobs_directory(), '--processors', 'face_swapper', '--execution-providers', 'cpu', '-s', get_test_example_file('source.jpg'), '-t', get_test_example_file('target-240p.mp4'), '-o', output_file_path, '--trim-frame-end', '40', '--workflow-strategy', workflow_strategy, '--output-video-fps', str(output_video_fps) ]
+	resample_commands = [ sys.executable, 'facefusion.py', 'headless-run', '--jobs-path', get_test_jobs_directory(), '--processors', 'face_swapper', '--execution-providers', 'cpu', '-s', get_test_example_file('source.jpg'), '-t', get_test_example_file('target-240p-' + str(output_video_fps) + 'fps.mp4'), '-o', resample_file_path, '--workflow-strategy', workflow_strategy ]
+
+	assert subprocess.run(commands).returncode == 0
+	assert subprocess.run(resample_commands).returncode == 0
+	assert detect_video_fps(output_file_path) == output_video_fps
+	assert count_video_frame_total(output_file_path) == output_video_frame_total
+	assert count_video_frame_total(resample_file_path) == output_video_frame_total
+
+	for frame_number in range(output_video_frame_total):
+		assert numpy.array_equal(read_video_frame(output_file_path, frame_number), read_video_frame(resample_file_path, frame_number)) is True

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -11,7 +11,7 @@ from facefusion.ffprobe import extract_video_metadata
 from facefusion.filesystem import copy_file
 from facefusion.temp_helper import clear_temp_directory, create_temp_directory, get_temp_file_path, resolve_temp_frame_set
 from facefusion.types import EncoderSet
-from facefusion.vision import read_image
+from facefusion.vision import predict_video_frame_total, read_image
 from .helper import get_test_example_file, get_test_examples_directory, get_test_output_file, prepare_test_output_directory
 
 
@@ -126,6 +126,7 @@ def test_extract_frames() -> None:
 
 		assert extract_frames(target_path, (452, 240), 30.0, trim_frame_start, trim_frame_end) is True
 		assert len(resolve_temp_frame_set(target_path)) == frame_total
+		assert predict_video_frame_total(target_path, 30.0, trim_frame_start, trim_frame_end) == frame_total
 
 		temp_vision_frame = read_image(resolve_temp_frame_set(target_path).get(trim_frame_start))
 

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -156,6 +156,8 @@ def test_predict_video_frame_total() -> None:
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 12.5, 0, 100) == 50
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 100) == 100
 	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 25, 0, 200) == 200
+	assert predict_video_frame_total(get_test_example_file('target-240p-25fps.mp4'), 6.25, 0, 270) == 68
+	assert predict_video_frame_total(get_test_example_file('target-240p-30fps.mp4'), 9.49, 40, 200) == 50
 	assert predict_video_frame_total('invalid', 25, 0, 100) == 0
 
 


### PR DESCRIPTION
  Fixes wrong frame mapping when --output-video-fps is lower than the source fps.                                                                                                                                                 
                                                                                                                                                                                                                                  
  Disk mode passed the temp frame number straight to select_video_frames as a                                                                                                                                                     
  source frame index. Those only coincide at native fps, so faces were detected                                                                                                                                                   
  on unrelated frames and the swap was applied from the wrong moment.                                                                                                                                                             
                                                                                                                                                                                                                                  
  Memory mode iterated every source frame and wrote them at the target fps, so                                                                                                                                                    
  the output kept the source frame count and played too slow.                                                                                                                                                                     
                                                                                                                                                                                                                                  
  Both now resolve the temp frame number to the frame ffmpeg's fps filter                                                                                                                                                         
  actually selects, via resolve_video_frame_number in to_video.py.                                                                                                                                                                
  predict_video_frame_total is corrected to match the same filter: trim keeps the                                                                                                                                                 
  original timestamps, so the count is the difference of two rounded global                                                                                                                                                       
  indices rather than a rounded span.                                                                                                                                                                                             
                                                                                                                                                                                                                                  
  Verified against 3.6.1 with and without trim at 3.0 / 6.25 / 9.49 fps - frame                                                                                                                                                   
  counts, durations and audio streams match, and lip_syncer stays in sync. 